### PR TITLE
fix: Select the home directory when filtering for home

### DIFF
--- a/internal/picker/fzf.go
+++ b/internal/picker/fzf.go
@@ -52,10 +52,6 @@ func fzfArgs(opts Options) []string {
 	if prompt == "" {
 		prompt = defaultPrompt
 	}
-	nth := "3..5"
-	if opts.SeparatorAware {
-		nth = "3..6"
-	}
 	args := []string{
 		"--layout=reverse",
 		"--border",
@@ -63,7 +59,7 @@ func fzfArgs(opts Options) []string {
 		"--prompt=" + prompt,
 		"--delimiter=\t",
 		"--with-nth=3,4,5",
-		"--nth=" + nth,
+		"--nth=3..6",
 		"--preview=" + fzfPreviewCommand(),
 		"--preview-window=right:60%,border-left,wrap",
 		"--header=Enter select  Ctrl-U clear  Esc cancel",
@@ -139,11 +135,15 @@ func fzfSourceBadge(source string) string {
 }
 
 func fzfSearchField(s sessionmodel.Session, separatorAware bool) string {
-	if !separatorAware {
-		return ""
+	var terms []string
+	if separatorAware {
+		repl := strings.NewReplacer("-", " ", "_", " ", "/", " ", ".", " ")
+		terms = append(terms, repl.Replace(s.Name+" "+s.Path))
 	}
-	repl := strings.NewReplacer("-", " ", "_", " ", "/", " ", ".", " ")
-	return fzfField(repl.Replace(s.Name + " " + s.Path))
+	if isHomeSession(s) {
+		terms = append(terms, "home")
+	}
+	return fzfField(strings.Join(terms, " "))
 }
 
 func fzfField(s string) string {

--- a/internal/picker/fzf_test.go
+++ b/internal/picker/fzf_test.go
@@ -42,6 +42,18 @@ func TestFZFInputKeepsIndexHiddenAndAddsSeparatorAwareSearch(t *testing.T) {
 	}
 }
 
+func TestFZFInputAddsHomeAliasSearchToken(t *testing.T) {
+	t.Setenv("HOME", "/Users/zach")
+	got := fzfInput([]model.Session{{Source: "herdr", Name: "zach", Path: "/Users/zach"}}, false)
+	if !strings.HasSuffix(got, "\thome\n") {
+		t.Fatalf("missing home alias search token: %q", got)
+	}
+	args := strings.Join(fzfArgs(Options{}), "\n")
+	if !strings.Contains(args, "--nth=3..6") {
+		t.Fatalf("home alias search field is not searchable:\n%s", args)
+	}
+}
+
 func TestFZFInputUsesSourceCategoryColors(t *testing.T) {
 	got := fzfInput([]model.Session{
 		{Source: "herdr", Name: "herdr"},

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -1,6 +1,8 @@
 package picker
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
@@ -24,10 +26,19 @@ func (m *Model) Filter(q string) {
 	queryChanged := q != m.Query
 	m.Query = q
 	m.Filtered = m.Filtered[:0]
+	var homeMatches []model.Session
+	homeQuery := strings.EqualFold(q, "home")
 	for _, s := range m.All {
 		if Match(s.Name, q, m.SeparatorAware) || Match(s.Path, q, m.SeparatorAware) {
+			if homeQuery && isHomeSession(s) {
+				homeMatches = append(homeMatches, s)
+				continue
+			}
 			m.Filtered = append(m.Filtered, s)
 		}
+	}
+	if len(homeMatches) > 0 {
+		m.Filtered = append(homeMatches, m.Filtered...)
 	}
 	if queryChanged {
 		m.Selected = 0
@@ -53,11 +64,32 @@ func (m *Model) Current() (model.Session, bool) {
 	return m.Filtered[m.Selected], true
 }
 func Match(s, q string, sep bool) bool {
+	raw := s
 	s = strings.ToLower(s)
 	q = strings.ToLower(q)
 	if sep {
 		repl := strings.NewReplacer("-", " ", "_", " ", "/", " ", ".", " ")
 		s = repl.Replace(s)
 	}
-	return strings.Contains(s, q)
+	if strings.Contains(s, q) {
+		return true
+	}
+	return q == "home" && isHomePath(raw)
+}
+func isHomePath(p string) bool {
+	if p == "" {
+		return false
+	}
+	cleaned := filepath.Clean(p)
+	if cleaned == "~" {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return strings.EqualFold(cleaned, filepath.Clean(home))
+}
+func isHomeSession(s model.Session) bool {
+	return isHomePath(s.Name) || isHomePath(s.Path)
 }

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -31,6 +31,18 @@ func TestFilterResetsSelectionWhenQueryChanges(t *testing.T) {
 		t.Fatalf("cur=%#v ok=%v", cur, ok)
 	}
 }
+func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
+	t.Setenv("HOME", "/Users/zach")
+	m := New([]model.Session{
+		{Name: "home-manager", Path: "/tmp/home-manager"},
+		{Name: "~", Path: "/Users/zach"},
+	})
+	m.Filter("home")
+	cur, ok := m.Current()
+	if !ok || cur.Name != "~" {
+		t.Fatalf("cur=%#v ok=%v", cur, ok)
+	}
+}
 func TestSeparatorAwareMatch(t *testing.T) {
 	if !Match("my-api.service", "api service", true) {
 		t.Fatal("expected separator aware match")


### PR DESCRIPTION
## Summary
- Prefer the actual home directory session when the query is `home`
- Treat `~` and the configured home path as home matches
- Add a regression test for home selection order

## Testing
- Unit tests added for picker filtering behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The session picker now selects your actual home directory when you search for "home". It recognizes `~` and your user home path as home, and adds a regression test to lock in the selection order.

<sup>Written for commit 45db379cda4f2595f538e3b341f1407fd3f4e8c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

