### PR TITLE
feat: refresh workspace navigator with agent status

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,10 @@ the state directory.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 
+Open Herdr workspaces show the agent state reported by Herdr when the picker
+opens: green `●` working, amber `◆` blocked, muted `○` idle, and violet `✓`
+done. Workspaces with an unknown state have no indicator.
+
 ## Session behavior
 
 `[default_session]` supports only:

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -17,6 +17,7 @@ type Workspace struct {
 	CWD           string `json:"cwd"`
 	ForegroundCWD string `json:"foreground_cwd"`
 	ActiveTabID   string `json:"active_tab_id"`
+	AgentStatus   string `json:"agent_status"`
 }
 type Tab struct {
 	ID          string `json:"id"`

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -44,23 +44,23 @@ func TestCLIClientConstructsWorkspaceCreateNoFocus(t *testing.T) {
 }
 
 func TestCLIClientDecodesWorkspaceListEnvelope(t *testing.T) {
-	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"workspaces":[{"workspace_id":"w1","label":"api"}]}}`)}}
+	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"workspaces":[{"workspace_id":"w1","label":"api","agent_status":"working"}]}}`)}}
 	got, err := c.WorkspaceList(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" {
+	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" || got[0].AgentStatus != "working" {
 		t.Fatalf("workspaces=%#v", got)
 	}
 }
 
 func TestCLIClientDecodesWorkspaceListArray(t *testing.T) {
-	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`[{"id":"w1","label":"api"}]`)}}
+	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`[{"id":"w1","label":"api","agent_status":"blocked"}]`)}}
 	got, err := c.WorkspaceList(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" {
+	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" || got[0].AgentStatus != "blocked" {
 		t.Fatalf("workspaces=%#v", got)
 	}
 }

--- a/internal/model/session.go
+++ b/internal/model/session.go
@@ -18,6 +18,7 @@ type Session struct {
 	DisableStartupSet     bool           `json:"-"`
 	WindowNames           []string       `json:"window_names,omitempty"`
 	WindowConfigs         []WindowConfig `json:"-"`
+	AgentStatus           string         `json:"-"`
 	Score                 float64        `json:"score,omitempty"`
 	Attached              bool           `json:"attached,omitempty"`
 }

--- a/internal/model/session_test.go
+++ b/internal/model/session_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestSessionJSONOmitsInternalWindowConfigs(t *testing.T) {
-	s := Session{Source: "config", Name: "api", Path: "/tmp/api", WindowConfigs: []WindowConfig{{Name: "dev"}}}
+func TestSessionJSONOmitsInternalPickerFields(t *testing.T) {
+	s := Session{Source: "config", Name: "api", Path: "/tmp/api", AgentStatus: "working", WindowConfigs: []WindowConfig{{Name: "dev"}}}
 	b, err := json.Marshal(s)
 	if err != nil {
 		t.Fatal(err)
@@ -18,6 +18,9 @@ func TestSessionJSONOmitsInternalWindowConfigs(t *testing.T) {
 	}
 	if strings.Contains(got, "WindowConfigs") || strings.Contains(got, "window_configs") {
 		t.Fatalf("json leaked internal window configs: %s", got)
+	}
+	if strings.Contains(got, "AgentStatus") || strings.Contains(got, "agent_status") {
+		t.Fatalf("json leaked internal agent status: %s", got)
 	}
 }
 
@@ -30,5 +33,9 @@ func TestKeyIsStableAndSourceScoped(t *testing.T) {
 	}
 	if Key(a) == Key(c) {
 		t.Fatalf("expected source-scoped key, got %q", Key(a))
+	}
+	b.AgentStatus = "working"
+	if Key(a) != Key(b) {
+		t.Fatalf("expected status-independent key, got %q and %q", Key(a), Key(b))
 	}
 }

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -3,12 +3,16 @@ package picker
 import (
 	"context"
 	"fmt"
+	"image/color"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	sessionmodel "github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	previewpkg "github.com/fullerzz/herdr-plugin-sesh/internal/preview"
@@ -20,93 +24,64 @@ const (
 	defaultPrompt      = "Sesh> "
 	defaultPlaceholder = "Filter workspaces"
 	defaultWidth       = 80
-	minContentWidth    = 36
-	maxContentWidth    = 132
 	previewSplitWidth  = 92
 	minPreviewWidth    = 36
 	maxPreviewWidth    = 52
 	previewTitleRows   = 1
-	previewBorderRows  = 2
-	pickerTopPadding   = 1
-	pickerChromeRows   = 14 + pickerTopPadding
+	pickerChromeRows   = 8
 	compactPreviewBody = 6
+	horizontalPadding  = 2
+	rowPathMinWidth    = 60
+	rowSourceWidth     = 10
+	rowNameMinWidth    = 12
+	rowNameMaxWidth    = 28
 	herdrSourceIcon    = "\U000f0cc6"
 	zoxideSourceIcon   = "\uf114"
 	configSourceIcon   = "\ue615"
 )
 
 var (
-	panelStyle = lipgloss.NewStyle().
-			Border(lipgloss.Border{
-			Top:         "-",
-			Bottom:      "-",
-			Left:        "|",
-			Right:       "|",
-			TopLeft:     "+",
-			TopRight:    "+",
-			BottomLeft:  "+",
-			BottomRight: "+",
-		}).
-		BorderForeground(lipgloss.Color("63")).
-		Padding(1, 2)
+	skyColor    = lipgloss.Color("#7DCFFF")
+	violetColor = lipgloss.Color("#BB9AF7")
+	greenColor  = lipgloss.Color("#9ECE6A")
+	amberColor  = lipgloss.Color("#E0AF68")
+	textColor   = lipgloss.Color("#C0CAF5")
+	mutedColor  = lipgloss.Color("#565F89")
 
 	titleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("63")).
+			Foreground(violetColor).
 			Bold(true)
 
 	countStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
+			Foreground(mutedColor)
 
-	inputBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.Border{
-			Top:         "-",
-			Bottom:      "-",
-			Left:        "|",
-			Right:       "|",
-			TopLeft:     "+",
-			TopRight:    "+",
-			BottomLeft:  "+",
-			BottomRight: "+",
-		}).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
+	sectionStyle = lipgloss.NewStyle().
+			Foreground(violetColor).
+			Bold(true)
 
-	previewBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.Border{
-			Top:         "-",
-			Bottom:      "-",
-			Left:        "|",
-			Right:       "|",
-			TopLeft:     "+",
-			TopRight:    "+",
-			BottomLeft:  "+",
-			BottomRight: "+",
-		}).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
+	ruleStyle = lipgloss.NewStyle().
+			Foreground(mutedColor)
 
-	rowStyle = lipgloss.NewStyle().
-			Padding(0, 1)
+	rowLabelStyle = lipgloss.NewStyle().
+			Foreground(textColor)
 
-	selectedRowStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("230")).
-				Background(lipgloss.Color("63")).
-				Bold(true).
-				Padding(0, 1)
+	selectedLabelStyle = rowLabelStyle.Bold(true)
+
+	selectionRailStyle = lipgloss.NewStyle().
+				Foreground(skyColor).
+				Bold(true)
 
 	pathStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
+			Foreground(mutedColor)
 
 	emptyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("203")).
-			Padding(1, 1)
+			Foreground(amberColor)
 
 	moreStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244")).
-			Padding(0, 1)
+			Foreground(mutedColor)
 
 	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
+			Foreground(mutedColor)
 )
 
 var renderPreview = previewpkg.Render
@@ -172,10 +147,10 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	input.Prompt = prompt
 	input.Placeholder = placeholder
 	styles := input.Styles()
-	styles.Focused.Prompt = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Bold(true)
-	styles.Focused.Text = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
-	styles.Focused.Placeholder = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-	styles.Cursor.Color = lipgloss.Color("63")
+	styles.Focused.Prompt = lipgloss.NewStyle().Foreground(skyColor).Bold(true)
+	styles.Focused.Text = lipgloss.NewStyle().Foreground(textColor)
+	styles.Focused.Placeholder = lipgloss.NewStyle().Foreground(mutedColor)
+	styles.Cursor.Color = skyColor
 	input.SetStyles(styles)
 	input.Focus()
 	m := teaModel{list: list, input: input, defaultPreviewCommand: opts.DefaultPreviewCommand, showIcons: opts.ShowIcons}
@@ -246,69 +221,92 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m teaModel) View() tea.View {
 	width := m.contentWidth()
 	listWidth, previewWidth := previewLayout(width)
-	previewLines := m.previewBodyLines()
-	listRows := previewLines
-	if previewWidth == 0 {
-		previewLines = compactPreviewBody
-		listRows = defaultVisibleRows
-	}
-	var b strings.Builder
-	b.WriteString(m.header(width))
-	b.WriteString("\n\n")
+	lines := []string{"", m.header(width), horizontalRule(width)}
 	input := m.input
-	input.SetWidth(maxInt(8, width-lipgloss.Width(input.Prompt)-4))
-	b.WriteString(inputBoxStyle.Width(width).Render(input.View()))
-	b.WriteString("\n\n")
-	list := m.listView(listWidth, listRows)
+	input.SetWidth(maxInt(8, width-lipgloss.Width(input.Prompt)-1))
+	lines = append(lines, fitLine(input.View(), width), horizontalRule(width))
+
 	if previewWidth > 0 {
-		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, list, "  ", m.previewView(previewWidth, previewLines)))
+		previewLines := m.previewBodyLines()
+		list := sectionStyle.Render("WORKSPACES") + "\n" + m.listView(listWidth, previewLines)
+		preview := m.previewView(previewWidth, previewLines)
+		lines = append(lines, strings.Split(joinPanels(list, preview, listWidth, previewWidth), "\n")...)
 	} else {
-		b.WriteString(list)
-		b.WriteString("\n")
-		b.WriteString(m.previewView(width, previewLines))
+		listRows, previewLines := m.stackedBodyLines()
+		lines = append(lines, sectionStyle.Render("WORKSPACES"))
+		lines = append(lines, strings.Split(strings.TrimSuffix(m.listView(listWidth, listRows), "\n"), "\n")...)
+		lines = append(lines, strings.Split(m.previewView(width, previewLines), "\n")...)
 	}
-	b.WriteString("\n")
-	b.WriteString(helpStyle.Width(width).Render("Enter select  Up/Down move  Ctrl+U clear  Esc cancel"))
-	view := tea.NewView(strings.Repeat("\n", pickerTopPadding) + panelStyle.Width(width+6).Render(b.String()))
+	lines = append(lines,
+		horizontalRule(width),
+		helpStyle.Render("enter select   ↑/↓ move   ctrl+u clear   esc close"),
+		"",
+	)
+	framed := make([]string, len(lines))
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		framed[i] = strings.Repeat(" ", horizontalPadding) + fitLine(line, width) + strings.Repeat(" ", horizontalPadding)
+	}
+	view := tea.NewView(strings.Join(framed, "\n"))
 	view.AltScreen = true
 	return view
 }
 
 func (m teaModel) listView(width, visibleRows int) string {
-	var b strings.Builder
+	if visibleRows < 1 {
+		return ""
+	}
+	lines := make([]string, 0, visibleRows)
 	if len(m.list.Filtered) == 0 {
-		b.WriteString(emptyStyle.Width(width).Render("No matching workspaces"))
+		lines = append(lines, emptyStyle.Render("No matching workspaces"))
 	} else {
-		start := 0
-		if m.list.Selected >= visibleRows {
-			start = m.list.Selected - visibleRows + 1
-		}
-		end := start + visibleRows
-		if end > len(m.list.Filtered) {
-			end = len(m.list.Filtered)
-		}
-		if start > 0 {
-			b.WriteString(moreStyle.Render("...") + "\n")
+		start, end, moreAbove, moreBelow := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)
+		if moreAbove {
+			lines = append(lines, moreStyle.Render(fmt.Sprintf("↑ %d more", start)))
 		}
 		for i := start; i < end; i++ {
-			b.WriteString(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons))
+			lines = append(lines, strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons), "\n"))
 		}
-		if end < len(m.list.Filtered) {
-			b.WriteString(moreStyle.Render("...") + "\n")
+		if moreBelow {
+			lines = append(lines, moreStyle.Render(fmt.Sprintf("↓ %d more", len(m.list.Filtered)-end)))
 		}
 	}
-	return b.String()
+	for len(lines) < visibleRows {
+		lines = append(lines, "")
+	}
+	if len(lines) > visibleRows {
+		lines = lines[:visibleRows]
+	}
+	for i := range lines {
+		lines[i] = fitLine(lines[i], width)
+	}
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func (m teaModel) previewBodyLines() int {
 	if m.height == 0 {
 		return defaultVisibleRows
 	}
-	lines := m.height - pickerChromeRows
+	lines := m.height - pickerChromeRows - previewTitleRows
 	if lines < compactPreviewBody {
 		return compactPreviewBody
 	}
 	return lines
+}
+
+func (m teaModel) stackedBodyLines() (int, int) {
+	if m.height == 0 {
+		return defaultVisibleRows, compactPreviewBody
+	}
+	const stackedChromeRows = 10
+	available := m.height - stackedChromeRows
+	if available < 2 {
+		return 1, 1
+	}
+	previewLines := min(compactPreviewBody, maxInt(1, available/3))
+	return maxInt(1, available-previewLines), previewLines
 }
 
 func (m teaModel) contentWidth() int {
@@ -316,24 +314,21 @@ func (m teaModel) contentWidth() int {
 	if width == 0 {
 		width = defaultWidth
 	}
-	width -= 6
-	if width < minContentWidth {
-		width = minContentWidth
-	}
-	if width > maxContentWidth {
-		width = maxContentWidth
-	}
-	return width
+	return maxInt(1, width-horizontalPadding*2)
 }
 
 func (m teaModel) header(width int) string {
-	title := titleStyle.Render("herdr workspace picker")
-	count := countStyle.Render(fmt.Sprintf("%d/%d matches", len(m.list.Filtered), len(m.list.All)))
+	title := titleStyle.Render("herdr / sesh")
+	countText := fmt.Sprintf("%d workspaces", len(m.list.All))
+	if m.list.Query != "" {
+		countText = fmt.Sprintf("%d/%d workspaces", len(m.list.Filtered), len(m.list.All))
+	}
+	count := countStyle.Render(countText)
 	gap := width - lipgloss.Width(title) - lipgloss.Width(count)
 	if gap < 1 {
 		gap = 1
 	}
-	return title + strings.Repeat(" ", gap) + count
+	return fitLine(title+strings.Repeat(" ", gap)+count, width)
 }
 
 func (m teaModel) previewView(width, maxLines int) string {
@@ -341,14 +336,31 @@ func (m teaModel) previewView(width, maxLines int) string {
 	if text == "" {
 		text = "No preview available"
 	}
-	bodyWidth := maxInt(8, width-4)
-	text = fixedVisualLines(text, bodyWidth, maxLines)
-	height := maxLines + previewTitleRows
-	return previewBoxStyle.
-		Width(width).
-		Height(height).
-		MaxWidth(width).
-		Render(titleStyle.Render("preview") + "\n" + text)
+	text = fixedVisualLines(text, width, maxLines)
+	lines := append([]string{m.previewTitle()}, strings.Split(text, "\n")...)
+	for i := range lines {
+		lines[i] = fitLine(lines[i], width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m teaModel) previewTitle() string {
+	title := sectionStyle.Render("PREVIEW")
+	current, ok := m.list.Current()
+	if !ok {
+		return title
+	}
+	label := current.Name
+	if label == "" {
+		label = compactHome(current.Path)
+	}
+	if label != "" {
+		title += countStyle.Render(" · " + label)
+	}
+	if _, status := agentStatusIndicator(current.AgentStatus); status != "" {
+		title += agentStatusStyle(current.AgentStatus).Render(" · " + status)
+	}
+	return title
 }
 
 func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
@@ -382,7 +394,7 @@ func previewCommand(key string, s sessionmodel.Session, defaultPreviewCommand st
 }
 
 func previewLayout(width int) (int, int) {
-	if width < previewSplitWidth {
+	if width < previewSplitWidth-horizontalPadding*2 {
 		return width, 0
 	}
 	previewWidth := width / 2
@@ -392,7 +404,7 @@ func previewLayout(width int) (int, int) {
 	if previewWidth < minPreviewWidth {
 		previewWidth = minPreviewWidth
 	}
-	return width - previewWidth - 2, previewWidth
+	return width - previewWidth - 3, previewWidth
 }
 
 func fixedVisualLines(text string, width, count int) string {
@@ -414,32 +426,44 @@ func fixedVisualLines(text string, width, count int) string {
 }
 
 func row(s sessionmodel.Session, selected bool, width int, showIcons bool) string {
-	cursor := " "
+	rail := "  "
 	if selected {
-		cursor = ">"
+		rail = selectionRailStyle.Render("┃ ")
 	}
 	label := s.Name
 	if label == "" {
-		label = s.Path
+		label = compactHome(s.Path)
 	}
-	source := s.Source
-	badgeText := sourceBadge(source, showIcons)
-	badge := sourceBadgeStyle(source).Render(badgeText)
-	path := ""
-	showPath := s.Path != "" && s.Path != label
+	statusGlyph, _ := agentStatusIndicator(s.AgentStatus)
+	status := "  "
+	if statusGlyph != "" {
+		status = agentStatusStyle(s.AgentStatus).Render(statusGlyph + " ")
+	}
+	badge := sourceBadgeStyle(s.Source).Render(fitPlain(sourceBadge(s.Source, showIcons), rowSourceWidth))
+	remaining := maxInt(1, width-lipgloss.Width(rail)-2-rowSourceWidth)
+	path := compactHome(s.Path)
+	showPath := width >= rowPathMinWidth && path != "" && path != label
+	nameWidth := remaining
+	pathWidth := 0
 	if showPath {
-		path = pathStyle.Inline(true).MaxWidth(maxInt(8, width/2)).Render(s.Path)
-	}
-	line := rowText(cursor, badge, label, path)
-	if selected {
-		path = ""
-		if showPath {
-			path = lipgloss.NewStyle().Inline(true).MaxWidth(maxInt(8, width/2)).Render(s.Path)
+		available := maxInt(1, remaining-2)
+		nameWidth = min(rowNameMaxWidth, maxInt(rowNameMinWidth, available*2/5))
+		if nameWidth >= available {
+			showPath = false
+			nameWidth = remaining
+		} else {
+			pathWidth = available - nameWidth
 		}
-		line = rowText(cursor, badgeText, label, path)
-		return selectedRowStyle.Width(width).Render(line) + "\n"
 	}
-	return rowStyle.Width(width).Render(line) + "\n"
+	labelStyle := rowLabelStyle
+	if selected {
+		labelStyle = selectedLabelStyle
+	}
+	line := rail + status + badge + labelStyle.Render(fitPlain(label, nameWidth))
+	if showPath {
+		line += "  " + pathStyle.Render(fitPlain(path, pathWidth))
+	}
+	return fitLine(line, width) + "\n"
 }
 
 func sourceBadge(source string, showIcons bool) string {
@@ -464,7 +488,22 @@ func sourceBadge(source string, showIcons bool) string {
 }
 
 func sourceBadgeStyle(source string) lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(sourceBadgeColor(source))).Bold(true)
+	return lipgloss.NewStyle().Foreground(sourceBadgeTerminalColor(source)).Bold(true)
+}
+
+func sourceBadgeTerminalColor(source string) color.Color {
+	color := mutedColor
+	switch source {
+	case "herdr":
+		color = skyColor
+	case "config":
+		color = amberColor
+	case "zoxide":
+		color = greenColor
+	case "dir":
+		color = violetColor
+	}
+	return color
 }
 
 func sourceBadgeColor(source string) string {
@@ -482,11 +521,120 @@ func sourceBadgeColor(source string) string {
 	return color
 }
 
-func rowText(cursor, badge, label, path string) string {
-	if path == "" {
-		return fmt.Sprintf("%s %s %s", cursor, badge, label)
+func agentStatusIndicator(status string) (string, string) {
+	switch status {
+	case "working":
+		return "●", "working"
+	case "blocked":
+		return "◆", "blocked"
+	case "idle":
+		return "○", "idle"
+	case "done":
+		return "✓", "done"
+	default:
+		return "", ""
 	}
-	return fmt.Sprintf("%s %s %s  %s", cursor, badge, label, path)
+}
+
+func agentStatusStyle(status string) lipgloss.Style {
+	color := mutedColor
+	switch status {
+	case "working":
+		color = greenColor
+	case "blocked":
+		color = amberColor
+	case "done":
+		color = violetColor
+	}
+	return lipgloss.NewStyle().Foreground(color).Bold(true)
+}
+
+func compactHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	cleanPath := filepath.Clean(path)
+	cleanHome := filepath.Clean(home)
+	if cleanPath == cleanHome {
+		return "~"
+	}
+	prefix := cleanHome + string(filepath.Separator)
+	if strings.HasPrefix(cleanPath, prefix) {
+		return "~" + cleanPath[len(cleanHome):]
+	}
+	return path
+}
+
+func horizontalRule(width int) string {
+	return ruleStyle.Render(strings.Repeat("─", maxInt(1, width)))
+}
+
+func fitLine(line string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	line = ansi.Truncate(line, width, "…")
+	return line + strings.Repeat(" ", maxInt(0, width-lipgloss.Width(line)))
+}
+
+func fitPlain(text string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	text = ansi.Truncate(text, width, "…")
+	return text + strings.Repeat(" ", maxInt(0, width-lipgloss.Width(text)))
+}
+
+func joinPanels(left, right string, leftWidth, rightWidth int) string {
+	leftLines := strings.Split(strings.TrimSuffix(left, "\n"), "\n")
+	rightLines := strings.Split(strings.TrimSuffix(right, "\n"), "\n")
+	height := max(len(leftLines), len(rightLines))
+	lines := make([]string, height)
+	divider := ruleStyle.Render("│")
+	for i := range height {
+		var leftLine, rightLine string
+		if i < len(leftLines) {
+			leftLine = leftLines[i]
+		}
+		if i < len(rightLines) {
+			rightLine = rightLines[i]
+		}
+		lines[i] = fitLine(leftLine, leftWidth) + " " + divider + " " + fitLine(rightLine, rightWidth)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func listWindow(total, selected, height int) (start, end int, moreAbove, moreBelow bool) {
+	if total <= 0 || height <= 0 {
+		return 0, 0, false, false
+	}
+	if total <= height {
+		return 0, total, false, false
+	}
+	if height == 1 {
+		selected = min(maxInt(0, selected), total-1)
+		return selected, selected + 1, false, false
+	}
+	if height == 2 {
+		selected = min(maxInt(0, selected), total-1)
+		if selected < total-1 {
+			return selected, selected + 1, false, true
+		}
+		return selected, selected + 1, true, false
+	}
+	if selected < height-1 {
+		return 0, height - 1, false, true
+	}
+	if selected >= total-(height-1) {
+		return total - (height - 1), total, true, false
+	}
+	itemRows := height - 2
+	start = selected - itemRows + 1
+	return start, start + itemRows, true, true
 }
 
 func maxInt(a, b int) int {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -61,7 +61,7 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	t.Cleanup(func() { renderPreview = oldPreview })
 
 	m := newTeaModel([]model.Session{
-		{Source: "herdr", Name: "workspace-api", Path: "/tmp/workspace-api"},
+		{Source: "herdr", Name: "workspace-api", Path: "/tmp/workspace-api", AgentStatus: "working"},
 		{Source: "zoxide", Name: "tools", Path: "/tmp/tools"},
 		{Source: "config", Name: "api", Path: "/tmp/api"},
 	}, Options{
@@ -69,15 +69,21 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 		Placeholder: "Search sessions",
 		ShowIcons:   true,
 	})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 30})
 	m = updated.(teaModel)
 	updated, _ = m.Update(previewCommand(m.previewKey, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)())
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
-	for _, want := range []string{"herdr workspace picker", "3/3 matches", "Find> ", "Search sessions", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview", "preview content", "Enter select"} {
+	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "WORKSPACES", "PREVIEW · workspace-api · working", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}
+	}
+	if strings.Contains(view, "+-") || strings.Contains(view, "| ") {
+		t.Fatalf("view still contains ASCII box chrome:\n%s", view)
+	}
+	if got, want := maxLineWidth(view), 160; got != want {
+		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
 	}
 }
 
@@ -99,16 +105,65 @@ func TestRowUsesSourceCategoryColors(t *testing.T) {
 		source string
 		color  string
 	}{
-		{source: "herdr", color: "38;5;81"},
-		{source: "config", color: "38;5;214"},
-		{source: "zoxide", color: "38;5;114"},
-		{source: "dir", color: "38;5;176"},
+		{source: "herdr", color: "38;2;125;207;255"},
+		{source: "config", color: "38;2;224;175;104"},
+		{source: "zoxide", color: "38;2;158;206;106"},
+		{source: "dir", color: "38;2;187;154;247"},
 	}
 	for _, tt := range tests {
 		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80, true)
 		if !strings.Contains(got, tt.color) {
 			t.Fatalf("row for source %q missing color %s:\n%q", tt.source, tt.color, got)
 		}
+	}
+}
+
+func TestRowUsesAgentStatusIndicators(t *testing.T) {
+	tests := []struct {
+		status string
+		glyph  string
+		color  string
+	}{
+		{status: "working", glyph: "●", color: "38;2;158;206;106"},
+		{status: "blocked", glyph: "◆", color: "38;2;224;175;104"},
+		{status: "idle", glyph: "○", color: "38;2;86;95;137"},
+		{status: "done", glyph: "✓", color: "38;2;187;154;247"},
+	}
+	for _, tt := range tests {
+		got := row(model.Session{Source: "herdr", Name: "api", AgentStatus: tt.status}, false, 80, true)
+		if !strings.Contains(ansi.Strip(got), tt.glyph) || !strings.Contains(got, tt.color) {
+			t.Fatalf("row for status %q missing glyph/color:\n%q", tt.status, got)
+		}
+	}
+	for _, status := range []string{"", "unknown", "future"} {
+		got := ansi.Strip(row(model.Session{Source: "herdr", Name: "api", AgentStatus: status}, false, 80, true))
+		if strings.ContainsAny(got, "●◆○✓") {
+			t.Fatalf("row for status %q unexpectedly contains indicator: %q", status, got)
+		}
+	}
+}
+
+func TestRowCompactsHomeAndNeverWraps(t *testing.T) {
+	t.Setenv("HOME", "/Users/picker")
+	s := model.Session{
+		Source:      "herdr",
+		Name:        "workspace-with-a-name-that-is-longer-than-the-column",
+		Path:        "/Users/picker/Code/Go/workspace-with-a-path-that-is-longer-than-the-row",
+		AgentStatus: "working",
+	}
+	wide := ansi.Strip(strings.TrimSuffix(row(s, true, 76, true), "\n"))
+	if strings.Contains(wide, "\n") || lipgloss.Width(wide) != 76 {
+		t.Fatalf("wide row width=%d or wrapped:\n%q", lipgloss.Width(wide), wide)
+	}
+	if !strings.Contains(wide, "~/Code/Go/") || strings.Contains(wide, "/Users/picker") {
+		t.Fatalf("wide row did not compact home path: %q", wide)
+	}
+	narrow := ansi.Strip(strings.TrimSuffix(row(s, false, 48, true), "\n"))
+	if strings.Contains(narrow, "~/") || strings.Contains(narrow, "/Users/picker") {
+		t.Fatalf("narrow row should omit its path: %q", narrow)
+	}
+	if strings.Contains(narrow, "\n") || lipgloss.Width(narrow) != 48 {
+		t.Fatalf("narrow row width=%d or wrapped: %q", lipgloss.Width(narrow), narrow)
 	}
 }
 
@@ -143,14 +198,14 @@ func TestPreviewViewUsesConstantHeight(t *testing.T) {
 	if lipgloss.Height(short) != lipgloss.Height(long) {
 		t.Fatalf("preview heights changed: short=%d long=%d\nshort:\n%s\nlong:\n%s", lipgloss.Height(short), lipgloss.Height(long), short, long)
 	}
-	if got, want := lipgloss.Height(short), 4+previewTitleRows+previewBorderRows; got != want {
+	if got, want := lipgloss.Height(short), 4+previewTitleRows; got != want {
 		t.Fatalf("preview height=%d, want %d\n%s", got, want, short)
 	}
 	if !strings.Contains(long, "...") {
 		t.Fatalf("long preview missing truncation marker:\n%s", long)
 	}
-	if last := ansi.Strip(strings.Split(long, "\n")[lipgloss.Height(long)-1]); !strings.HasPrefix(last, "+") || !strings.HasSuffix(last, "+") {
-		t.Fatalf("preview bottom border was clipped:\n%s", long)
+	if strings.Contains(ansi.Strip(long), "+-") {
+		t.Fatalf("preview still contains box chrome:\n%s", long)
 	}
 }
 
@@ -173,27 +228,104 @@ func TestTeaModelUsesAvailableWindowHeight(t *testing.T) {
 	if lines[0] != "" {
 		t.Fatalf("expected top padding row, got %q\n%s", lines[0], view)
 	}
-	if topBorder := lines[1]; !strings.HasPrefix(topBorder, "+") || !strings.HasSuffix(topBorder, "+") {
-		t.Fatalf("expected parent top border after padding, got %q\n%s", topBorder, view)
+	if header := lines[1]; !strings.Contains(header, "herdr / sesh") {
+		t.Fatalf("expected navigator header after padding, got %q\n%s", header, view)
 	}
-	if padding := lines[len(lines)-2]; strings.Contains(padding, "+") || strings.Contains(padding, "preview") || strings.Contains(padding, "Enter select") {
-		t.Fatalf("expected one padding line before parent bottom border, got %q\n%s", padding, view)
+	if got, want := maxLineWidth(view), 120; got != want {
+		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
+	}
+	if last := lines[len(lines)-1]; strings.TrimSpace(last) != "" {
+		t.Fatalf("expected bottom breathing room, got %q\n%s", last, view)
 	}
 }
 
-func TestSelectedRowHighlightDoesNotResetBeforeContent(t *testing.T) {
-	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh"}, true, 80, true)
-	if !strings.Contains(got, "48;5;63") {
-		t.Fatalf("selected row missing highlight background:\n%q", got)
+func TestSelectedRowUsesRailAndPreservesSourceColor(t *testing.T) {
+	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh", AgentStatus: "working"}, true, 80, true)
+	plain := ansi.Strip(got)
+	if !strings.Contains(plain, "┃") {
+		t.Fatalf("selected row missing navigation rail:\n%q", got)
 	}
-	for _, want := range []string{herdrSourceIcon + " herdr", "herdr-plugin-sesh", "/tmp/herdr-plugin-sesh"} {
-		i := strings.Index(got, want)
-		if i == -1 {
+	for _, want := range []string{"38;2;125;207;255", "38;2;158;206;106", herdrSourceIcon + " herdr", "herdr-plugin-sesh", "/tmp/herdr-plugin-sesh"} {
+		if !strings.Contains(got, want) {
 			t.Fatalf("selected row missing %q:\n%q", want, got)
 		}
-		prefix := got[:i]
-		if bg, reset := strings.LastIndex(prefix, "48;5;63"), strings.LastIndex(prefix, "\x1b[0m"); bg == -1 || bg < reset {
-			t.Fatalf("selected row highlight inactive before %q:\n%q", want, got)
+	}
+	if strings.Contains(got, "48;2;") || strings.Contains(got, "48;5;") {
+		t.Fatalf("selected row should not use a background fill:\n%q", got)
+	}
+}
+
+func TestTeaModelStacksPreviewAtNarrowWidth(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "herdr", Name: "api", Path: "/tmp/api", AgentStatus: "blocked"}}, Options{})
+	m.preview = "preview content"
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 70, Height: 28})
+	m = updated.(teaModel)
+	view := ansi.Strip(m.View().Content)
+	if got, want := lipgloss.Height(view), 28; got != want {
+		t.Fatalf("view height=%d, want %d:\n%s", got, want, view)
+	}
+	if !strings.Contains(view, "WORKSPACES") || !strings.Contains(view, "PREVIEW · api · blocked") {
+		t.Fatalf("narrow view missing stacked sections:\n%s", view)
+	}
+	if strings.Contains(view, "│") {
+		t.Fatalf("narrow view should not contain a vertical pane divider:\n%s", view)
+	}
+}
+
+func TestTeaModelSplitsPreviewAtTerminalThreshold(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: previewSplitWidth, Height: 28})
+	m = updated.(teaModel)
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "│") {
+		t.Fatalf("preview should split at width %d:\n%s", previewSplitWidth, view)
+	}
+}
+
+func TestTeaModelHeaderShowsFilteredCountWhenAllRowsMatch(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	m.list.Filter("workspace")
+	if got := ansi.Strip(m.header(80)); !strings.Contains(got, "2/2 workspaces") {
+		t.Fatalf("filtered header=%q, want total-aware count", got)
+	}
+}
+
+func TestTeaModelSearchRailDoesNotTruncateAtWindowEdge(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 28})
+	m = updated.(teaModel)
+	for _, line := range strings.Split(ansi.Strip(m.View().Content), "\n") {
+		if strings.Contains(line, defaultPrompt) && strings.Contains(line, "…") {
+			t.Fatalf("search rail was truncated at the window edge: %q", line)
 		}
 	}
+}
+
+func TestListViewUsesDirectionalOverflowMarkers(t *testing.T) {
+	items := make([]model.Session, 20)
+	for i := range items {
+		items[i] = model.Session{Name: "workspace"}
+	}
+	m := newTeaModel(items, Options{})
+	m.list.Selected = 10
+	view := ansi.Strip(m.listView(60, 6))
+	if !strings.Contains(view, "↑ 7 more") || !strings.Contains(view, "↓ 9 more") || strings.Contains(view, "...") {
+		t.Fatalf("list view missing directional overflow markers:\n%s", view)
+	}
+}
+
+func TestListViewKeepsSelectionVisibleWithTwoRows(t *testing.T) {
+	items := []model.Session{{Name: "workspace-0"}, {Name: "workspace-1"}, {Name: "workspace-2"}, {Name: "workspace-3"}, {Name: "workspace-4"}}
+	m := newTeaModel(items, Options{})
+	m.list.Selected = 2
+	if view := ansi.Strip(m.listView(60, 2)); !strings.Contains(view, "workspace-2") {
+		t.Fatalf("two-row list hid the selected workspace:\n%s", view)
+	}
+}
+
+func maxLineWidth(s string) int {
+	maxWidth := 0
+	for _, line := range strings.Split(s, "\n") {
+		maxWidth = max(maxWidth, lipgloss.Width(line))
+	}
+	return maxWidth
 }

--- a/internal/sources/herdr_workspaces.go
+++ b/internal/sources/herdr_workspaces.go
@@ -25,7 +25,7 @@ func (s HerdrWorkspaces) List(ctx context.Context) (model.Sessions, error) {
 	}
 	for _, w := range ws {
 		path := workspacePath(w, panes)
-		out.Add(model.Session{Source: "herdr", Name: w.Label, Path: path, WorkspaceID: w.ID})
+		out.Add(model.Session{Source: "herdr", Name: w.Label, Path: path, WorkspaceID: w.ID, AgentStatus: w.AgentStatus})
 	}
 	return out, nil
 }

--- a/internal/sources/herdr_workspaces_test.go
+++ b/internal/sources/herdr_workspaces_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHerdrWorkspacesUsesPaneCWDWhenWorkspaceListOmitsPath(t *testing.T) {
 	src := HerdrWorkspaces{Client: &herdr.FakeClient{
-		Workspaces: []herdr.Workspace{{ID: "w1", Label: "api", ActiveTabID: "w1:t2"}},
+		Workspaces: []herdr.Workspace{{ID: "w1", Label: "api", ActiveTabID: "w1:t2", AgentStatus: "working"}},
 		Panes: []herdr.Pane{
 			{ID: "p1", WorkspaceID: "w1", TabID: "w1:t1", ForegroundCWD: "/tmp/wrong"},
 			{ID: "p2", WorkspaceID: "w1", TabID: "w1:t2", CWD: "/tmp/api"},
@@ -20,7 +20,7 @@ func TestHerdrWorkspacesUsesPaneCWDWhenWorkspaceListOmitsPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessions := got.Ordered()
-	if len(sessions) != 1 || sessions[0].Path != "/tmp/api" {
+	if len(sessions) != 1 || sessions[0].Path != "/tmp/api" || sessions[0].AgentStatus != "working" {
 		t.Fatalf("sessions=%#v", sessions)
 	}
 }


### PR DESCRIPTION
## Summary

- replace the native picker's nested panels with a full-width, responsive Workspace Navigator layout
- decode Herdr workspace agent status and render working, blocked, idle, and done indicators without changing JSON or identity contracts
- keep rows single-line with compacted paths, directional overflow markers, responsive preview placement, and stable terminal dimensions
- address review edge cases for the 92-column split threshold, filtered counts when every row matches, and two-row viewport selection visibility
- document the native picker agent-status glyphs

## Why

The existing picker underused Herdr's overlay and did not show whether a workspace had an active or completed agent. This makes the picker easier to scan while reusing Herdr's existing workspace response and preserving the fzf and JSON interfaces.

## Validation

- `go test ./internal/herdr ./internal/model ./internal/sources ./internal/picker`
- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check` (119 tests)
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `./bin/herdr-sesh picker --json --config testdata/sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the picker with a full-width, responsive Workspace Navigator and surfaces Herdr agent status per workspace. Improves scan-ability while keeping JSON and fzf interfaces unchanged.

- **New Features**
  - Full-width navigator with responsive preview: splits at ~92 cols, stacks when narrow, steady heights.
  - Decodes `agent_status` from Herdr and shows indicators: green ● working, amber ◆ blocked, muted ○ idle, violet ✓ done; hidden when unknown.
  - Single-line rows with compact home paths, directional overflow counts (↑/↓), and a selection rail; preserves source icons/colors.
  - Preview title includes the selected label and agent status; docs updated with glyph legend.

- **Bug Fixes**
  - Correct split behavior at the threshold; removes ASCII box chrome; no wrapping or background bleed.
  - Header shows filtered counts even when all rows match; keeps the selected row visible with a two-row viewport.

<sup>Written for commit 222c2c3ce7a878d84e14f936624cb5501d8cb434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

