### PR TITLE
fix: accept explicit config for preview

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -249,11 +249,17 @@ func (a *App) connect(ctx context.Context, args []string) error {
 }
 
 func (a *App) preview(ctx context.Context, args []string) error {
-	if len(args) < 1 {
+	fs := flag.NewFlagSet("preview", flag.ContinueOnError)
+	fs.SetOutput(a.Err)
+	cfgPath := fs.String("config", "", "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
 		return errors.New("preview requires target")
 	}
-	target := args[0]
-	cfg, err := a.loadConfig("")
+	target := fs.Arg(0)
+	cfg, err := a.loadConfig(*cfgPath)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -98,6 +98,43 @@ func TestPickerJSONCommand(t *testing.T) {
 	}
 }
 
+func TestPreviewCommandUsesExplicitConfig(t *testing.T) {
+	d := t.TempDir()
+	targetDir := filepath.Join(d, "target")
+	if err := os.Mkdir(targetDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(d, "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte("[default_session]\npreview_command = \"printf configured:%s {}\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fakeBin := filepath.Join(d, "bin")
+	if err := os.MkdirAll(fakeBin, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"herdr", "zoxide"} {
+		//nolint:gosec // test creates local executable fixtures.
+		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte("#!/bin/sh\nexit 1\n"), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	//nolint:gosec // test creates a local executable fixture.
+	if err := os.WriteFile(filepath.Join(fakeBin, "eza"), []byte("#!/bin/sh\nprintf 'default:%s\\n' \"$*\"\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var out bytes.Buffer
+	a := &App{Out: &out, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), []string{"preview", "--config", cfgPath, targetDir}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "configured:") || !strings.Contains(out.String(), targetDir) {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
 func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	d := t.TempDir()
 	stateDir := filepath.Join(d, "state")

--- a/plans/README.md
+++ b/plans/README.md
@@ -10,7 +10,7 @@ honor its STOP conditions, and update your row when done.
 |------|----------------|-------|----------|--------|------------|--------|
 | 001 | #5 | Harden release workflow shell inputs | P1 | S | - | TODO |
 | 002 | #2 | Merge nested config tables field by field | P1 | S | - | TODO |
-| 003 | #3 | Add explicit config support to preview | P2 | S | - | TODO |
+| 003 | #3 | Add explicit config support to preview | P2 | S | - | DONE |
 | 004 | #4 | Run the local check gate in pull request CI | P2 | S | - | TODO |
 | 005 | #6 | Return stable native preview text when path is missing | P3 | S | - | TODO |
 


### PR DESCRIPTION
## Summary
- parse `--config` for the `preview` command before resolving the target
- add a regression proving `preview --config PATH TARGET` uses the configured default preview command
- mark Plan 003 as done in `plans/README.md`

## Validation
- `go test ./internal/app`
- `just lint`
- `just fmt-check`
- `just test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `--config` in the preview command to load an explicit config file. Fixes preview ignoring the provided config and ensures the configured default `preview_command` runs. Satisfies Plan 003 (#3).

- **Bug Fixes**
  - Parse `--config` before target resolution and load config from the given path.
  - Add a regression test for `preview --config PATH TARGET`; mark Plan 003 as DONE in `plans/README.md`.

<sup>Written for commit fe18a4b56af1d8e77762236f8e44be32141422ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

