### PR TITLE
feat: refresh agent statuses in native picker

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -197,6 +197,18 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf") {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
+		client := herdr.NewCLIClient()
+		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
+			workspaces, err := client.WorkspaceList(ctx)
+			if err != nil {
+				return nil, err
+			}
+			statuses := make(map[string]string, len(workspaces))
+			for _, workspace := range workspaces {
+				statuses[workspace.ID] = workspace.AgentStatus
+			}
+			return statuses, nil
+		}
 		selected, ok, err = pickerpkg.Run(sessions, pickOpts)
 	}
 	if err != nil || !ok {

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -49,6 +49,14 @@ func (m *Model) Move(delta int) {
 	m.Selected += delta
 	m.clampSelected()
 }
+func (m *Model) UpdateAgentStatuses(statuses map[string]string) {
+	for i := range m.All {
+		if m.All[i].WorkspaceID != "" {
+			m.All[i].AgentStatus = statuses[m.All[i].WorkspaceID]
+		}
+	}
+	m.Filter(m.Query)
+}
 func (m *Model) clampSelected() {
 	if m.Selected >= len(m.Filtered) {
 		m.Selected = len(m.Filtered) - 1

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -18,7 +19,10 @@ import (
 	previewpkg "github.com/fullerzz/herdr-plugin-sesh/internal/preview"
 )
 
-const defaultVisibleRows = 12
+const (
+	defaultVisibleRows    = 12
+	statusRefreshInterval = time.Second
+)
 
 const (
 	defaultPrompt      = "Sesh> "
@@ -98,6 +102,7 @@ type Options struct {
 	SeparatorAware        bool
 	DefaultPreviewCommand string
 	FZFCommand            string
+	RefreshAgentStatuses  func() (map[string]string, error)
 }
 
 func Run(items []sessionmodel.Session, opts Options) (sessionmodel.Session, bool, error) {
@@ -129,11 +134,19 @@ type teaModel struct {
 
 	defaultPreviewCommand string
 	showIcons             bool
+	refreshAgentStatuses  func() (map[string]string, error)
 }
 
 type previewMsg struct {
 	key  string
 	text string
+}
+
+type statusRefreshTickMsg struct{}
+
+type agentStatusesMsg struct {
+	statuses map[string]string
+	err      error
 }
 
 func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
@@ -157,7 +170,13 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	styles.Cursor.Color = skyColor
 	input.SetStyles(styles)
 	input.Focus()
-	m := teaModel{list: list, input: input, defaultPreviewCommand: opts.DefaultPreviewCommand, showIcons: opts.ShowIcons}
+	m := teaModel{
+		list:                  list,
+		input:                 input,
+		defaultPreviewCommand: opts.DefaultPreviewCommand,
+		showIcons:             opts.ShowIcons,
+		refreshAgentStatuses:  opts.RefreshAgentStatuses,
+	}
 	if current, ok := list.Current(); ok {
 		m.previewKey = sessionmodel.Key(current)
 		m.preview = "Loading preview..."
@@ -170,11 +189,23 @@ func (m teaModel) Init() tea.Cmd {
 	if current, ok := m.list.Current(); ok && m.previewKey != "" {
 		cmds = append(cmds, previewCommand(m.previewKey, current, m.defaultPreviewCommand))
 	}
+	if m.refreshAgentStatuses != nil {
+		cmds = append(cmds, scheduleStatusRefresh())
+	}
 	return tea.Batch(cmds...)
 }
 
 //nolint:ireturn // Bubble Tea's Model interface requires this return shape.
 func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(statusRefreshTickMsg); ok {
+		return m, refreshAgentStatusesCommand(m.refreshAgentStatuses)
+	}
+	if statuses, ok := msg.(agentStatusesMsg); ok {
+		if statuses.err == nil {
+			m.list.UpdateAgentStatuses(statuses.statuses)
+		}
+		return m, scheduleStatusRefresh()
+	}
 	if preview, ok := msg.(previewMsg); ok {
 		if preview.key == m.previewKey {
 			m.preview = preview.text
@@ -219,6 +250,17 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list.Filter(m.input.Value())
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(cmd, previewCmd)
+	}
+}
+
+func scheduleStatusRefresh() tea.Cmd {
+	return tea.Tick(statusRefreshInterval, func(time.Time) tea.Msg { return statusRefreshTickMsg{} })
+}
+
+func refreshAgentStatusesCommand(refresh func() (map[string]string, error)) tea.Cmd {
+	return func() tea.Msg {
+		statuses, err := refresh()
+		return agentStatusesMsg{statuses: statuses, err: err}
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -190,6 +190,35 @@ func TestTeaModelRefreshesPreviewWhenSelectionChanges(t *testing.T) {
 	}
 }
 
+func TestTeaModelRefreshesAgentStatuses(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1", AgentStatus: "working"},
+		{Source: "config", Name: "local", Path: "/tmp/local"},
+	}, Options{RefreshAgentStatuses: func() (map[string]string, error) {
+		return map[string]string{"w1": "blocked"}, nil
+	}})
+	m.list.Filter("api")
+
+	updated, cmd := m.Update(statusRefreshTickMsg{})
+	m = updated.(teaModel)
+	if cmd == nil {
+		t.Fatal("status refresh tick did not fetch statuses")
+	}
+
+	updated, next := m.Update(cmd())
+	m = updated.(teaModel)
+	current, ok := m.list.Current()
+	if !ok || current.AgentStatus != "blocked" {
+		t.Fatalf("current=%#v ok=%v", current, ok)
+	}
+	if m.list.Query != "api" || len(m.list.Filtered) != 1 {
+		t.Fatalf("query=%q filtered=%#v", m.list.Query, m.list.Filtered)
+	}
+	if next == nil {
+		t.Fatal("status refresh did not schedule the next tick")
+	}
+}
+
 func TestPreviewViewUsesConstantHeight(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
 	m.preview = "one line"


### PR DESCRIPTION
## Summary

- poll Herdr for current agent statuses while the native picker remains open
- update existing workspace rows by workspace ID without disturbing the active filter or selection
- retry after transient refresh failures while leaving the fzf picker unchanged

## Why

The native picker currently snapshots agent status when it opens, so transitions such as working to blocked or done are not visible until the picker is reopened. This keeps the displayed status current while the user is still choosing a workspace.

## Validation

- `just check`
- 122 race-enabled tests
- `git diff --check`