### PR TITLE
fix: merge nested config tables field by field

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -131,11 +130,29 @@ func merge(dst *Config, src Config) {
 	if src.TmuxCommand != "" {
 		dst.TmuxCommand = src.TmuxCommand
 	}
-	if src.TUI != (TUIConfig{}) {
-		dst.TUI = src.TUI
+	if src.TUI.ShowIcons {
+		dst.TUI.ShowIcons = true
 	}
-	if !reflect.DeepEqual(src.DefaultSessionConfig, DefaultSessionConfig{}) {
-		dst.DefaultSessionConfig = src.DefaultSessionConfig
+	if src.TUI.Prompt != "" {
+		dst.TUI.Prompt = src.TUI.Prompt
+	}
+	if src.TUI.Placeholder != "" {
+		dst.TUI.Placeholder = src.TUI.Placeholder
+	}
+	if src.DefaultSessionConfig.StartupCommand != "" {
+		dst.DefaultSessionConfig.StartupCommand = src.DefaultSessionConfig.StartupCommand
+	}
+	if src.DefaultSessionConfig.Tmuxp != "" {
+		dst.DefaultSessionConfig.Tmuxp = src.DefaultSessionConfig.Tmuxp
+	}
+	if src.DefaultSessionConfig.Tmuxinator != "" {
+		dst.DefaultSessionConfig.Tmuxinator = src.DefaultSessionConfig.Tmuxinator
+	}
+	if src.DefaultSessionConfig.PreviewCommand != "" {
+		dst.DefaultSessionConfig.PreviewCommand = src.DefaultSessionConfig.PreviewCommand
+	}
+	if len(src.DefaultSessionConfig.Windows) > 0 {
+		dst.DefaultSessionConfig.Windows = src.DefaultSessionConfig.Windows
 	}
 	dst.SessionConfigs = append(dst.SessionConfigs, src.SessionConfigs...)
 	dst.WindowConfigs = append(dst.WindowConfigs, src.WindowConfigs...)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -59,6 +60,47 @@ path="/extra"
 	}
 	if got := []string{cfg.SessionConfigs[0].Name, cfg.SessionConfigs[1].Name}; got[0] != "extra" || got[1] != "main" {
 		t.Fatalf("bad order %#v", got)
+	}
+}
+
+func TestLoadMergesNestedConfigTablesFieldByField(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), `[default_session]
+startup_command = "git status"
+preview_command = "printf extra {}"
+windows = ["git"]
+
+[tui]
+prompt = "Extra> "
+placeholder = "Extra search"
+`)
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, `import = ["extra.toml"]
+
+[default_session]
+startup_command = "make test"
+
+[tui]
+placeholder = "Search workspaces"
+`)
+	cfg, _, err := Load(LoadOptions{Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DefaultSessionConfig.StartupCommand != "make test" {
+		t.Fatalf("startup command = %q", cfg.DefaultSessionConfig.StartupCommand)
+	}
+	if cfg.DefaultSessionConfig.PreviewCommand != "printf extra {}" {
+		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
+	}
+	if want := []string{"git"}; !reflect.DeepEqual(cfg.DefaultSessionConfig.Windows, want) {
+		t.Fatalf("windows = %#v, want %#v", cfg.DefaultSessionConfig.Windows, want)
+	}
+	if cfg.TUI.Prompt != "Extra> " {
+		t.Fatalf("prompt = %q", cfg.TUI.Prompt)
+	}
+	if cfg.TUI.Placeholder != "Search workspaces" {
+		t.Fatalf("placeholder = %q", cfg.TUI.Placeholder)
 	}
 }
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -9,7 +9,7 @@ honor its STOP conditions, and update your row when done.
 | Plan | Source finding | Title | Priority | Effort | Depends on | Status |
 |------|----------------|-------|----------|--------|------------|--------|
 | 001 | #5 | Harden release workflow shell inputs | P1 | S | - | TODO |
-| 002 | #2 | Merge nested config tables field by field | P1 | S | - | TODO |
+| 002 | #2 | Merge nested config tables field by field | P1 | S | - | DONE |
 | 003 | #3 | Add explicit config support to preview | P2 | S | - | TODO |
 | 004 | #4 | Run the local check gate in pull request CI | P2 | S | - | TODO |
 | 005 | #6 | Return stable native preview text when path is missing | P3 | S | - | TODO |


### PR DESCRIPTION
## Summary
- merge nested `[tui]` and `[default_session]` config tables field by field across imports
- preserve inherited nested values when a later config file overrides only one field
- add a regression test for partial nested-table overrides and mark Plan 002 done

## Validation
- `go test ./internal/config` (red before implementation: lost imported `preview_command`)
- `go test ./internal/config`
- `just lint`
- `just fmt-check`
- `just test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nested config merging to work field by field across imports. Prevents losing inherited `[tui]` and `[default_session]` values when a later file overrides only one field.

- **Bug Fixes**
  - Merge `[tui]` and `[default_session]` tables per-field instead of replacing the whole table.
  - Preserve inherited values like `preview_command`, `windows`, `prompt`, and `placeholder`.
  - Added a regression test for partial nested-table overrides.
  - Marked Plan 002 as DONE in `plans/README.md`.

<sup>Written for commit 3b6f9ed7644ca9203df0e1efaaaf5c2675c4a9d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

