### PR TITLE
fix: align Sesh config runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ prototype uses a `bat` preview for items with an existing directory path.
 
 ## Configuration
 
-The plugin reads Sesh-compatible TOML from:
+The plugin reads the supported Sesh-style TOML subset documented in
+[`docs/config.md`](docs/config.md) from:
 
 1. `--config PATH`
 2. `HERDR_SESH_CONFIG`

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,7 @@
 # Configuration
 
-`herdr-sesh` intentionally accepts the core Sesh TOML shape so existing Sesh users can migrate gradually.
+`herdr-sesh` accepts a deliberate subset of Sesh TOML. The fields below are the
+implemented contract; tmux-specific Sesh settings are not supported by Herdr.
 
 Lookup order:
 
@@ -9,7 +10,7 @@ Lookup order:
 3. `${HERDR_PLUGIN_CONFIG_DIR}/sesh.toml`
 4. `~/.config/sesh/sesh.toml`
 
-For a linked Herdr plugin, create or edit the plugin-owned config file with:
+For a linked Herdr plugin, create or inspect the plugin-owned config with:
 
 ```bash
 just install-plugin
@@ -18,44 +19,118 @@ HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)" ./bin/herdr-s
 ```
 
 Herdr creates `HERDR_PLUGIN_CONFIG_DIR` and `HERDR_PLUGIN_STATE_DIR` for the
-plugin. Keep user-editable configuration in the config directory and runtime
-state in the state directory; do not rely on the linked or installed plugin root
-for durable user data.
+plugin. Keep user configuration in the config directory and runtime state in
+the state directory.
 
-Supported keys include:
+## Top-level fields
 
-- `cache`
-- `strict_mode`
-- `import`
-- `blacklist`
-- `sort_order`
-- `dir_length`
-- `separator_aware`
-- `tmux_command`
-- `[tui]`
-- `[default_session]`
-- `[[session]]`
-- `[[window]]`
-- `[[wildcard]]`
+| Field | Runtime effect |
+| --- | --- |
+| `cache` | Caches normal deduplicated `list` results for five seconds in `HERDR_PLUGIN_STATE_DIR`, scoped to the resolved config file. It does not cache `list --blacklisted`, `list --hide-duplicates=false`, `picker`, or `connect`. |
+| `strict_mode` | Rejects unknown fields in this file and its imported files. Without strict mode, unknown fields are ignored. |
+| `import` | Loads additional TOML files before the current file. Relative paths are resolved from the importing file; `~/` is expanded. |
+| `blacklist` | Treats each value as a regular expression matched against session names. Normal listings hide matches; `list --blacklisted` shows them. |
+| `sort_order` | Orders sources such as `herdr`, `config`, `zoxide`, and `dir`. Sources omitted from the list are appended. |
+| `dir_length` | Sets the number of path components used by the directory-name fallback for a newly created direct-path workspace. Git repositories keep their repository-derived name. The default and minimum effective value are `1`. |
+| `separator_aware` | Makes native and fzf picker searches treat `-`, `_`, `/`, and `.` as spaces. |
 
-Example:
+## Picker fields
+
+`[tui]` supports:
+
+| Field | Runtime effect |
+| --- | --- |
+| `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
+| `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
+| `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
+
+## Session behavior
+
+`[default_session]` supports only:
+
+| Field | Runtime effect |
+| --- | --- |
+| `startup_command` | Fallback command run after a new Herdr workspace is created. `{}` is replaced with the session path. |
+| `preview_command` | Fallback command used by `preview` and the native picker. `{}` is replaced with the session path. |
+
+`[[session]]` supports:
+
+| Field | Runtime effect |
+| --- | --- |
+| `name` | Session label and connect target. |
+| `path` | Workspace path; `~/` is expanded before it is sent to Herdr. |
+| `startup_command` | Session-specific startup command. |
+| `preview_command` | Session-specific preview command. |
+| `disable_startup_command` | Suppresses startup execution when `true`. |
+| `windows` | Names of `[[window]]` entries to create as Herdr tabs. |
+
+Startup commands are selected in this order: the explicit session command, the
+first matching wildcard command, then `[default_session].startup_command`.
+Preview commands use the same explicit session, wildcard, then default order.
+
+`[[window]]` supports:
+
+| Field | Runtime effect |
+| --- | --- |
+| `name` | Name referenced by a session or wildcard `windows` list and used as the Herdr tab label. |
+| `path` | Optional tab working directory. Without it, the session path is used; `~/` is expanded. |
+| `startup_script` | Command run in the new tab. `{}` is replaced with that tab's working directory. |
+
+## Wildcards
+
+Wildcard startup, preview, and disable settings apply to every matching session
+when the corresponding explicit session field is unset. Wildcard windows apply
+only to discovered or direct-path sessions. The first matching wildcard wins.
+
+| Field | Runtime effect |
+| --- | --- |
+| `pattern` | Path glob. `*`, `?`, and character classes use `filepath.Match` semantics; a trailing `/**` matches the base directory and all descendants. |
+| `startup_command` | Startup command for a matching path. |
+| `preview_command` | Preview command for a matching path. |
+| `disable_startup_command` | Suppresses wildcard and default startup behavior for a matching path when `true`. |
+| `windows` | `[[window]]` entries created for a matching discovered or direct-path session, not a configured session. |
+
+## Unsupported Sesh fields
+
+`tmux_command`, `tmuxp`, and `tmuxinator` have no Herdr equivalent and are not
+supported. `windows` is supported on `[[session]]` and `[[wildcard]]`, but not
+under `[default_session]`. These and any other unknown fields are rejected when
+`strict_mode = true`; otherwise they are ignored rather than changing runtime
+behavior. The generated starter config therefore does not reference Sesh's
+broader JSON schema.
+
+## Example
 
 ```toml
-[default_session]
-preview_command = "eza --icons=always -la {}"
+cache = true
+strict_mode = true
+sort_order = ["herdr", "config", "zoxide", "dir"]
+dir_length = 1
+separator_aware = true
+blacklist = ["^scratch$"]
 
-[[session]]
-name = "brain"
-path = "~/brain"
+[tui]
+show_icons = true
+prompt = "Sesh> "
+placeholder = "Search workspaces"
+
+[default_session]
 startup_command = "git status"
-disable_startup_command = false
-windows = ["git"]
+preview_command = "eza --icons=always -la {}"
 
 [[window]]
 name = "git"
 startup_script = "git status"
 
+[[session]]
+name = "brain"
+path = "~/brain"
+disable_startup_command = true
+windows = ["git"]
+
 [[wildcard]]
 pattern = "~/projects/**"
+startup_command = "git status"
 preview_command = "eza --icons=always -la {}"
+windows = ["git"]
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -85,12 +85,16 @@ func (a *App) collect(ctx context.Context, cfg config.Config, target string) ([]
 	hs := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}
 	srcs := []sources.Source{ignoreSource{hs}, sources.ConfigSessions{Config: cfg}, sources.Zoxide{}}
 	if target != "" {
-		srcs = append(srcs, sources.DirectPath{Path: target})
+		srcs = append(srcs, sources.DirectPath{
+			Path:  target,
+			Label: namer.Namer{}.Name(ctx, target, cfg.DirLength),
+		})
 	}
 	merged, err := sources.Merge(ctx, srcs, cfg.SortOrder, cfg.Blacklist, false, true)
 	if err != nil {
 		return nil, err
 	}
+	sources.ApplyConfig(&merged, cfg, "")
 	return merged.Ordered(), nil
 }
 
@@ -114,12 +118,13 @@ func (a *App) list(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	cfg, err := a.loadConfig(*cfgPath)
+	cfg, resolvedConfigPath, err := config.Load(config.LoadOptions{Path: *cfgPath})
 	if err != nil {
 		return err
 	}
-	if cfg.Cache {
-		if cached, ok, err := state.LoadSessionCache(os.Getenv("HERDR_PLUGIN_STATE_DIR"), 5*time.Second, time.Now()); err != nil {
+	cacheable := cfg.Cache && !*blacklisted && *hideDup
+	if cacheable {
+		if cached, ok, err := state.LoadSessionCache(os.Getenv("HERDR_PLUGIN_STATE_DIR"), resolvedConfigPath, 5*time.Second, time.Now()); err != nil {
 			a.warnf("ignoring session cache: %v", err)
 		} else if ok {
 			return a.printSessions(cached, *jsonOut)
@@ -129,9 +134,10 @@ func (a *App) list(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	sources.ApplyConfig(&ss, cfg, "")
 	sessions := ss.Ordered()
-	if cfg.Cache {
-		if err := state.SaveSessionCache(os.Getenv("HERDR_PLUGIN_STATE_DIR"), sessions, time.Now()); err != nil {
+	if cacheable {
+		if err := state.SaveSessionCache(os.Getenv("HERDR_PLUGIN_STATE_DIR"), resolvedConfigPath, sessions, time.Now()); err != nil {
 			a.warnf("could not save session cache: %v", err)
 		}
 	}
@@ -182,6 +188,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		Output:                a.Out,
 		Prompt:                cfg.TUI.Prompt,
 		Placeholder:           cfg.TUI.Placeholder,
+		ShowIcons:             cfg.TUI.ShowIcons,
 		SeparatorAware:        cfg.SeparatorAware,
 		DefaultPreviewCommand: cfg.DefaultSessionConfig.PreviewCommand,
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,12 +3,16 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
+	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 )
 
@@ -87,6 +91,100 @@ func TestListWarnsWhenSessionCacheCannotBeSaved(t *testing.T) {
 	}
 }
 
+func TestListCacheDoesNotMaskBlacklistedResults(t *testing.T) {
+	d := t.TempDir()
+	cfgPath := filepath.Join(d, "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte(`cache = true
+blacklist = ["^scratch$"]
+
+[[session]]
+name = "api"
+path = "/tmp/api"
+
+[[session]]
+name = "scratch"
+path = "/tmp/scratch"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
+
+	if got := runListJSON(t, cfgPath, ""); len(got) != 1 || got[0].Name != "api" {
+		t.Fatalf("normal sessions = %#v", got)
+	}
+	if got := runListJSON(t, cfgPath, "", "--blacklisted"); len(got) != 1 || got[0].Name != "scratch" {
+		t.Fatalf("blacklisted sessions = %#v", got)
+	}
+}
+
+func TestListCacheDoesNotMaskDuplicateResults(t *testing.T) {
+	d := t.TempDir()
+	cfgPath := filepath.Join(d, "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte(`cache = true
+sort_order = ["config", "zoxide"]
+
+[[session]]
+name = "api"
+path = "/configured/api"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
+	zoxideOutput := "42 /discovered/api\n"
+
+	if got := runListJSON(t, cfgPath, zoxideOutput); len(got) != 1 {
+		t.Fatalf("deduplicated sessions = %#v", got)
+	}
+	if got := runListJSON(t, cfgPath, zoxideOutput, "--hide-duplicates=false"); len(got) != 2 {
+		t.Fatalf("duplicate sessions = %#v", got)
+	}
+}
+
+func TestListCacheDoesNotCrossConfigFiles(t *testing.T) {
+	d := t.TempDir()
+	firstConfig := filepath.Join(d, "first.toml")
+	secondConfig := filepath.Join(d, "second.toml")
+	if err := os.WriteFile(firstConfig, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondConfig, []byte("cache = true\n[[session]]\nname = \"web\"\npath = \"/tmp/web\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
+
+	if got := runListJSON(t, firstConfig, ""); len(got) != 1 || got[0].Name != "api" {
+		t.Fatalf("first config sessions = %#v", got)
+	}
+	if got := runListJSON(t, secondConfig, ""); len(got) != 1 || got[0].Name != "web" {
+		t.Fatalf("second config sessions = %#v", got)
+	}
+}
+
+func TestListCacheDistinguishesRelativeConfigsAcrossWorkingDirectories(t *testing.T) {
+	d := t.TempDir()
+	firstDir := filepath.Join(d, "first")
+	secondDir := filepath.Join(d, "second")
+	for dir, name := range map[string]string{firstDir: "api", secondDir: "web"} {
+		if err := os.Mkdir(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf("cache = true\n[[session]]\nname = %q\npath = %q\n", name, filepath.Join("/tmp", name))
+		if err := os.WriteFile(filepath.Join(dir, "sesh.toml"), []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
+
+	t.Chdir(firstDir)
+	if got := runListJSON(t, "sesh.toml", ""); len(got) != 1 || got[0].Name != "api" {
+		t.Fatalf("first config sessions = %#v", got)
+	}
+	t.Chdir(secondDir)
+	if got := runListJSON(t, "sesh.toml", ""); len(got) != 1 || got[0].Name != "web" {
+		t.Fatalf("second config sessions = %#v", got)
+	}
+}
+
 func TestPickerJSONCommand(t *testing.T) {
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
@@ -95,6 +193,109 @@ func TestPickerJSONCommand(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"name": "sesh"`) {
 		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestPickerJSONAppliesDefaultStartupCommand(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[default_session]
+startup_command = "printf default:{}"
+
+[[session]]
+name = "api"
+path = "/tmp/api"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := runPickerJSON(t, cfgPath, "")
+	if len(sessions) != 1 || sessions[0].StartupCommand != "printf default:{}" {
+		t.Fatalf("sessions = %#v", sessions)
+	}
+}
+
+func TestPickerJSONAppliesWildcardSettings(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.Mkdir(project, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte(`strict_mode = true
+
+[[wildcard]]
+pattern = "`+project+`"
+startup_command = "printf wildcard:{}"
+preview_command = "printf preview:{}"
+disable_startup_command = true
+windows = ["git"]
+
+[[window]]
+name = "git"
+startup_script = "git status"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := runPickerJSON(t, cfgPath, "42 "+project+"\n")
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %#v", sessions)
+	}
+	s := sessions[0]
+	if s.StartupCommand != "" || s.PreviewCommand != "printf preview:{}" || !s.DisableStartupCommand || !reflect.DeepEqual(s.WindowNames, []string{"git"}) {
+		t.Fatalf("wildcard session = %#v", s)
+	}
+	if len(s.WindowConfigs) != 0 {
+		t.Fatalf("window configs leaked into JSON: %#v", s.WindowConfigs)
+	}
+}
+
+func TestPickerJSONExplicitFalseOverridesWildcardDisable(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.Mkdir(project, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[default_session]
+startup_command = "printf default:{}"
+
+[[session]]
+name = "project"
+path = "`+project+`"
+disable_startup_command = false
+
+[[wildcard]]
+pattern = "`+project+`"
+startup_command = "printf wildcard:{}"
+disable_startup_command = true
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := runPickerJSON(t, cfgPath, "")
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %#v", sessions)
+	}
+	if sessions[0].DisableStartupCommand || sessions[0].StartupCommand != "printf wildcard:{}" {
+		t.Fatalf("session = %#v", sessions[0])
+	}
+}
+
+func TestCollectDirectPathUsesConfiguredDirLength(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "parent")
+	target := filepath.Join(parent, "child")
+	if err := os.MkdirAll(target, 0700); err != nil {
+		t.Fatal(err)
+	}
+	configureFakeSources(t, "")
+	cfg := config.Default()
+	cfg.DirLength = 2
+
+	sessions, err := (&App{}).collect(context.Background(), cfg, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Name != filepath.Join("parent", "child") {
+		t.Fatalf("sessions = %#v", sessions)
 	}
 }
 
@@ -173,4 +374,54 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	if !reflect.DeepEqual(h.Workspaces, want) {
 		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
 	}
+}
+
+func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {
+	t.Helper()
+	configureFakeSources(t, zoxideOutput)
+
+	var out bytes.Buffer
+	a := &App{Out: &out, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), []string{"picker", "--json", "--config", cfgPath}); err != nil {
+		t.Fatal(err)
+	}
+	var sessions []model.Session
+	if err := json.Unmarshal(out.Bytes(), &sessions); err != nil {
+		t.Fatalf("decode picker JSON: %v\n%s", err, out.String())
+	}
+	return sessions
+}
+
+func runListJSON(t *testing.T, cfgPath, zoxideOutput string, extraArgs ...string) []model.Session {
+	t.Helper()
+	configureFakeSources(t, zoxideOutput)
+
+	args := append([]string{"list", "--json", "--config", cfgPath}, extraArgs...)
+	var out bytes.Buffer
+	a := &App{Out: &out, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), args); err != nil {
+		t.Fatal(err)
+	}
+	var sessions []model.Session
+	if err := json.Unmarshal(out.Bytes(), &sessions); err != nil {
+		t.Fatalf("decode list JSON: %v\n%s", err, out.String())
+	}
+	return sessions
+}
+
+func configureFakeSources(t *testing.T, zoxideOutput string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	for name, script := range map[string]string{
+		"herdr":  "#!/bin/sh\nexit 1\n",
+		"zoxide": "#!/bin/sh\nprintf '%s' \"$FAKE_ZOXIDE_OUTPUT\"\n",
+	} {
+		//nolint:gosec // test creates local executable fixtures.
+		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte(script), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
+	t.Setenv("FAKE_ZOXIDE_OUTPUT", zoxideOutput)
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,24 +16,21 @@ type Config struct {
 	WildcardConfigs      []WildcardConfig     `toml:"wildcard"`
 	DirLength            int                  `toml:"dir_length"`
 	SeparatorAware       bool                 `toml:"separator_aware"`
-	TmuxCommand          string               `toml:"tmux_command"`
 	TUI                  TUIConfig            `toml:"tui"`
 }
 
 type DefaultSessionConfig struct {
-	StartupCommand string   `toml:"startup_command"`
-	Tmuxp          string   `toml:"tmuxp"`
-	Tmuxinator     string   `toml:"tmuxinator"`
-	PreviewCommand string   `toml:"preview_command"`
-	Windows        []string `toml:"windows"`
+	StartupCommand string `toml:"startup_command"`
+	PreviewCommand string `toml:"preview_command"`
 }
 
 type SessionConfig struct {
 	DefaultSessionConfig
 
-	Name                string `toml:"name"`
-	Path                string `toml:"path"`
-	DisableStartCommand bool   `toml:"disable_startup_command"`
+	Name                string   `toml:"name"`
+	Path                string   `toml:"path"`
+	DisableStartCommand *bool    `toml:"disable_startup_command"`
+	Windows             []string `toml:"windows"`
 }
 
 type TUIConfig struct {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -25,8 +25,13 @@ func Load(opts LoadOptions) (Config, string, error) {
 	if path == "" {
 		return cfg, "", nil
 	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return cfg, path, err
+	}
+	path = filepath.Clean(path)
 	seen := map[string]bool{}
-	if err := loadInto(&cfg, path, seen); err != nil {
+	if err := loadInto(&cfg, path, seen, false); err != nil {
 		return cfg, path, err
 	}
 	attachDefaults(&cfg)
@@ -67,7 +72,7 @@ func ResolvePath(opts LoadOptions) (string, error) {
 	return "", nil
 }
 
-func loadInto(dst *Config, path string, seen map[string]bool) error {
+func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return err
@@ -90,11 +95,13 @@ func loadInto(dst *Config, path string, seen map[string]bool) error {
 		TUI struct {
 			Prompt      *string `toml:"prompt"`
 			Placeholder *string `toml:"placeholder"`
+			ShowIcons   *bool   `toml:"show_icons"`
 		} `toml:"tui"`
 	}
 	_ = toml.Unmarshal(data, &probe)
+	strict = strict || probe.StrictMode
 	dec := toml.NewDecoder(bytes.NewReader(data))
-	if probe.StrictMode {
+	if strict {
 		dec.DisallowUnknownFields()
 	}
 	var next Config
@@ -107,7 +114,7 @@ func loadInto(dst *Config, path string, seen map[string]bool) error {
 		if !filepath.IsAbs(ip) {
 			ip = filepath.Join(base, ip)
 		}
-		if err := loadInto(dst, ip, seen); err != nil {
+		if err := loadInto(dst, ip, seen, strict); err != nil {
 			return err
 		}
 	}
@@ -115,11 +122,12 @@ func loadInto(dst *Config, path string, seen map[string]bool) error {
 		probe.DefaultSessionConfig.PreviewCommand != nil,
 		probe.TUI.Prompt != nil,
 		probe.TUI.Placeholder != nil,
+		probe.TUI.ShowIcons != nil,
 	)
 	return nil
 }
 
-func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet bool) {
+func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet bool) {
 	if src.Cache {
 		dst.Cache = true
 	}
@@ -138,11 +146,8 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	if src.SeparatorAware {
 		dst.SeparatorAware = true
 	}
-	if src.TmuxCommand != "" {
-		dst.TmuxCommand = src.TmuxCommand
-	}
-	if src.TUI.ShowIcons {
-		dst.TUI.ShowIcons = true
+	if showIconsSet {
+		dst.TUI.ShowIcons = src.TUI.ShowIcons
 	}
 	if promptSet {
 		dst.TUI.Prompt = src.TUI.Prompt
@@ -153,17 +158,8 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	if src.DefaultSessionConfig.StartupCommand != "" {
 		dst.DefaultSessionConfig.StartupCommand = src.DefaultSessionConfig.StartupCommand
 	}
-	if src.DefaultSessionConfig.Tmuxp != "" {
-		dst.DefaultSessionConfig.Tmuxp = src.DefaultSessionConfig.Tmuxp
-	}
-	if src.DefaultSessionConfig.Tmuxinator != "" {
-		dst.DefaultSessionConfig.Tmuxinator = src.DefaultSessionConfig.Tmuxinator
-	}
 	if previewCommandSet {
 		dst.DefaultSessionConfig.PreviewCommand = src.DefaultSessionConfig.PreviewCommand
-	}
-	if len(src.DefaultSessionConfig.Windows) > 0 {
-		dst.DefaultSessionConfig.Windows = src.DefaultSessionConfig.Windows
 	}
 	dst.SessionConfigs = append(dst.SessionConfigs, src.SessionConfigs...)
 	dst.WindowConfigs = append(dst.WindowConfigs, src.WindowConfigs...)
@@ -220,6 +216,6 @@ func InitConfig(dir string) (string, error) {
 	if err == nil {
 		return p, nil
 	}
-	starter := fmt.Sprintf("#:schema https://github.com/joshmedeski/sesh/raw/main/sesh.schema.json\n\n[default_session]\npreview_command = %q\n\n# [[session]]\n# name = \"Example\"\n# path = \"~/projects/example\"\n", DefaultPreviewCommand)
+	starter := fmt.Sprintf("[default_session]\npreview_command = %q\n\n# [[session]]\n# name = \"Example\"\n# path = \"~/projects/example\"\n", DefaultPreviewCommand)
 	return p, os.WriteFile(p, []byte(starter), 0600)
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +46,37 @@ func TestLoadStrictRejectsUnknown(t *testing.T) {
 		t.Fatal("expected strict error")
 	}
 }
+
+func TestLoadStrictRejectsUnsupportedSeshKeys(t *testing.T) {
+	tests := map[string]string{
+		"tmux command":               "tmux_command = \"psmux\"\n",
+		"default session windows":    "[default_session]\nwindows = [\"git\"]\n",
+		"default session tmuxp":      "[default_session]\ntmuxp = \"project.yaml\"\n",
+		"default session tmuxinator": "[default_session]\ntmuxinator = \"project\"\n",
+		"session tmuxp":              "[[session]]\nname = \"api\"\npath = \"/tmp/api\"\ntmuxp = \"project.yaml\"\n",
+		"session tmuxinator":         "[[session]]\nname = \"api\"\npath = \"/tmp/api\"\ntmuxinator = \"project\"\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "sesh.toml")
+			mustWrite(t, p, "strict_mode = true\n"+body)
+			if _, _, err := Load(LoadOptions{Path: p}); err == nil {
+				t.Fatal("expected strict error")
+			}
+		})
+	}
+}
+
+func TestLoadStrictRejectsUnsupportedSeshKeysInImports(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), "tmux_command = \"psmux\"\n")
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, "strict_mode = true\nimport = [\"extra.toml\"]\n")
+	if _, _, err := Load(LoadOptions{Path: p}); err == nil {
+		t.Fatal("expected strict error from imported config")
+	}
+}
+
 func TestLoadImportOrder(t *testing.T) {
 	d := t.TempDir()
 	mustWrite(t, filepath.Join(d, "extra.toml"), `[[session]]
@@ -68,7 +99,6 @@ func TestLoadMergesNestedConfigTablesFieldByField(t *testing.T) {
 	mustWrite(t, filepath.Join(d, "extra.toml"), `[default_session]
 startup_command = "git status"
 preview_command = "printf extra {}"
-windows = ["git"]
 
 [tui]
 prompt = "Extra> "
@@ -92,9 +122,6 @@ placeholder = "Search workspaces"
 	}
 	if cfg.DefaultSessionConfig.PreviewCommand != "printf extra {}" {
 		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
-	if want := []string{"git"}; !reflect.DeepEqual(cfg.DefaultSessionConfig.Windows, want) {
-		t.Fatalf("windows = %#v, want %#v", cfg.DefaultSessionConfig.Windows, want)
 	}
 	if cfg.TUI.Prompt != "Extra> " {
 		t.Fatalf("prompt = %q", cfg.TUI.Prompt)
@@ -146,6 +173,20 @@ placeholder = ""
 	}
 }
 
+func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), "[tui]\nshow_icons = true\n")
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_icons = false\n")
+	cfg, _, err := Load(LoadOptions{Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.ShowIcons {
+		t.Fatal("show_icons = true, want false")
+	}
+}
+
 func TestDefaultPreviewCommandUsesEzaIcons(t *testing.T) {
 	cfg := Default()
 	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
@@ -153,6 +194,21 @@ func TestDefaultPreviewCommandUsesEzaIcons(t *testing.T) {
 	}
 	if DefaultPreviewCommand != "eza --icons=always -la {}" {
 		t.Fatalf("default preview command = %q", DefaultPreviewCommand)
+	}
+}
+
+func TestInitConfigDoesNotAdvertiseUnsupportedSeshSchema(t *testing.T) {
+	p, err := InitConfig(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // p is returned from InitConfig using a test-owned temporary directory.
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "sesh.schema.json") {
+		t.Fatalf("starter config advertises the full Sesh schema:\n%s", data)
 	}
 }
 

--- a/internal/config/wildcard_test.go
+++ b/internal/config/wildcard_test.go
@@ -10,6 +10,9 @@ func TestWildcardOneLevelAndRecursive(t *testing.T) {
 	if MatchWildcard("~/projects/*", "/home/zach/projects/team/api", home) {
 		t.Fatal("one-level should not match nested")
 	}
+	if !MatchWildcard("~/projects/**", "/home/zach/projects", home) {
+		t.Fatal("recursive should match base directory")
+	}
 	if !MatchWildcard("~/projects/**", "/home/zach/projects/team/api", home) {
 		t.Fatal("recursive should match nested")
 	}

--- a/internal/model/session.go
+++ b/internal/model/session.go
@@ -15,6 +15,7 @@ type Session struct {
 	StartupCommand        string         `json:"startup_command,omitempty"`
 	PreviewCommand        string         `json:"preview_command,omitempty"`
 	DisableStartupCommand bool           `json:"disable_startup_command,omitempty"`
+	DisableStartupSet     bool           `json:"-"`
 	WindowNames           []string       `json:"window_names,omitempty"`
 	WindowConfigs         []WindowConfig `json:"-"`
 	Score                 float64        `json:"score,omitempty"`

--- a/internal/picker/fzf.go
+++ b/internal/picker/fzf.go
@@ -131,7 +131,7 @@ func fzfLabel(s sessionmodel.Session) string {
 }
 
 func fzfSourceBadge(source string) string {
-	return "\x1b[1;38;5;" + sourceBadgeColor(source) + "m" + fzfField(sourceBadge(source)) + "\x1b[0m"
+	return "\x1b[1;38;5;" + sourceBadgeColor(source) + "m" + fzfField(sourceBadge(source, true)) + "\x1b[0m"
 }
 
 func fzfSearchField(s sessionmodel.Session, separatorAware bool) string {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -115,6 +115,7 @@ type Options struct {
 	Output                io.Writer
 	Prompt                string
 	Placeholder           string
+	ShowIcons             bool
 	SeparatorAware        bool
 	DefaultPreviewCommand string
 	FZFCommand            string
@@ -148,6 +149,7 @@ type teaModel struct {
 	previewKey string
 
 	defaultPreviewCommand string
+	showIcons             bool
 }
 
 type previewMsg struct {
@@ -174,7 +176,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	input.PlaceholderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
 	input.Cursor.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
 	input.Focus()
-	m := teaModel{list: list, input: input, defaultPreviewCommand: opts.DefaultPreviewCommand}
+	m := teaModel{list: list, input: input, defaultPreviewCommand: opts.DefaultPreviewCommand, showIcons: opts.ShowIcons}
 	if current, ok := list.Current(); ok {
 		m.previewKey = sessionmodel.Key(current)
 		m.preview = "Loading preview..."
@@ -285,7 +287,7 @@ func (m teaModel) listView(width, visibleRows int) string {
 			b.WriteString(moreStyle.Render("...") + "\n")
 		}
 		for i := start; i < end; i++ {
-			b.WriteString(row(m.list.Filtered[i], i == m.list.Selected, width))
+			b.WriteString(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons))
 		}
 		if end < len(m.list.Filtered) {
 			b.WriteString(moreStyle.Render("...") + "\n")
@@ -407,7 +409,7 @@ func fixedVisualLines(text string, width, count int) string {
 	return strings.Join(lines, "\n")
 }
 
-func row(s sessionmodel.Session, selected bool, width int) string {
+func row(s sessionmodel.Session, selected bool, width int, showIcons bool) string {
 	cursor := " "
 	if selected {
 		cursor = ">"
@@ -417,7 +419,7 @@ func row(s sessionmodel.Session, selected bool, width int) string {
 		label = s.Path
 	}
 	source := s.Source
-	badgeText := sourceBadge(source)
+	badgeText := sourceBadge(source, showIcons)
 	badge := sourceBadgeStyle(source).Render(badgeText)
 	path := ""
 	showPath := s.Path != "" && s.Path != label
@@ -436,7 +438,13 @@ func row(s sessionmodel.Session, selected bool, width int) string {
 	return rowStyle.Width(width-2).Render(line) + "\n"
 }
 
-func sourceBadge(source string) string {
+func sourceBadge(source string, showIcons bool) string {
+	if !showIcons {
+		if source == "" {
+			return "[session]"
+		}
+		return "[" + source + "]"
+	}
 	switch source {
 	case "herdr":
 		return herdrSourceIcon + " herdr"

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -67,6 +67,7 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	}, Options{
 		Prompt:      "Find> ",
 		Placeholder: "Search sessions",
+		ShowIcons:   true,
 	})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = updated.(teaModel)
@@ -77,6 +78,19 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}
+	}
+}
+
+func TestTeaModelShowIconsControlsSourceIcons(t *testing.T) {
+	items := []model.Session{{Source: "herdr", Name: "api"}}
+	withoutIcons := newTeaModel(items, Options{}).View()
+	if strings.Contains(withoutIcons, herdrSourceIcon) {
+		t.Fatalf("view unexpectedly contains source icon:\n%s", withoutIcons)
+	}
+
+	withIcons := newTeaModel(items, Options{ShowIcons: true}).View()
+	if !strings.Contains(withIcons, herdrSourceIcon+" herdr") {
+		t.Fatalf("view missing source icon:\n%s", withIcons)
 	}
 }
 
@@ -97,7 +111,7 @@ func TestRowUsesSourceCategoryColors(t *testing.T) {
 		{source: "dir", color: "38;5;176"},
 	}
 	for _, tt := range tests {
-		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80)
+		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80, true)
 		if !strings.Contains(got, tt.color) {
 			t.Fatalf("row for source %q missing color %s:\n%q", tt.source, tt.color, got)
 		}
@@ -180,7 +194,7 @@ func TestSelectedRowHighlightDoesNotResetBeforeContent(t *testing.T) {
 		lipgloss.SetColorProfile(prev)
 	})
 
-	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh"}, true, 80)
+	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh"}, true, 80, true)
 	if !strings.Contains(got, "48;5;63") {
 		t.Fatalf("selected row missing highlight background:\n%q", got)
 	}

--- a/internal/sources/config_sessions.go
+++ b/internal/sources/config_sessions.go
@@ -21,7 +21,8 @@ func (s ConfigSessions) List(context.Context) (model.Sessions, error) {
 		win[w.Name] = w
 	}
 	for _, c := range s.Config.SessionConfigs {
-		sess := model.Session{Source: "config", Name: c.Name, Path: config.ExpandHome(c.Path, s.Home), StartupCommand: c.StartupCommand, PreviewCommand: c.PreviewCommand, DisableStartupCommand: c.DisableStartCommand, WindowNames: c.Windows}
+		disableStartup := c.DisableStartCommand != nil && *c.DisableStartCommand
+		sess := model.Session{Source: "config", Name: c.Name, Path: config.ExpandHome(c.Path, s.Home), StartupCommand: c.StartupCommand, PreviewCommand: c.PreviewCommand, DisableStartupCommand: disableStartup, DisableStartupSet: c.DisableStartCommand != nil, WindowNames: c.Windows}
 		for _, n := range c.Windows {
 			if w, ok := win[n]; ok {
 				sess.WindowConfigs = append(sess.WindowConfigs, w)
@@ -30,4 +31,41 @@ func (s ConfigSessions) List(context.Context) (model.Sessions, error) {
 		out.Add(sess)
 	}
 	return out, nil
+}
+
+func ApplyConfig(sessions *model.Sessions, cfg config.Config, home string) {
+	windows := make(map[string]model.WindowConfig, len(cfg.WindowConfigs))
+	for _, window := range cfg.WindowConfigs {
+		window.Path = config.ExpandHome(window.Path, home)
+		windows[window.Name] = window
+	}
+	for key, session := range sessions.Directory {
+		wildcard, matched := config.FindWildcard(cfg, session.Path, home)
+		if matched && !session.DisableStartupSet {
+			session.DisableStartupCommand = wildcard.DisableStartCommand
+		}
+		if session.StartupCommand == "" && !session.DisableStartupCommand {
+			if matched {
+				session.StartupCommand = wildcard.StartupCommand
+			}
+			if session.StartupCommand == "" && !session.DisableStartupCommand {
+				session.StartupCommand = cfg.DefaultSessionConfig.StartupCommand
+			}
+		}
+		if session.PreviewCommand == "" && matched {
+			session.PreviewCommand = wildcard.PreviewCommand
+		}
+		if session.Source != "config" && len(session.WindowNames) == 0 && matched {
+			session.WindowNames = wildcard.Windows
+		}
+		if len(session.WindowNames) > 0 {
+			session.WindowConfigs = session.WindowConfigs[:0]
+			for _, name := range session.WindowNames {
+				if window, ok := windows[name]; ok {
+					session.WindowConfigs = append(session.WindowConfigs, window)
+				}
+			}
+		}
+		sessions.Directory[key] = session
+	}
 }

--- a/internal/sources/config_sessions_test.go
+++ b/internal/sources/config_sessions_test.go
@@ -11,7 +11,7 @@ import (
 func TestConfigSessionsExpandsHomePaths(t *testing.T) {
 	cfg := config.Config{
 		SessionConfigs: []config.SessionConfig{
-			{Name: "api", Path: "~/projects/api", DefaultSessionConfig: config.DefaultSessionConfig{Windows: []string{"logs"}}},
+			{Name: "api", Path: "~/projects/api", Windows: []string{"logs"}},
 		},
 		WindowConfigs: []model.WindowConfig{
 			{Name: "logs", Path: "~/projects/api/logs"},
@@ -31,5 +31,45 @@ func TestConfigSessionsExpandsHomePaths(t *testing.T) {
 	}
 	if len(sessions[0].WindowConfigs) != 1 || sessions[0].WindowConfigs[0].Path != "/home/zach/projects/api/logs" {
 		t.Fatalf("window configs = %#v", sessions[0].WindowConfigs)
+	}
+}
+
+func TestApplyConfigAttachesWildcardWindows(t *testing.T) {
+	cfg := config.Config{
+		WildcardConfigs: []config.WildcardConfig{{Pattern: "~/projects/*", Windows: []string{"logs"}}},
+		WindowConfigs:   []model.WindowConfig{{Name: "logs", Path: "~/projects/api/logs"}},
+	}
+	sessions := model.NewSessions()
+	sessions.Add(model.Session{Source: "zoxide", Name: "api", Path: "/home/zach/projects/api"})
+
+	ApplyConfig(&sessions, cfg, "/home/zach")
+
+	got := sessions.Ordered()[0]
+	if len(got.WindowConfigs) != 1 || got.WindowConfigs[0].Name != "logs" || got.WindowConfigs[0].Path != "/home/zach/projects/api/logs" {
+		t.Fatalf("window configs = %#v", got.WindowConfigs)
+	}
+}
+
+func TestApplyConfigWildcardDisablePrecedesStartupFallback(t *testing.T) {
+	cfg := config.Config{
+		DefaultSessionConfig: config.DefaultSessionConfig{StartupCommand: "default"},
+		WildcardConfigs: []config.WildcardConfig{{
+			Pattern:             "/projects/**",
+			StartupCommand:      "wildcard",
+			DisableStartCommand: true,
+		}},
+	}
+	sessions := model.NewSessions()
+	sessions.Add(model.Session{Source: "config", Name: "explicit", Path: "/projects/explicit", StartupCommand: "configured"})
+	sessions.Add(model.Session{Source: "config", Name: "fallback", Path: "/projects/fallback"})
+
+	ApplyConfig(&sessions, cfg, "")
+
+	got := sessions.Ordered()
+	if !got[0].DisableStartupCommand || got[0].StartupCommand != "configured" {
+		t.Fatalf("explicit session = %#v", got[0])
+	}
+	if !got[1].DisableStartupCommand || got[1].StartupCommand != "" {
+		t.Fatalf("fallback session = %#v", got[1])
 	}
 }

--- a/internal/state/cache.go
+++ b/internal/state/cache.go
@@ -10,25 +10,26 @@ import (
 )
 
 type SessionCache struct {
-	SavedAt  time.Time       `json:"saved_at"`
-	Sessions []model.Session `json:"sessions"`
+	SavedAt    time.Time       `json:"saved_at"`
+	ConfigPath string          `json:"config_path"`
+	Sessions   []model.Session `json:"sessions"`
 }
 
 func SessionCachePath(dir string) string {
 	return filepath.Join(dir, "sessions.json")
 }
 
-func SaveSessionCache(dir string, sessions []model.Session, now time.Time) error {
+func SaveSessionCache(dir, configPath string, sessions []model.Session, now time.Time) error {
 	if dir == "" {
 		return nil
 	}
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	return writeJSONFile(SessionCachePath(dir), SessionCache{SavedAt: now, Sessions: sessions})
+	return writeJSONFile(SessionCachePath(dir), SessionCache{SavedAt: now, ConfigPath: configPath, Sessions: sessions})
 }
 
-func LoadSessionCache(dir string, ttl time.Duration, now time.Time) ([]model.Session, bool, error) {
+func LoadSessionCache(dir, configPath string, ttl time.Duration, now time.Time) ([]model.Session, bool, error) {
 	if dir == "" || ttl <= 0 {
 		return nil, false, nil
 	}
@@ -42,6 +43,9 @@ func LoadSessionCache(dir string, ttl time.Duration, now time.Time) ([]model.Ses
 	var payload SessionCache
 	if err := json.Unmarshal(b, &payload); err != nil {
 		return nil, false, err
+	}
+	if payload.ConfigPath != configPath {
+		return nil, false, nil
 	}
 	if now.Sub(payload.SavedAt) > ttl {
 		return nil, false, nil

--- a/internal/state/cache_test.go
+++ b/internal/state/cache_test.go
@@ -10,10 +10,10 @@ import (
 func TestSessionCacheUsesFreshEntries(t *testing.T) {
 	d := t.TempDir()
 	want := []model.Session{{Source: "config", Name: "api", Path: "/tmp/api"}}
-	if err := SaveSessionCache(d, want, time.Now()); err != nil {
+	if err := SaveSessionCache(d, "/tmp/sesh.toml", want, time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	got, ok, err := LoadSessionCache(d, 5*time.Second, time.Now())
+	got, ok, err := LoadSessionCache(d, "/tmp/sesh.toml", 5*time.Second, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,10 +24,10 @@ func TestSessionCacheUsesFreshEntries(t *testing.T) {
 
 func TestSessionCacheIgnoresStaleEntries(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveSessionCache(d, []model.Session{{Name: "old"}}, time.Unix(0, 0)); err != nil {
+	if err := SaveSessionCache(d, "", []model.Session{{Name: "old"}}, time.Unix(0, 0)); err != nil {
 		t.Fatal(err)
 	}
-	got, ok, err := LoadSessionCache(d, time.Second, time.Unix(10, 0))
+	got, ok, err := LoadSessionCache(d, "", time.Second, time.Unix(10, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestSessionCacheIgnoresStaleEntries(t *testing.T) {
 }
 
 func TestSessionCacheMissWhenMissing(t *testing.T) {
-	got, ok, err := LoadSessionCache(t.TempDir(), time.Second, time.Now())
+	got, ok, err := LoadSessionCache(t.TempDir(), "", time.Second, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,10 +47,10 @@ func TestSessionCacheMissWhenMissing(t *testing.T) {
 }
 
 func TestSessionCacheNoopsWithoutStateDir(t *testing.T) {
-	if err := SaveSessionCache("", []model.Session{{Name: "api"}}, time.Now()); err != nil {
+	if err := SaveSessionCache("", "", []model.Session{{Name: "api"}}, time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	got, ok, err := LoadSessionCache("", time.Second, time.Now())
+	got, ok, err := LoadSessionCache("", "", time.Second, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- define and document the supported Sesh-style TOML subset, including strict handling for unsupported tmux-only keys and imported configs
- wire retained settings into runtime behavior for native picker icons, startup/preview wildcards, direct-path naming, and configured session precedence
- scope list caching to canonical config identity and bypass cache variants whose filtering differs from the normal deduplicated list
- add focused regressions for every corrected behavior, including explicit false overrides and recursive wildcard base matching

Closes #23

## Validation

- `just check` (108 race-enabled tests)
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `herdr-sesh` with a documented Sesh-style TOML subset and wires those settings into runtime behavior (picker icons, wildcard/default commands, direct-path naming). Tightens session list caching by scoping it to the resolved config and skipping non-standard variants.

- **New Features**
  - Defined the supported Sesh TOML subset; `strict_mode` now validates this file and all `import`ed files. Updated `docs/config.md` and example.
  - Applied config at runtime: explicit > wildcard > default precedence for startup/preview; wildcard windows for discovered/direct-path sessions; explicit `disable_startup_command = false` overrides wildcard disables; `/**` recursive matches include the base dir; `dir_length` names direct-path sessions.
  - Picker: added `tui.show_icons` (native and `fzf` badges); kept source names when icons are off; `separator_aware` search respected.

- **Bug Fixes**
  - List caching keyed by the resolved config path; skipped for `--blacklisted` and `--hide-duplicates=false` to avoid stale/mismatched results.
  - Robust path handling for configs and `import`: absolute/cleaned paths; relative imports resolved from the file; `~/` expanded.
  - Removed tmux-only Sesh keys and schema reference; `tui.show_icons` now merges correctly when set to false.

<sup>Written for commit 27430bce0d1040edb1fb7b57c89230683f0525d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

