### PR TITLE
feat: highlight native picker search matches

### DIFF
--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -67,6 +67,10 @@ var (
 
 	selectedLabelStyle = rowLabelStyle.Bold(true)
 
+	matchStyle = lipgloss.NewStyle().
+			Foreground(violetColor).
+			Bold(true)
+
 	selectionRailStyle = lipgloss.NewStyle().
 				Foreground(skyColor).
 				Bold(true)
@@ -267,7 +271,7 @@ func (m teaModel) listView(width, visibleRows int) string {
 			lines = append(lines, moreStyle.Render(fmt.Sprintf("↑ %d more", start)))
 		}
 		for i := start; i < end; i++ {
-			lines = append(lines, strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons), "\n"))
+			lines = append(lines, strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons, m.list.Query), "\n"))
 		}
 		if moreBelow {
 			lines = append(lines, moreStyle.Render(fmt.Sprintf("↓ %d more", len(m.list.Filtered)-end)))
@@ -425,7 +429,7 @@ func fixedVisualLines(text string, width, count int) string {
 	return strings.Join(lines, "\n")
 }
 
-func row(s sessionmodel.Session, selected bool, width int, showIcons bool) string {
+func row(s sessionmodel.Session, selected bool, width int, showIcons bool, query string) string {
 	rail := "  "
 	if selected {
 		rail = selectionRailStyle.Render("┃ ")
@@ -459,11 +463,32 @@ func row(s sessionmodel.Session, selected bool, width int, showIcons bool) strin
 	if selected {
 		labelStyle = selectedLabelStyle
 	}
-	line := rail + status + badge + labelStyle.Render(fitPlain(label, nameWidth))
+	line := rail + status + badge + highlightMatches(label, query, nameWidth, labelStyle)
 	if showPath {
-		line += "  " + pathStyle.Render(fitPlain(path, pathWidth))
+		line += "  " + highlightMatches(path, query, pathWidth, pathStyle)
 	}
 	return fitLine(line, width) + "\n"
+}
+
+func highlightMatches(text, query string, width int, baseStyle lipgloss.Style) string {
+	text = fitPlain(text, width)
+	if query == "" {
+		return baseStyle.Render(text)
+	}
+
+	lowerText, lowerQuery := strings.ToLower(text), strings.ToLower(query)
+	var rendered strings.Builder
+	for {
+		index := strings.Index(lowerText, lowerQuery)
+		if index < 0 {
+			rendered.WriteString(baseStyle.Render(text))
+			return rendered.String()
+		}
+		rendered.WriteString(baseStyle.Render(text[:index]))
+		rendered.WriteString(matchStyle.Render(text[index : index+len(lowerQuery)]))
+		text = text[index+len(lowerQuery):]
+		lowerText = lowerText[index+len(lowerQuery):]
+	}
 }
 
 func sourceBadge(source string, showIcons bool) string {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -476,19 +476,23 @@ func highlightMatches(text, query string, width int, baseStyle lipgloss.Style) s
 		return baseStyle.Render(text)
 	}
 
-	lowerText, lowerQuery := strings.ToLower(text), strings.ToLower(query)
+	textRunes := []rune(text)
+	queryRunes := []rune(query)
 	var rendered strings.Builder
-	for {
-		index := strings.Index(lowerText, lowerQuery)
-		if index < 0 {
-			rendered.WriteString(baseStyle.Render(text))
-			return rendered.String()
+	plainStart := 0
+	for index := 0; index+len(queryRunes) <= len(textRunes); {
+		matchEnd := index + len(queryRunes)
+		if !strings.EqualFold(string(textRunes[index:matchEnd]), query) {
+			index++
+			continue
 		}
-		rendered.WriteString(baseStyle.Render(text[:index]))
-		rendered.WriteString(matchStyle.Render(text[index : index+len(lowerQuery)]))
-		text = text[index+len(lowerQuery):]
-		lowerText = lowerText[index+len(lowerQuery):]
+		rendered.WriteString(baseStyle.Render(string(textRunes[plainStart:index])))
+		rendered.WriteString(matchStyle.Render(string(textRunes[index:matchEnd])))
+		index = matchEnd
+		plainStart = matchEnd
 	}
+	rendered.WriteString(baseStyle.Render(string(textRunes[plainStart:])))
+	return rendered.String()
 }
 
 func sourceBadge(source string, showIcons bool) string {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -111,7 +111,7 @@ func TestRowUsesSourceCategoryColors(t *testing.T) {
 		{source: "dir", color: "38;2;187;154;247"},
 	}
 	for _, tt := range tests {
-		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80, true)
+		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80, true, "")
 		if !strings.Contains(got, tt.color) {
 			t.Fatalf("row for source %q missing color %s:\n%q", tt.source, tt.color, got)
 		}
@@ -130,13 +130,13 @@ func TestRowUsesAgentStatusIndicators(t *testing.T) {
 		{status: "done", glyph: "✓", color: "38;2;187;154;247"},
 	}
 	for _, tt := range tests {
-		got := row(model.Session{Source: "herdr", Name: "api", AgentStatus: tt.status}, false, 80, true)
+		got := row(model.Session{Source: "herdr", Name: "api", AgentStatus: tt.status}, false, 80, true, "")
 		if !strings.Contains(ansi.Strip(got), tt.glyph) || !strings.Contains(got, tt.color) {
 			t.Fatalf("row for status %q missing glyph/color:\n%q", tt.status, got)
 		}
 	}
 	for _, status := range []string{"", "unknown", "future"} {
-		got := ansi.Strip(row(model.Session{Source: "herdr", Name: "api", AgentStatus: status}, false, 80, true))
+		got := ansi.Strip(row(model.Session{Source: "herdr", Name: "api", AgentStatus: status}, false, 80, true, ""))
 		if strings.ContainsAny(got, "●◆○✓") {
 			t.Fatalf("row for status %q unexpectedly contains indicator: %q", status, got)
 		}
@@ -151,14 +151,14 @@ func TestRowCompactsHomeAndNeverWraps(t *testing.T) {
 		Path:        "/Users/picker/Code/Go/workspace-with-a-path-that-is-longer-than-the-row",
 		AgentStatus: "working",
 	}
-	wide := ansi.Strip(strings.TrimSuffix(row(s, true, 76, true), "\n"))
+	wide := ansi.Strip(strings.TrimSuffix(row(s, true, 76, true, ""), "\n"))
 	if strings.Contains(wide, "\n") || lipgloss.Width(wide) != 76 {
 		t.Fatalf("wide row width=%d or wrapped:\n%q", lipgloss.Width(wide), wide)
 	}
 	if !strings.Contains(wide, "~/Code/Go/") || strings.Contains(wide, "/Users/picker") {
 		t.Fatalf("wide row did not compact home path: %q", wide)
 	}
-	narrow := ansi.Strip(strings.TrimSuffix(row(s, false, 48, true), "\n"))
+	narrow := ansi.Strip(strings.TrimSuffix(row(s, false, 48, true, ""), "\n"))
 	if strings.Contains(narrow, "~/") || strings.Contains(narrow, "/Users/picker") {
 		t.Fatalf("narrow row should omit its path: %q", narrow)
 	}
@@ -240,7 +240,7 @@ func TestTeaModelUsesAvailableWindowHeight(t *testing.T) {
 }
 
 func TestSelectedRowUsesRailAndPreservesSourceColor(t *testing.T) {
-	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh", AgentStatus: "working"}, true, 80, true)
+	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh", AgentStatus: "working"}, true, 80, true, "")
 	plain := ansi.Strip(got)
 	if !strings.Contains(plain, "┃") {
 		t.Fatalf("selected row missing navigation rail:\n%q", got)
@@ -252,6 +252,17 @@ func TestSelectedRowUsesRailAndPreservesSourceColor(t *testing.T) {
 	}
 	if strings.Contains(got, "48;2;") || strings.Contains(got, "48;5;") {
 		t.Fatalf("selected row should not use a background fill:\n%q", got)
+	}
+}
+
+func TestListViewHighlightsCaseInsensitiveQueryMatches(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "workspace-API", Path: "/tmp/workspace-API"}}, Options{})
+	m.list.Filter("api")
+
+	got := m.listView(80, 1)
+	want := lipgloss.NewStyle().Foreground(violetColor).Bold(true).Render("API")
+	if matches := strings.Count(got, want); matches != 2 {
+		t.Fatalf("highlighted matches=%d, want 2:\n%q", matches, got)
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"charm.land/bubbles/v2/cursor"
 	tea "charm.land/bubbletea/v2"
@@ -261,6 +262,20 @@ func TestListViewHighlightsCaseInsensitiveQueryMatches(t *testing.T) {
 
 	got := m.listView(80, 1)
 	want := lipgloss.NewStyle().Foreground(violetColor).Bold(true).Render("API")
+	if matches := strings.Count(got, want); matches != 2 {
+		t.Fatalf("highlighted matches=%d, want 2:\n%q", matches, got)
+	}
+}
+
+func TestListViewPreservesUnicodeWhenHighlightingFoldedMatch(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "workspace-Ⱥ", Path: "/tmp/workspace-Ⱥ"}}, Options{})
+	m.list.Filter("ⱥ")
+
+	got := m.listView(80, 1)
+	want := matchStyle.Render("Ⱥ")
+	if !utf8.ValidString(got) {
+		t.Fatalf("highlighted row is invalid UTF-8: %q", got)
+	}
 	if matches := strings.Count(got, want); matches != 2 {
 		t.Fatalf("highlighted matches=%d, want 2:\n%q", matches, got)
 	}


### PR DESCRIPTION
## Summary

- thread the native picker's active filter query into row rendering
- highlight every case-insensitive exact match in workspace names and visible paths with bold violet text
- add regression coverage for repeated name and path matches

## Why

The native picker filtered the workspace list but discarded the query before rendering each row, so users had no visual indication of why a result matched. This makes filtered results easier to scan without changing filter semantics or the selected-row design.

## Validation

- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlights search matches in the native picker so users can see why items matched. Matches in names and visible paths are bold violet, with no change to filtering or selection behavior.

- **New Features**
  - Pass the active filter query into row rendering.
  - Highlight all case-insensitive exact matches in workspace names and visible paths.
  - Add tests for multiple matches and case-insensitive highlighting.

<sup>Written for commit 0d89cb7df4fb7eb1ca109ed12d6dfb5659c73d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

