### PR TITLE
fix: package release binary under manifest path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             goos=${target%/*}
             goarch=${target#*/}
             name="herdr-sesh_${version}_${goos}_${goarch}"
-            out="dist/work/${name}/herdr-sesh"
+            out="dist/work/${name}/bin/herdr-sesh"
             mkdir -p "$(dirname "$out")"
             GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
               go build \
@@ -106,6 +106,16 @@ jobs:
             cp README.md LICENSE herdr-plugin.toml "dist/work/${name}/"
             tar -C dist/work -czf "dist/release/${name}.tar.gz" "$name"
           done
+          smoke_dir=$(mktemp -d)
+          smoke_name="herdr-sesh_${version}_linux_amd64"
+          tar -xzf "dist/release/${smoke_name}.tar.gz" -C "$smoke_dir"
+          test -x "$smoke_dir/${smoke_name}/bin/herdr-sesh"
+          grep -Fq './bin/herdr-sesh' "$smoke_dir/${smoke_name}/herdr-plugin.toml"
+          "$smoke_dir/${smoke_name}/bin/herdr-sesh" --version
+          "$smoke_dir/${smoke_name}/bin/herdr-sesh" list --json \
+            --config testdata/sesh.toml \
+            >/tmp/herdr-sesh-release-list.json
+          test -s /tmp/herdr-sesh-release-list.json
           (cd dist/release && sha256sum *.tar.gz > checksums.txt)
 
       - name: Generate release notes


### PR DESCRIPTION
## Summary
- package release archives with `bin/herdr-sesh` so `herdr-plugin.toml` command paths resolve
- add release archive smoke coverage for the extracted manifest command path

Closes #9

## Validation
- `just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `mise x actionlint@1.7.11 -- actionlint -shellcheck= .github/workflows/release.yml`
- local archive packaging smoke; the Darwin arm64 archive contained and ran `bin/herdr-sesh`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release archive layout by placing the binary at `bin/herdr-sesh` so `herdr-plugin.toml` command paths resolve. Adds a smoke test in the release workflow to confirm the path and basic CLI behavior.

- **Bug Fixes**
  - Build now outputs to `dist/work/{name}/bin/herdr-sesh` and packages that structure.
  - Smoke test extracts a Linux archive, checks `bin/herdr-sesh` exists and is referenced in `herdr-plugin.toml`, runs `--version` and `list --json` with `testdata/sesh.toml`, and verifies the JSON output is created.

<sup>Written for commit 4d90c6a39f06300e68299a1df29731213dae7968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

