### PR TITLE
ci: bind releases to requested tag commit

### DIFF
--- a/.github/scripts/checkout-release-ref.sh
+++ b/.github/scripts/checkout-release-ref.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ref=${1:-}
+case "$ref" in
+  refs/tags/v*) ;;
+  *) echo "Release ref must be an explicit refs/tags/v* ref, got: ${ref:-<empty>}" >&2; exit 1 ;;
+esac
+tag=${ref#refs/tags/}
+if [[ ! "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+  echo "Release tag must match project-safe syntax: $tag" >&2
+  exit 1
+fi
+if ! git check-ref-format "$ref" >/dev/null; then
+  echo "Invalid release tag ref: $ref" >&2
+  exit 1
+fi
+
+if ! git show-ref --verify --quiet "$ref"; then
+  echo "Requested release tag is missing: $ref" >&2
+  exit 1
+fi
+if ! commit=$(git rev-parse --verify "${ref}^{commit}" 2>/dev/null); then
+  echo "Requested release tag does not peel to a commit: $ref" >&2
+  exit 1
+fi
+
+git checkout --detach --quiet "$commit"
+head=$(git rev-parse HEAD)
+if [ "$head" != "$commit" ]; then
+  echo "Checked-out HEAD $head does not match requested tag commit $commit" >&2
+  exit 1
+fi
+
+printf '%s\n' "$commit"

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+workflow="$repo_root/.github/workflows/release.yml"
+helper="$repo_root/.github/scripts/checkout-release-ref.sh"
+
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'bash .github/scripts/checkout-release-ref.sh "$RELEASE_REF"' "$workflow"; then
+  echo 'release workflow must resolve the explicit tag ref through checkout-release-ref.sh' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'if [ "$remote_commit" != "$EXPECTED_COMMIT" ]; then' "$workflow"; then
+  echo 'publish must reject a tag that moved after build verification' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'if [[ ! "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then' "$workflow"; then
+  echo 'release workflow must reject tags outside the project-safe syntax' >&2
+  exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+git -C "$tmp" init -q
+git -C "$tmp" config user.email test@example.com
+git -C "$tmp" config user.name 'Release workflow test'
+
+printf 'tag\n' >"$tmp/version"
+git -C "$tmp" add version
+git -C "$tmp" commit -qm 'tag commit'
+tag_commit=$(git -C "$tmp" rev-parse HEAD)
+git -C "$tmp" tag -am 'annotated release tag' v1.2.3
+git -C "$tmp" tag v1.2.4
+
+git -C "$tmp" switch -qc v1.2.3
+printf 'branch\n' >"$tmp/version"
+git -C "$tmp" commit -qam 'same-named branch commit'
+branch_commit=$(git -C "$tmp" rev-parse HEAD)
+
+resolved=$(cd "$tmp" && bash "$helper" refs/tags/v1.2.3)
+head=$(git -C "$tmp" rev-parse HEAD)
+
+if [ "$resolved" != "$tag_commit" ] || [ "$head" != "$tag_commit" ]; then
+  echo "expected explicit tag commit $tag_commit, resolved $resolved with HEAD $head" >&2
+  exit 1
+fi
+if [ "$resolved" = "$branch_commit" ]; then
+  echo "resolved same-named branch commit $branch_commit instead of tag" >&2
+  exit 1
+fi
+
+lightweight=$(cd "$tmp" && bash "$helper" refs/tags/v1.2.4)
+if [ "$lightweight" != "$tag_commit" ]; then
+  echo "expected lightweight tag commit $tag_commit, resolved $lightweight" >&2
+  exit 1
+fi
+
+if missing=$(cd "$tmp" && bash "$helper" refs/tags/v9.9.9 2>&1); then
+  echo 'expected a missing release tag to fail' >&2
+  exit 1
+fi
+case "$missing" in
+  *'Requested release tag is missing: refs/tags/v9.9.9'*) ;;
+  *) echo "missing release tag failed unclearly: $missing" >&2; exit 1 ;;
+esac
+
+for unsafe_tag in 'v#probe' 'v%2Fprobe' 'v/path' 'v?probe'; do
+  if unsafe=$(cd "$tmp" && bash "$helper" "refs/tags/$unsafe_tag" 2>&1); then
+    echo "expected unsafe release tag $unsafe_tag to fail" >&2
+    exit 1
+  fi
+  case "$unsafe" in
+    *"Release tag must match project-safe syntax: $unsafe_tag"*) ;;
+    *) echo "unsafe release tag $unsafe_tag failed unclearly: $unsafe" >&2; exit 1 ;;
+  esac
+done

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -16,6 +16,11 @@ if ! grep -Fq 'if [ "$remote_commit" != "$EXPECTED_COMMIT" ]; then' "$workflow";
   echo 'publish must reject a tag that moved after build verification' >&2
   exit 1
 fi
+# shellcheck disable=SC2016 # Match the workflow's literal GitHub expression.
+if ! grep -Fq 'GH_REPO: ${{ github.repository }}' "$workflow"; then
+  echo 'publish must provide repository context to gh release commands' >&2
+  exit 1
+fi
 # shellcheck disable=SC2016 # Match the workflow's literal shell variables.
 if ! grep -Fq 'if [[ ! "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then' "$workflow"; then
   echo 'release workflow must reject tags outside the project-safe syntax' >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
           EXPECTED_COMMIT: ${{ needs.release.outputs.commit }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,17 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
     name: Test before release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.release-ref.outputs.tag }}
+      commit: ${{ steps.verify-ref.outputs.commit }}
     steps:
       - name: Resolve release ref
         id: release-ref
@@ -25,27 +30,56 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          REF_NAME: ${{ github.ref_name }}
+          EVENT_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             tag="$INPUT_TAG"
+            if [ -z "$tag" ]; then
+              echo 'Release tag is required' >&2
+              exit 1
+            fi
+            ref="refs/tags/$tag"
           else
-            tag="$REF_NAME"
+            ref="$EVENT_REF"
+            case "$ref" in
+              refs/tags/*) tag=${ref#refs/tags/} ;;
+              *) echo "Release ref must be a tag, got: $ref" >&2; exit 1 ;;
+            esac
           fi
           case "$tag" in
             v*) ;;
             *) echo "Release tag must start with v, got: $tag" >&2; exit 1 ;;
           esac
+          if [[ ! "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+            echo "Release tag must match project-safe syntax: $tag" >&2
+            exit 1
+          fi
+          if ! git check-ref-format "$ref" >/dev/null; then
+            echo "Invalid release tag ref: $ref" >&2
+            exit 1
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout workflow source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ steps.release-ref.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify and check out requested tag commit
+        id: verify-ref
+        shell: bash
+        env:
+          RELEASE_REF: ${{ steps.release-ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          commit=$(bash .github/scripts/checkout-release-ref.sh "$RELEASE_REF")
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -60,38 +94,35 @@ jobs:
           ./bin/herdr-sesh --version
 
   release:
-    name: Build and publish release
+    name: Build release assets
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      commit: ${{ needs.test.outputs.commit }}
     steps:
-      - name: Resolve release ref
-        id: release-ref
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.test.outputs.commit }}
+          persist-credentials: false
+
+      - name: Verify immutable release commit
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_TAG: ${{ inputs.tag }}
-          REF_NAME: ${{ github.ref_name }}
+          EXPECTED_COMMIT: ${{ needs.test.outputs.commit }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            tag="$INPUT_TAG"
-          else
-            tag="$REF_NAME"
+          head=$(git rev-parse HEAD)
+          if [ "$head" != "$EXPECTED_COMMIT" ]; then
+            echo "Checked-out HEAD $head does not match verified release commit $EXPECTED_COMMIT" >&2
+            exit 1
           fi
-          case "$tag" in
-            v*) ;;
-            *) echo "Release tag must start with v, got: $tag" >&2; exit 1 ;;
-          esac
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.release-ref.outputs.tag }}
-          fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -100,7 +131,7 @@ jobs:
         id: meta
         shell: bash
         env:
-          TAG: ${{ steps.release-ref.outputs.tag }}
+          TAG: ${{ needs.test.outputs.tag }}
         run: |
           set -euo pipefail
           tag="$TAG"
@@ -155,13 +186,14 @@ jobs:
             --config testdata/sesh.toml \
             >/tmp/herdr-sesh-release-list.json
           test -s /tmp/herdr-sesh-release-list.json
-          (cd dist/release && sha256sum *.tar.gz > checksums.txt)
+          (cd dist/release && sha256sum -- *.tar.gz > checksums.txt)
 
       - name: Generate release notes
         shell: bash
         env:
           TAG: ${{ steps.meta.outputs.tag }}
           VERSION: ${{ steps.meta.outputs.version }}
+          COMMIT: ${{ needs.test.outputs.commit }}
         run: |
           set -euo pipefail
           tag="$TAG"
@@ -178,6 +210,7 @@ jobs:
             echo "cd herdr-plugin-sesh"
             echo "git checkout ${tag}"
             echo 'go build -o bin/herdr-sesh ./cmd/herdr-sesh'
+            # shellcheck disable=SC2016 # Keep $PWD literal in the generated instructions.
             echo 'herdr plugin link "$PWD"'
             echo '```'
             echo
@@ -189,20 +222,61 @@ jobs:
             echo "- checksums.txt"
             echo
             echo "Version: ${version}"
-            echo "Commit: ${GITHUB_SHA}"
+            echo "Commit: ${COMMIT}"
           } > dist/release/RELEASE_NOTES.md
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: herdr-plugin-sesh-${{ steps.meta.outputs.tag }}
           path: dist/release/*
 
+  publish:
+    name: Publish GitHub release
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.meta.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
+          EXPECTED_COMMIT: ${{ needs.release.outputs.commit }}
         run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          gh run download "$GITHUB_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "herdr-plugin-sesh-${TAG}" \
+            --dir dist/release
+
+          if ! object=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
+            --jq '[.object.type, .object.sha] | @tsv'); then
+            echo "Requested release tag is no longer available: refs/tags/$TAG" >&2
+            exit 1
+          fi
+          IFS=$'\t' read -r object_type remote_commit <<< "$object"
+          while [ "$object_type" = tag ]; do
+            if ! object=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/git/tags/${remote_commit}" \
+              --jq '[.object.type, .object.sha] | @tsv'); then
+              echo "Could not peel requested release tag refs/tags/$TAG" >&2
+              exit 1
+            fi
+            IFS=$'\t' read -r object_type remote_commit <<< "$object"
+          done
+          if [ "$object_type" != commit ]; then
+            echo "Requested release tag does not peel to a commit: refs/tags/$TAG" >&2
+            exit 1
+          fi
+          if [ "$remote_commit" != "$EXPECTED_COMMIT" ]; then
+            echo "Requested release tag moved from $EXPECTED_COMMIT to $remote_commit" >&2
+            exit 1
+          fi
+
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" \
               --title "$TAG" \

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ test:
     @echo "{{ BOLD + BLUE + BG_BLACK }} Running tests...{{ NORMAL }}"
     gotestsum --format-icons=octicons --format=pkgname -- -race ./...
 
+# Exercise release tag resolution against a same-named branch/tag collision
+test-release-ref:
+    bash .github/scripts/test-release-ref.sh
+
 # Run all checks for code changes
-check: lint fmt-check test
+check: lint fmt-check test test-release-ref
     @echo "{{ BOLD + GREEN + BG_BLACK }} All checks passed!{{ NORMAL }}"


### PR DESCRIPTION
## Summary

- normalize release inputs to explicit tag refs, peel and verify the requested tag commit, and pass the same immutable SHA through test and asset-build jobs
- keep build jobs read-only, pin workflow actions to immutable SHAs, and expose write authority only in the publish job
- re-resolve the remote tag immediately before publishing so moved tags cannot replace release assets
- add bounded regressions for same-named branch/tag collisions, annotated and lightweight tags, missing tags, and URL-unsafe tag names

Closes #24

## Validation

- `just test-release-ref`
- `mise x shellcheck@0.11.0 actionlint@1.7.11 -- actionlint .github/workflows/release.yml`
- `mise x shellcheck@0.11.0 -- shellcheck .github/scripts/checkout-release-ref.sh .github/scripts/test-release-ref.sh`
- `just check` (87 race-enabled tests plus the release-ref regression)
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind releases to the exact commit of the requested `refs/tags/v*` and re-verify the tag at publish time so moved tags cannot replace assets. Tightens the release workflow with read-only builds, pinned actions, and stricter tag validation.

- **Refactors**
  - Resolve the explicit tag ref to a commit via `.github/scripts/checkout-release-ref.sh`, check out detached HEAD, and pass the immutable SHA between `test` and `release`.
  - Make build jobs read-only and pin `actions/checkout`, `actions/setup-go`, and `actions/upload-artifact` to immutable SHAs; only `publish` has `contents: write`.
  - Re-fetch and peel the remote tag in `publish`; abort if it moved or doesn’t peel to a commit.
  - Enforce project-safe tag syntax, handle annotated and lightweight tags, and avoid same-name branch/tag collisions.
  - Add `.github/scripts/test-release-ref.sh`, a `just test-release-ref` task, and include it in `just check`.

<sup>Written for commit ba4a23c0868570a9f72e758e5ebcc91313c8db50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

