### PR TITLE
chore(renovate): group mise tool updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,12 @@
       ]
     },
     {
+      "matchManagers": [
+        "mise"
+      ],
+      "groupName": "mise tools"
+    },
+    {
       "matchCategories": [
         "ci"
       ],


### PR DESCRIPTION
## Summary
- group Renovate updates managed by `mise` into one PR

## Validation
- `renovate-config-validator renovate.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Renovate rule to group `mise`-managed tool updates into a single PR. This reduces PR noise and makes tool upgrades easier to review.

<sup>Written for commit b29eac9533c9bb6e3c4f9f28fa00d12c8b5e1372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

