### PR TITLE
feat: add previous workspace switching

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -14,6 +14,12 @@ key = "prefix+shift+t"
 type = "plugin_action"
 command = "fullerzz.sesh.open-picker"
 description = "open Sesh picker"
+
+[[keys.command]]
+key = "prefix+shift+b"
+type = "plugin_action"
+command = "fullerzz.sesh.last"
+description = "switch to previous Sesh workspace"
 ```
 
 Manual picker open:

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -22,7 +22,7 @@ command = ["./bin/herdr-sesh", "root", "--connect"]
 
 [[actions]]
 id = "last"
-title = "Switch to Last Sesh Workspace"
+title = "Switch to Previous Workspace"
 contexts = ["workspace", "pane"]
 command = ["./bin/herdr-sesh", "last"]
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -195,15 +195,14 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if err != nil || !ok {
 		return err
 	}
+	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 	res, err := connectpkg.Connect(ctx, herdr.NewCLIClient(), []model.Session{selected}, pickerTarget(selected), connectpkg.Options{
 		Namer: func(ctx context.Context, p string) string { return namer.Namer{}.Name(ctx, p, cfg.DirLength) },
 	})
 	if err != nil {
 		return err
 	}
-	if err := state.Record(os.Getenv("HERDR_PLUGIN_STATE_DIR"), res.Session.WorkspaceID); err != nil {
-		a.warnf("could not record workspace history: %v", err)
-	}
+	a.recordWorkspaceSwitch(currentWorkspaceID, res.Session.WorkspaceID)
 	return nil
 }
 
@@ -237,12 +236,13 @@ func (a *App) connect(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 	res, err := connectpkg.Connect(ctx, herdr.NewCLIClient(), sessions, target, connectpkg.Options{NoFocus: *noFocus, Namer: func(ctx context.Context, p string) string { return namer.Namer{}.Name(ctx, p, cfg.DirLength) }})
 	if err != nil {
 		return err
 	}
-	if err := state.Record(os.Getenv("HERDR_PLUGIN_STATE_DIR"), res.Session.WorkspaceID); err != nil {
-		a.warnf("could not record workspace history: %v", err)
+	if !*noFocus {
+		a.recordWorkspaceSwitch(currentWorkspaceID, res.Session.WorkspaceID)
 	}
 	_, err = fmt.Fprintf(a.Out, "%s\n", res.Session.Name)
 	return err
@@ -315,15 +315,33 @@ func gitRoot(ctx context.Context, dir string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 func (a *App) last(ctx context.Context, _ []string) error {
-	id, ok, err := state.Last(os.Getenv("HERDR_PLUGIN_STATE_DIR"))
+	stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
+	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
+	id, ok, err := state.Previous(stateDir, currentWorkspaceID)
+	if currentWorkspaceID == "" {
+		id, ok, err = state.Last(stateDir)
+	}
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return errors.New("no previous workspace recorded")
 	}
-	return herdr.NewCLIClient().WorkspaceFocus(ctx, id)
+	if err := herdr.NewCLIClient().WorkspaceFocus(ctx, id); err != nil {
+		return err
+	}
+	if err := state.RecordSwitch(stateDir, currentWorkspaceID, id); err != nil {
+		a.warnf("could not record workspace history: %v", err)
+	}
+	return nil
 }
+
+func (a *App) recordWorkspaceSwitch(fromWorkspaceID, toWorkspaceID string) {
+	if err := state.RecordSwitch(os.Getenv("HERDR_PLUGIN_STATE_DIR"), fromWorkspaceID, toWorkspaceID); err != nil {
+		a.warnf("could not record workspace history: %v", err)
+	}
+}
+
 func (a *App) window(ctx context.Context, args []string) error {
 	c := herdr.NewCLIClient()
 	if len(args) == 0 {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"forgejo.local/fullerzz/herdr-plugin-sesh/internal/state"
 )
 
 func TestVersionCommand(t *testing.T) {
@@ -92,5 +95,45 @@ func TestPickerJSONCommand(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"name": "sesh"`) {
 		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
+	d := t.TempDir()
+	stateDir := filepath.Join(d, "state")
+	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	fakeHerdr := filepath.Join(d, "herdr")
+	logPath := filepath.Join(d, "herdr.log")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"
+	//nolint:gosec // test creates a local executable fixture.
+	if err := os.WriteFile(fakeHerdr, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
+	t.Setenv("HERDR_FAKE_LOG", logPath)
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_WORKSPACE_ID", "current")
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), []string{"last"}); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // logPath is a test-owned temp file.
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "workspace focus previous" {
+		t.Fatalf("herdr args = %q", got)
+	}
+	h, err := state.LoadHistory(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"previous", "current", "older"}
+	if !reflect.DeepEqual(h.Workspaces, want) {
+		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
 	}
 }

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -11,6 +11,8 @@ type History struct {
 	Workspaces []string `json:"workspaces"`
 }
 
+const maxWorkspaces = 50
+
 func Path(dir string) string { return filepath.Join(dir, "history.json") }
 
 func LoadHistory(dir string) (History, error) {
@@ -42,27 +44,51 @@ func Record(dir, workspaceID string) error {
 	if workspaceID == "" {
 		return nil
 	}
-	h, err := LoadHistory(dir)
+	h, err := loadHistoryForWrite(dir)
 	if err != nil {
-		if !isJSONDecodeError(err) {
-			return err
-		}
-		h = History{}
+		return err
 	}
-	if len(h.Workspaces) > 0 && h.Workspaces[0] == workspaceID {
+	h.Workspaces = dedupeWorkspaces([]string{workspaceID}, h.Workspaces)
+	return SaveHistory(dir, h)
+}
+
+func RecordSwitch(dir, fromWorkspaceID, toWorkspaceID string) error {
+	if toWorkspaceID == "" {
 		return nil
 	}
-	filtered := []string{workspaceID}
-	for _, id := range h.Workspaces {
-		if id != workspaceID {
-			filtered = append(filtered, id)
+	h, err := loadHistoryForWrite(dir)
+	if err != nil {
+		return err
+	}
+	h.Workspaces = dedupeWorkspaces([]string{toWorkspaceID, fromWorkspaceID}, h.Workspaces)
+	return SaveHistory(dir, h)
+}
+
+func loadHistoryForWrite(dir string) (History, error) {
+	h, err := LoadHistory(dir)
+	if err == nil {
+		return h, nil
+	}
+	if !isJSONDecodeError(err) {
+		return History{}, err
+	}
+	return History{}, nil
+}
+
+func dedupeWorkspaces(front []string, rest []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(front)+len(rest))
+	for _, id := range append(front, rest...) {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+		if len(out) == maxWorkspaces {
+			return out
 		}
 	}
-	if len(filtered) > 50 {
-		filtered = filtered[:50]
-	}
-	h.Workspaces = filtered
-	return SaveHistory(dir, h)
+	return out
 }
 
 func isJSONDecodeError(err error) bool {
@@ -80,4 +106,17 @@ func Last(dir string) (string, bool, error) {
 		return "", false, nil
 	}
 	return h.Workspaces[1], true, nil
+}
+
+func Previous(dir, currentWorkspaceID string) (string, bool, error) {
+	h, err := LoadHistory(dir)
+	if err != nil {
+		return "", false, err
+	}
+	for _, id := range h.Workspaces {
+		if id != "" && id != currentWorkspaceID {
+			return id, true, nil
+		}
+	}
+	return "", false, nil
 }

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -1,8 +1,10 @@
 package state
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -30,12 +32,22 @@ func TestHistoryNoopsWithoutStateDir(t *testing.T) {
 	if err := Record("", "ws1"); err != nil {
 		t.Fatal(err)
 	}
+	if err := RecordSwitch("", "ws1", "ws2"); err != nil {
+		t.Fatal(err)
+	}
 	last, ok, err := Last("")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok || last != "" {
 		t.Fatalf("last=%q ok=%v", last, ok)
+	}
+	previous, ok, err := Previous("", "ws1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || previous != "" {
+		t.Fatalf("previous=%q ok=%v", previous, ok)
 	}
 }
 
@@ -53,5 +65,68 @@ func TestRecordRecoversCorruptHistory(t *testing.T) {
 	}
 	if len(h.Workspaces) != 1 || h.Workspaces[0] != "ws1" {
 		t.Fatalf("history=%#v", h)
+	}
+}
+
+func TestPreviousSkipsCurrentWorkspace(t *testing.T) {
+	d := t.TempDir()
+	if err := SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	previous, ok, err := Previous(d, "current")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || previous != "previous" {
+		t.Fatalf("previous=%q ok=%v", previous, ok)
+	}
+}
+
+func TestRecordSwitchRotatesPreviousWorkspace(t *testing.T) {
+	d := t.TempDir()
+	if err := SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordSwitch(d, "current", "previous"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := LoadHistory(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"previous", "current", "older"}
+	if !reflect.DeepEqual(h.Workspaces, want) {
+		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
+	}
+}
+
+func TestRecordSwitchDeduplicatesAndCapsHistory(t *testing.T) {
+	d := t.TempDir()
+	workspaces := []string{"target", "from"}
+	for i := 0; i < maxWorkspaces+20; i++ {
+		workspaces = append(workspaces, fmt.Sprintf("ws-%02d", i))
+	}
+	if err := SaveHistory(d, History{Workspaces: workspaces}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordSwitch(d, "from", "target"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := LoadHistory(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(h.Workspaces) != maxWorkspaces {
+		t.Fatalf("len=%d want %d", len(h.Workspaces), maxWorkspaces)
+	}
+	if h.Workspaces[0] != "target" || h.Workspaces[1] != "from" {
+		t.Fatalf("workspaces start=%#v", h.Workspaces[:2])
+	}
+	seen := map[string]bool{}
+	for _, id := range h.Workspaces {
+		if seen[id] {
+			t.Fatalf("duplicate workspace %q in %#v", id, h.Workspaces)
+		}
+		seen[id] = true
 	}
 }


### PR DESCRIPTION
## Summary
- make `herdr-sesh last` focus the previous workspace immediately and rotate history after success
- record the workspace being left during plugin-driven connect and picker switches
- document the `fullerzz.sesh.last` keybinding and update the action title

## Validation
- `just fmt-check`
- `just lint`
- `just test`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add previous workspace switching to Sesh. `herdr-sesh last` now jumps to the previous workspace and only rotates history after a successful focus.

- New Features
  - Records workspace switches during plugin connect and picker flows, so `herdr-sesh last` works consistently.
  - Uses the current workspace ID to pick the true previous workspace; falls back to last-known for older contexts.
  - Deduplicates and caps history at 50 entries; ignores empty IDs.
  - Adds `prefix+shift+b` keybinding for `fullerzz.sesh.last` and updates the action title to “Switch to Previous Workspace”.
  - Adds tests for previous-switch behavior, history rotation, dedupe, and size cap.

<sup>Written for commit 96f9d719cae49d46b576d138a95c1f8e7f2d09db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

