### PR TITLE
ci: add gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,24 @@
+name: Gitleaks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary

- scan every push and pull request for leaked secrets
- allow the scan to be run manually with `workflow_dispatch`
- use the supported Gitleaks v3 action with full git history

## Impact

The Gitleaks job will fail when it detects a secret, making leaks visible in push and pull request checks.

## Validation

- `mise exec actionlint@1.7.11 -- actionlint .github/workflows/gitleaks.yml`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow to run Gitleaks on every push and pull request, plus manual runs via `workflow_dispatch`. Uses `gitleaks/gitleaks-action@v3` with full history and `contents: read`/`pull-requests: read` permissions; fails if any secrets are detected.

<sup>Written for commit 749896ebabf5af9e7beb8d01256a9ebbdcd64d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

