### PR TITLE
fix: resolve clone destination under cmdDir

### DIFF
--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -15,7 +15,10 @@ type Request struct {
 
 func Destination(r Request) string {
 	if r.Dir != "" {
-		return r.Dir
+		if filepath.IsAbs(r.Dir) || r.CmdDir == "" {
+			return r.Dir
+		}
+		return filepath.Join(r.CmdDir, r.Dir)
 	}
 	base := strings.TrimSuffix(filepath.Base(r.Repo), ".git")
 	if base == "" || base == "." {

--- a/internal/clone/clone_test.go
+++ b/internal/clone/clone_test.go
@@ -14,3 +14,17 @@ func TestDestinationOverride(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestDestinationRelativeDirUsesCmdDir(t *testing.T) {
+	got := Destination(Request{Repo: "x", CmdDir: "/tmp/work", Dir: "repo"})
+	if got != "/tmp/work/repo" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestDestinationRelativeDirWithoutCmdDir(t *testing.T) {
+	got := Destination(Request{Repo: "x", Dir: "repo"})
+	if got != "repo" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- resolve relative clone `--dir` values under `--cmdDir`
- preserve absolute `--dir` values and existing inferred repo-name behavior
- add focused destination regression coverage

Closes #11

## Validation
- `go test ./internal/clone`
- `just check`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clone destination resolution: relative `--dir` values are now resolved under `--cmdDir`; absolute `--dir` and the default inferred repo name remain unchanged. Adds focused tests in `internal/clone` to prevent regressions.

<sup>Written for commit 2a8c8267cbe66ff77657968db67457554b03dbc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

