### PR TITLE
fix: scope startup commands to workspace

### DIFF
--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -38,6 +38,46 @@ func TestConnectCreatesWorkspaceForConfigSession(t *testing.T) {
 	}
 }
 
+func TestConnectNoFocusScopesStartupCommandToCreatedWorkspace(t *testing.T) {
+	f := &herdr.FakeClient{
+		Workspaces: []herdr.Workspace{{ID: "existing-workspace"}},
+		Panes: []herdr.Pane{
+			{ID: "existing-pane", WorkspaceID: "existing-workspace"},
+			{ID: "new-pane", WorkspaceID: "new-workspace"},
+		},
+	}
+	session := model.Session{Source: "config", Name: "api", Path: "/tmp/api", StartupCommand: "echo ready"}
+	if _, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{NoFocus: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.CreatedWorkspaces) != 1 || f.CreatedWorkspaces[0].Focus {
+		t.Fatalf("created workspaces: %#v", f.CreatedWorkspaces)
+	}
+	if len(f.PaneRuns) != 1 || f.PaneRuns[0] != "new-pane:echo ready" {
+		t.Fatalf("pane runs: %#v", f.PaneRuns)
+	}
+}
+
+func TestConnectFocusedScopesStartupCommandToCreatedWorkspace(t *testing.T) {
+	f := &herdr.FakeClient{
+		Workspaces: []herdr.Workspace{{ID: "existing-workspace"}},
+		Panes: []herdr.Pane{
+			{ID: "existing-pane", WorkspaceID: "existing-workspace"},
+			{ID: "new-pane", WorkspaceID: "new-workspace"},
+		},
+	}
+	session := model.Session{Source: "config", Name: "api", Path: "/tmp/api", StartupCommand: "echo ready"}
+	if _, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.CreatedWorkspaces) != 1 || !f.CreatedWorkspaces[0].Focus {
+		t.Fatalf("created workspaces: %#v", f.CreatedWorkspaces)
+	}
+	if len(f.PaneRuns) != 1 || f.PaneRuns[0] != "new-pane:echo ready" {
+		t.Fatalf("pane runs: %#v", f.PaneRuns)
+	}
+}
+
 func TestConnectUsesExpandedConfigSessionPath(t *testing.T) {
 	cfg := config.Config{SessionConfigs: []config.SessionConfig{{Name: "api", Path: "~/projects/api"}}}
 	got, err := sources.ConfigSessions{Config: cfg, Home: "/home/zach"}.List(context.Background())

--- a/internal/startup/startup.go
+++ b/internal/startup/startup.go
@@ -2,6 +2,7 @@ package startup
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
@@ -46,11 +47,19 @@ func Apply(ctx context.Context, client herdr.Client, p Plan) error {
 	}
 	paneID := firstPane
 	if paneID == "" {
-		pane, err := client.PaneCurrent(ctx)
+		panes, err := client.PaneList(ctx, p.WorkspaceID)
 		if err != nil {
 			return err
 		}
-		paneID = pane.ID
+		for _, pane := range panes {
+			if pane.ID != "" && pane.WorkspaceID == p.WorkspaceID {
+				paneID = pane.ID
+				break
+			}
+		}
+		if paneID == "" {
+			return fmt.Errorf("no pane available in workspace %q", p.WorkspaceID)
+		}
 	}
 	return client.PaneRun(ctx, paneID, config.SubstitutePath(p.Session.StartupCommand, path))
 }

--- a/internal/startup/startup_test.go
+++ b/internal/startup/startup_test.go
@@ -35,3 +35,15 @@ func TestApplySkipsDisabledStartup(t *testing.T) {
 		t.Fatalf("unexpected pane runs: %#v", f.PaneRuns)
 	}
 }
+
+func TestApplyFailsClearlyWhenOnlyOffTargetPaneExists(t *testing.T) {
+	f := &herdr.FakeClient{Panes: []herdr.Pane{{ID: "existing-pane", WorkspaceID: "existing-workspace"}}}
+	s := model.Session{Path: "/tmp/app", StartupCommand: "echo hi"}
+	err := Apply(context.Background(), f, Plan{WorkspaceID: "new-workspace", Session: s})
+	if err == nil || err.Error() != `no pane available in workspace "new-workspace"` {
+		t.Fatalf("error = %v", err)
+	}
+	if len(f.PaneRuns) != 0 {
+		t.Fatalf("unexpected pane runs: %#v", f.PaneRuns)
+	}
+}


### PR DESCRIPTION
## Summary

- resolve zero-window startup panes only within the newly created workspace
- return a clear error instead of falling back to another workspace's current pane
- cover no-focus, focused, configured-window, and missing-target-pane behavior

## Why

`startup.Apply` used the global `PaneCurrent` fallback when no configured window supplied a pane ID. During `connect --no-focus`, that could send the new session's startup command to the previously focused workspace. The fallback now lists panes for the target workspace and independently verifies each returned workspace ID before running the command.

## Validation

- `go test ./internal/connect ./internal/startup -run '^(TestConnectNoFocusScopesStartupCommandToCreatedWorkspace|TestConnectFocusedScopesStartupCommandToCreatedWorkspace|TestApplyCreatesTabsAndRunsCommands|TestApplyFailsClearlyWhenOnlyOffTargetPaneExists)$' -count=1`
- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-issue-022-golangci-lint-cache just check`
- `git diff --check`

Closes #22


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes startup commands to the target workspace so they never run in another workspace. If the workspace has no panes, `startup.Apply` now returns a clear error instead of falling back to a global current pane.

- **Bug Fixes**
  - Limit pane lookup to the target workspace via `PaneList`; verify `WorkspaceID`.
  - Remove fallback to `PaneCurrent` across workspaces.
  - Return `no pane available in workspace "<id>"` when no pane is found.
  - Add tests for `connect --no-focus`, focused startup, and missing target pane.

<sup>Written for commit 4889478680ead11e37dffdbd2d994cca5f1a0358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

