### PR TITLE
ci: harden release workflow shell inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,16 @@ jobs:
       - name: Resolve version
         id: meta
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag='${{ inputs.tag }}'
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
           else
-            tag='${{ github.ref_name }}'
+            tag="$REF_NAME"
           fi
           case "$tag" in
             v*) ;;
@@ -80,9 +84,11 @@ jobs:
 
       - name: Build release assets
         shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
-          version='${{ steps.meta.outputs.version }}'
+          version="$VERSION"
           module='github.com/fullerzz/herdr-plugin-sesh/internal/app'
           mkdir -p dist/release dist/work
           targets=(
@@ -110,10 +116,13 @@ jobs:
 
       - name: Generate release notes
         shell: bash
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
-          tag='${{ steps.meta.outputs.tag }}'
-          version='${{ steps.meta.outputs.version }}'
+          tag="$TAG"
+          version="$VERSION"
           {
             echo "# herdr-plugin-sesh ${tag}"
             echo

--- a/plans/README.md
+++ b/plans/README.md
@@ -8,7 +8,7 @@ honor its STOP conditions, and update your row when done.
 
 | Plan | Source finding | Title | Priority | Effort | Depends on | Status |
 |------|----------------|-------|----------|--------|------------|--------|
-| 001 | #5 | Harden release workflow shell inputs | P1 | S | - | TODO |
+| 001 | #5 | Harden release workflow shell inputs | P1 | S | - | DONE |
 | 002 | #2 | Merge nested config tables field by field | P1 | S | - | DONE |
 | 003 | #3 | Add explicit config support to preview | P2 | S | - | DONE |
 | 004 | #4 | Run the local check gate in pull request CI | P2 | S | - | TODO |


### PR DESCRIPTION
## Summary
- move release workflow tag/ref inputs into step `env:` before shell use
- move validated meta outputs into step `env:` for release asset and notes steps
- mark Plan 001 as done

## Validation
- `git diff --stat 1a2235e..HEAD -- .github/workflows/release.yml`
- `rg -n "tag='\\$\\{\\{|version='\\$\\{\\{|\\[ \\\"\\$\\{\\{" .github/workflows/release.yml`
- `git diff --check -- .github/workflows/release.yml`
- `just lint`
- `just fmt-check`
- `just test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the release workflow by moving tag/ref inputs and derived values into step env vars before shell use to avoid injection and incorrect interpolation. Also routed validated `tag`/`version` via env in build and notes steps, and marked Plan 001 as done.

- **Refactors**
  - Resolve version: set `EVENT_NAME`, `INPUT_TAG`, `REF_NAME` in `env:` and read them in bash.
  - Build assets: pass `VERSION` from `meta` outputs via `env:` and read in bash.
  - Release notes: pass `TAG` and `VERSION` via `env:` and read in bash.
  - Update `plans/README.md`: mark Plan 001 as DONE.

<sup>Written for commit 1275017802e4307423f3a487e63b7fda693a6019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

