### PR TITLE
fix: enforce plugin release version consistency

### DIFF
--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -37,6 +37,10 @@ if ! grep -Fq 'test "$packaged_version" = "$version"' "$workflow"; then
   echo 'release workflow must verify the packaged manifest version' >&2
   exit 1
 fi
+if ! grep -Fq 'cp README.md LICENSE herdr-plugin.toml build_plugin.sh' "$workflow"; then
+  echo 'release archives must include the manifest build script' >&2
+  exit 1
+fi
 # shellcheck disable=SC2016 # Match the workflow's literal shell variables.
 if ! grep -Fq 'if [ "$manifest_version" != "$version" ]; then' "$changelog_workflow"; then
   echo 'changelog workflow must reject tags that do not match the manifest version' >&2
@@ -45,6 +49,29 @@ fi
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
+
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "$*"' >"$fake_bin/herdr"
+chmod +x "$fake_bin/herdr"
+manifest_version=$(awk -F'"' '
+  /^version = / { print $2; exit }
+' "$repo_root/herdr-plugin.toml")
+if ! grep -Fq 'command = ["bash", "build_plugin.sh"]' "$repo_root/herdr-plugin.toml"; then
+  echo 'manifest build must use the version-injecting build script' >&2
+  exit 1
+fi
+(cd "$tmp" && bash "$repo_root/build_plugin.sh")
+if [ "$("$repo_root/bin/herdr-sesh" --version)" != "herdr-sesh ${manifest_version}" ]; then
+  echo 'manifest build must inject the manifest version into the binary' >&2
+  exit 1
+fi
+install_command=$(cd "$tmp" && PATH="$fake_bin:$PATH" "$repo_root/install_plugin.sh")
+expected_install="plugin install fullerzz/herdr-plugin-sesh --ref v${manifest_version} --yes"
+if [ "$install_command" != "$expected_install" ]; then
+  echo "installer must pin the manifest release: got $install_command" >&2
+  exit 1
+fi
 
 git -C "$tmp" init -q
 git -C "$tmp" config user.email test@example.com

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -41,6 +41,10 @@ if ! grep -Fq 'cp README.md LICENSE herdr-plugin.toml build_plugin.sh' "$workflo
   echo 'release archives must include the manifest build script' >&2
   exit 1
 fi
+if ! grep -Fq "echo 'bash build_plugin.sh'" "$workflow"; then
+  echo 'generated source-install instructions must inject the manifest version' >&2
+  exit 1
+fi
 # shellcheck disable=SC2016 # Match the workflow's literal shell variables.
 if ! grep -Fq 'if [ "$manifest_version" != "$version" ]; then' "$changelog_workflow"; then
   echo 'changelog workflow must reject tags that do not match the manifest version' >&2

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 repo_root=$(git rev-parse --show-toplevel)
 workflow="$repo_root/.github/workflows/release.yml"
+changelog_workflow="$repo_root/.github/workflows/changelog.yml"
 helper="$repo_root/.github/scripts/checkout-release-ref.sh"
 
 # shellcheck disable=SC2016 # Match the workflow's literal shell variables.
@@ -24,6 +25,21 @@ fi
 # shellcheck disable=SC2016 # Match the workflow's literal shell variables.
 if ! grep -Fq 'if [[ ! "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then' "$workflow"; then
   echo 'release workflow must reject tags outside the project-safe syntax' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'test "$("$binary" --version)" = "herdr-sesh ${version}"' "$workflow"; then
+  echo 'release workflow must verify the packaged binary version' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'test "$packaged_version" = "$version"' "$workflow"; then
+  echo 'release workflow must verify the packaged manifest version' >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match the workflow's literal shell variables.
+if ! grep -Fq 'if [ "$manifest_version" != "$version" ]; then' "$changelog_workflow"; then
+  echo 'changelog workflow must reject tags that do not match the manifest version' >&2
   exit 1
 fi
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify version
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          manifest_version=$(awk -F'"' '
+            /^version = / { print $2; exit }
+          ' herdr-plugin.toml)
+          if [ "$manifest_version" != "$version" ]; then
+            echo "Tag mismatch: $TAG != manifest $manifest_version" >&2
+            exit 1
+          fi
+
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
             echo "git clone https://github.com/fullerzz/herdr-plugin-sesh.git"
             echo "cd herdr-plugin-sesh"
             echo "git checkout ${tag}"
-            echo 'go build -o bin/herdr-sesh ./cmd/herdr-sesh'
+            echo 'bash build_plugin.sh'
             # shellcheck disable=SC2016 # Keep $PWD literal in the generated instructions.
             echo 'herdr plugin link "$PWD"'
             echo '```'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,10 +183,16 @@ jobs:
           smoke_dir=$(mktemp -d)
           smoke_name="herdr-sesh_${version}_linux_amd64"
           tar -xzf "dist/release/${smoke_name}.tar.gz" -C "$smoke_dir"
-          test -x "$smoke_dir/${smoke_name}/bin/herdr-sesh"
-          grep -Fq './bin/herdr-sesh' "$smoke_dir/${smoke_name}/herdr-plugin.toml"
-          "$smoke_dir/${smoke_name}/bin/herdr-sesh" --version
-          "$smoke_dir/${smoke_name}/bin/herdr-sesh" list --json \
+          binary="$smoke_dir/${smoke_name}/bin/herdr-sesh"
+          manifest="$smoke_dir/${smoke_name}/herdr-plugin.toml"
+          test -x "$binary"
+          grep -Fq './bin/herdr-sesh' "$manifest"
+          packaged_version=$(awk -F'"' '
+            /^version = / { print $2; exit }
+          ' "$manifest")
+          test "$packaged_version" = "$version"
+          test "$("$binary" --version)" = "herdr-sesh ${version}"
+          "$binary" list --json \
             --config testdata/sesh.toml \
             >/tmp/herdr-sesh-release-list.json
           test -s /tmp/herdr-sesh-release-list.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
                 -ldflags "-s -w -X ${module}.Version=${version}" \
                 -o "$out" \
                 ./cmd/herdr-sesh
-            cp README.md LICENSE herdr-plugin.toml "dist/work/${name}/"
+            cp README.md LICENSE herdr-plugin.toml build_plugin.sh "dist/work/${name}/"
             tar -C dist/work -czf "dist/release/${name}.tar.gz" "$name"
           done
           smoke_dir=$(mktemp -d)

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -11,4 +11,9 @@ if [ -z "$version" ]; then
   exit 1
 fi
 
-exec herdr plugin install fullerzz/herdr-plugin-sesh --ref "v$version" --yes
+mkdir -p "$repo_root/bin"
+cd "$repo_root"
+exec go build \
+  -ldflags "-X github.com/fullerzz/herdr-plugin-sesh/internal/app.Version=$version" \
+  -o bin/herdr-sesh \
+  ./cmd/herdr-sesh

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@ description = "Sesh-style smart workspace/session manager for Herdr"
 platforms = ["linux", "macos"]
 
 [[build]]
-command = ["go", "build", "-o", "bin/herdr-sesh", "./cmd/herdr-sesh"]
+command = ["bash", "build_plugin.sh"]
 
 [[actions]]
 id = "open-picker"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 )
 
-var Version = "0.1.0-dev"
+var Version = "dev"
 
 type App struct {
 	Out io.Writer

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -22,7 +22,7 @@ func TestVersionCommand(t *testing.T) {
 	if err := a.Run(context.Background(), []string{"--version"}); err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(out.String()) != "herdr-sesh 0.1.0-dev" {
+	if strings.TrimSpace(out.String()) != "herdr-sesh dev" {
 		t.Fatalf("got %q", out.String())
 	}
 }


### PR DESCRIPTION
## Summary

- keep `herdr-plugin.toml` as the repository version source while local builds default to `dev`
- make `install_plugin.sh` derive and pin `--ref v<manifest-version>` instead of installing the remote default branch
- build Herdr-managed source installs through `build_plugin.sh`, which injects the manifest version into `internal/app.Version`
- verify release archives contain matching binary and manifest versions and include the referenced build script
- reject changelog generation when a pushed tag does not match the manifest
- extend the release regression checks across all of these contracts

## Why

The manifest, source fallback, Git tag, managed source install, and release asset could previously diverge. In particular, an unqualified `herdr plugin install` fetched the remote default branch, and Herdr's plain source build did not receive the release workflow's linker flags.

The final version flow is:

- ordinary development build: `herdr-sesh dev`
- `install_plugin.sh`: installs the tag derived from the manifest, currently `v0.1.0`
- Herdr-managed tagged source build: injects the manifest version, currently `0.1.0`
- release workflow: validates the tag against the manifest and injects the same version into release assets

## Validation

- red/green regression checks for installer pinning, manifest source-build injection, and archive contents
- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check`
- `just build` with exact `herdr-sesh dev` assertion
- `bash build_plugin.sh` with exact manifest-version assertion
- fixture-backed list smoke tests for both build paths
- `bash -n install_plugin.sh build_plugin.sh .github/scripts/test-release-ref.sh`
- `mise x shellcheck@0.11.0 -- shellcheck install_plugin.sh build_plugin.sh .github/scripts/test-release-ref.sh`
- `mise x actionlint@1.7.11 shellcheck@0.11.0 -- actionlint .github/workflows/release.yml .github/workflows/changelog.yml .github/workflows/test.yml`
- `git diff --check`
- confirmed `v0.1.0` is the manifest-derived tag and the current latest GitHub release