### PR TITLE
ci: run repo-native checks in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,32 +18,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Set up mise
+        uses: jdx/mise-action@v2
         with:
-          go-version-file: go.mod
           cache: true
+          install: true
 
       - name: Download modules
         run: go mod download
 
-      - name: Check formatting
-        run: |
-          files=$(gofmt -l .)
-          if [ -n "$files" ]; then
-            echo "gofmt required for:"
-            echo "$files"
-            exit 1
-          fi
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: Test
-        run: go test ./...
+      - name: Repo checks
+        run: just check
 
       - name: Build
-        run: go build -o bin/herdr-sesh ./cmd/herdr-sesh
+        run: just build
 
       - name: CLI smoke test
         run: |


### PR DESCRIPTION
## Summary
- install the project toolchain through `mise` in GitHub CI
- replace duplicated formatting/vet/test steps with `just check`
- keep build and CLI smoke checks explicit

Closes #12

## Validation
- `just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `mise x actionlint@1.7.11 -- actionlint -shellcheck= .github/workflows/test.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run repo-native checks in GitHub Actions using `mise` for toolchain install and `just` for tasks. This removes duplicated Go steps and keeps build and CLI smoke tests explicit.

- **Refactors**
  - Replace `actions/setup-go@v5` with `jdx/mise-action@v2` (cache enabled, install=true).
  - Consolidate format/vet/test into `just check`.
  - Build via `just build`; retain CLI smoke test.

<sup>Written for commit 04686ed8bbe782c5ba35fc5bc3a7b3c4e7c6a322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

