### PR TITLE
ci: check out requested release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,30 @@ jobs:
     name: Test before release
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release ref
+        id: release-ref
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$REF_NAME"
+          fi
+          case "$tag" in
+            v*) ;;
+            *) echo "Release tag must start with v, got: $tag" >&2; exit 1 ;;
+          esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-ref.outputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -42,9 +64,30 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release ref
+        id: release-ref
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$REF_NAME"
+          fi
+          case "$tag" in
+            v*) ;;
+            *) echo "Release tag must start with v, got: $tag" >&2; exit 1 ;;
+          esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ steps.release-ref.outputs.tag }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -56,17 +99,11 @@ jobs:
       - name: Resolve version
         id: meta
         shell: bash
+        env:
+          TAG: ${{ steps.release-ref.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag='${{ inputs.tag }}'
-          else
-            tag='${{ github.ref_name }}'
-          fi
-          case "$tag" in
-            v*) ;;
-            *) echo "Release tag must start with v, got: $tag" >&2; exit 1 ;;
-          esac
+          tag="$TAG"
           version="${tag#v}"
           manifest_version=$(awk -F'"' '
             /^version = / { print $2; exit }


### PR DESCRIPTION
## Summary
- resolve the requested release tag before checkout in both release jobs
- check out that exact tag for manual dispatch and tag-push releases
- keep the `v*` tag validation and manifest version check

Closes #10

## Validation
- `just check`
- `just build`
- `mise x actionlint@1.7.11 -- actionlint -shellcheck= .github/workflows/release.yml`
- reviewed the workflow checkout path for both `workflow_dispatch` and tag push events


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release workflows now resolve and check out the exact requested tag for both manual dispatch and tag-push runs. This prevents releasing from the wrong ref and keeps existing version validations.

- **Bug Fixes**
  - Resolve the release tag from `inputs.tag` or `github.ref_name` and validate it starts with `v`.
  - Use the resolved tag for `actions/checkout@v4` in both jobs.
  - Use the same tag for the manifest version check to match `vX.Y.Z`.

<sup>Written for commit 8c7da9e00e19709cfa3a4710a5e0e49cacd7d514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

