### PR TITLE
feat: add plugin install script

### DIFF
--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+exec herdr plugin install fullerzz/herdr-plugin-sesh --yes


### PR DESCRIPTION
## Summary
- add an executable shell installer for the plugin
- delegate installation to Herdr with non-interactive confirmation

## Validation
- `bash -n install_plugin.sh`
- traced `install_plugin.sh` against a temporary fake `herdr` executable
- `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an executable `install_plugin.sh` that installs the Sesh plugin via `herdr` non-interactively. It runs `herdr plugin install fullerzz/herdr-plugin-sesh --yes` for a one-command, CI-friendly setup.

<sup>Written for commit b200fc6b7f66ffe2487d947037372fe6bad478ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

