### PR TITLE
fix: handle native previews without paths

### DIFF
--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -16,6 +16,13 @@ import (
 )
 
 func Render(ctx context.Context, s model.Session, fallbackCommand string) (string, error) {
+	if s.Path == "" {
+		if s.WorkspaceID != "" {
+			return fmt.Sprintf("workspace: %s\nid: %s\npath: %s\n", s.Name, s.WorkspaceID, s.Path), nil
+		}
+		return "No item path available\n", nil
+	}
+
 	cmd := s.PreviewCommand
 	if cmd == "" {
 		cmd = fallbackCommand

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -20,6 +20,29 @@ func TestRenderUsesPreviewCommand(t *testing.T) {
 	}
 }
 
+func TestRenderMissingPathWithoutWorkspaceReturnsStableText(t *testing.T) {
+	out, err := Render(context.Background(), model.Session{Name: "api"}, "printf %s {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No item path available") {
+		t.Fatalf("missing stable no-path text: %q", out)
+	}
+}
+
+func TestRenderMissingPathWithWorkspaceReturnsWorkspaceSummary(t *testing.T) {
+	out, err := Render(context.Background(), model.Session{Name: "api", WorkspaceID: "ws1"}, "printf %s {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "workspace: api") {
+		t.Fatalf("missing workspace name: %q", out)
+	}
+	if !strings.Contains(out, "id: ws1") {
+		t.Fatalf("missing workspace id: %q", out)
+	}
+}
+
 func TestRenderDirectoryFallbackSorted(t *testing.T) {
 	d := t.TempDir()
 	if err := os.WriteFile(filepath.Join(d, "b"), []byte(""), 0600); err != nil {

--- a/plans/README.md
+++ b/plans/README.md
@@ -12,7 +12,7 @@ honor its STOP conditions, and update your row when done.
 | 002 | #2 | Merge nested config tables field by field | P1 | S | - | DONE |
 | 003 | #3 | Add explicit config support to preview | P2 | S | - | DONE |
 | 004 | #4 | Run the local check gate in pull request CI | P2 | S | - | TODO |
-| 005 | #6 | Return stable native preview text when path is missing | P3 | S | - | TODO |
+| 005 | #6 | Return stable native preview text when path is missing | P3 | S | - | DONE |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale).


### PR DESCRIPTION
## Summary
- return stable no-path text from `preview.Render` before running shell preview commands
- preserve workspace summary output when a workspace ID exists without a path
- mark Plan 005 as done

## Validation
- `go test ./internal/preview`
- `go test ./internal/picker`
- `just lint`
- `just fmt-check`
- `just test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return stable native preview text from `preview.Render` when the path is missing, skipping shell commands and preserving a short workspace summary if a `WorkspaceID` exists. Marks Plan 005 (#6) as done.

<sup>Written for commit b66106730cc3e43085f1ebef9d7275ebe4f4ec34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

