### PR TITLE
feat: add picker cursor smear animations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ zoxide history in one searchable overlay. Selecting an item focuses its
 existing workspace or creates a new one with the configured startup command and
 tabs.
 
+![Herdr Sesh picker demo](assets/picker-demo-42.gif)
+
 ## Features
 
 - Search active Herdr workspaces, Sesh-style TOML sessions, and zoxide history

--- a/assets/picker-demo-42.gif
+++ b/assets/picker-demo-42.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dc667d8c0fe0c5c5a8f12cd080585104049a7cc1e16a200c9c825360b4f53f6
+size 3997817

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,10 @@ the state directory.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 
+Moving between workspaces stretches the cyan selection rail into a short violet
+trail. Set `HERDR_SESH_REDUCE_MOTION=1` (or `true`) to keep selection
+instantaneous without drawing the trail.
+
 Open Herdr workspaces show the agent state reported by Herdr when the picker
 opens: green `●` working, amber `◆` blocked, muted `○` idle, and violet `✓`
 done. Workspaces with an unknown state have no indicator.

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,9 +44,16 @@ the state directory.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 
-Moving between workspaces stretches the cyan selection rail into a short violet
-trail. Set `HERDR_SESH_REDUCE_MOTION=1` (or `true`) to keep selection
-instantaneous without drawing the trail.
+Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
+
+| Preset | Effect |
+| --- | --- |
+| `crisp` | Fast cyan rail with a short violet line trail. This is the default. |
+| `gooey` | Slower block cursor with a longer shaded trail and eased movement. |
+| `ghost` | Soft diamond cursor with a dotted, low-contrast trail. |
+
+Set `HERDR_SESH_REDUCE_MOTION=1` (or `true`) to keep cursor movement
+instantaneous without drawing any preset's trail.
 
 Open Herdr workspaces show the agent state reported by Herdr when the picker
 opens: green `●` working, amber `◆` blocked, muted `○` idle, and violet `✓`

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -39,6 +39,8 @@ const (
 	rowSourceWidth     = 10
 	rowNameMinWidth    = 12
 	rowNameMaxWidth    = 28
+	smearMaxLength     = 3
+	smearFrameInterval = 35 * time.Millisecond
 	herdrSourceIcon    = "\U000f0cc6"
 	zoxideSourceIcon   = "\uf114"
 	configSourceIcon   = "\ue615"
@@ -78,6 +80,9 @@ var (
 	selectionRailStyle = lipgloss.NewStyle().
 				Foreground(skyColor).
 				Bold(true)
+
+	smearTrailStyle = lipgloss.NewStyle().
+			Foreground(violetColor)
 
 	pathStyle = lipgloss.NewStyle().
 			Foreground(mutedColor)
@@ -129,6 +134,10 @@ type teaModel struct {
 	choice sessionmodel.Session
 	chosen bool
 
+	smearTail    int
+	smearActive  bool
+	reduceMotion bool
+
 	preview    string
 	previewKey string
 
@@ -148,6 +157,8 @@ type agentStatusesMsg struct {
 	statuses map[string]string
 	err      error
 }
+
+type smearTickMsg struct{}
 
 func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	list := New(items)
@@ -170,12 +181,14 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	styles.Cursor.Color = skyColor
 	input.SetStyles(styles)
 	input.Focus()
+	reduceMotion := os.Getenv("HERDR_SESH_REDUCE_MOTION")
 	m := teaModel{
 		list:                  list,
 		input:                 input,
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		showIcons:             opts.ShowIcons,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
+		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 	}
 	if current, ok := list.Current(); ok {
 		m.previewKey = sessionmodel.Key(current)
@@ -206,6 +219,21 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, scheduleStatusRefresh()
 	}
+	if _, ok := msg.(smearTickMsg); ok {
+		if !m.smearActive {
+			return m, nil
+		}
+		if m.smearTail < m.list.Selected {
+			m.smearTail++
+		} else if m.smearTail > m.list.Selected {
+			m.smearTail--
+		}
+		if m.smearTail == m.list.Selected {
+			m.smearActive = false
+			return m, nil
+		}
+		return m, smearTick()
+	}
 	if preview, ok := msg.(previewMsg); ok {
 		if preview.key == m.previewKey {
 			m.preview = preview.text
@@ -221,7 +249,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if !ok {
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
-		m.list.Filter(m.input.Value())
+		m = m.filter(m.input.Value())
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(cmd, previewCmd)
 	}
@@ -235,19 +263,17 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Quit
 	case "up", "ctrl+p":
-		m.list.Move(-1)
-		return m.refreshPreview()
+		return m.moveSelection(-1)
 	case "down", "ctrl+n":
-		m.list.Move(1)
-		return m.refreshPreview()
+		return m.moveSelection(1)
 	case "ctrl+u":
 		m.input.SetValue("")
-		m.list.Filter("")
+		m = m.filter("")
 		return m.refreshPreview()
 	default:
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
-		m.list.Filter(m.input.Value())
+		m = m.filter(m.input.Value())
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(cmd, previewCmd)
 	}
@@ -313,7 +339,11 @@ func (m teaModel) listView(width, visibleRows int) string {
 			lines = append(lines, moreStyle.Render(fmt.Sprintf("↑ %d more", start)))
 		}
 		for i := start; i < end; i++ {
-			lines = append(lines, strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons, m.list.Query), "\n"))
+			line := strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons, m.list.Query), "\n")
+			if rail := m.smearRail(i); rail != "" {
+				line = smearTrailStyle.Render(rail+" ") + strings.TrimPrefix(line, "  ")
+			}
+			lines = append(lines, line)
 		}
 		if moreBelow {
 			lines = append(lines, moreStyle.Render(fmt.Sprintf("↓ %d more", len(m.list.Filtered)-end)))
@@ -423,6 +453,58 @@ func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
 	m.previewKey = key
 	m.preview = "Loading preview..."
 	return m, previewCommand(key, current, m.defaultPreviewCommand)
+}
+
+func (m teaModel) moveSelection(delta int) (teaModel, tea.Cmd) {
+	previous := m.list.Selected
+	m.list.Move(delta)
+	var tick tea.Cmd
+	if m.list.Selected != previous && !m.reduceMotion && !m.smearActive {
+		m.smearTail = previous
+		m.smearActive = true
+		tick = smearTick()
+	}
+	if m.smearActive {
+		m.smearTail = min(maxInt(m.smearTail, m.list.Selected-smearMaxLength), m.list.Selected+smearMaxLength)
+	}
+	m, previewCmd := m.refreshPreview()
+	return m, tea.Batch(previewCmd, tick)
+}
+
+func (m teaModel) filter(query string) teaModel {
+	queryChanged := query != m.list.Query
+	m.list.Filter(query)
+	if queryChanged && m.smearActive {
+		m.smearTail = m.list.Selected
+	}
+	return m
+}
+
+func (m teaModel) smearRail(index int) string {
+	selected := m.list.Selected
+	if !m.smearActive || m.smearTail == selected {
+		return ""
+	}
+	if m.smearTail < selected {
+		if index < m.smearTail || index >= selected {
+			return ""
+		}
+		if index == m.smearTail {
+			return "╷"
+		}
+		return "│"
+	}
+	if index <= selected || index > m.smearTail {
+		return ""
+	}
+	if index == m.smearTail {
+		return "╵"
+	}
+	return "│"
+}
+
+func smearTick() tea.Cmd {
+	return tea.Tick(smearFrameInterval, func(time.Time) tea.Msg { return smearTickMsg{} })
 }
 
 func previewCommand(key string, s sessionmodel.Session, defaultPreviewCommand string) tea.Cmd {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -390,16 +390,29 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		fallthrough
 	default:
-		var focusCmd tea.Cmd
-		if m.listFocused {
-			m, focusCmd = m.focusInput()
-		}
-		var cmd tea.Cmd
-		m.input, cmd = m.input.Update(msg)
-		m = m.filter(m.input.Value())
-		m, previewCmd := m.refreshPreview()
-		return m, tea.Batch(focusCmd, cmd, previewCmd)
+		return m.updateInput(msg)
 	}
+}
+
+func (m teaModel) updateInput(msg tea.Msg) (teaModel, tea.Cmd) {
+	var focusCmd tea.Cmd
+	smearing := false
+	if m.listFocused {
+		m, focusCmd = m.smearToInput()
+		smearing = m.focusSmearActive
+		if smearing {
+			m.input.Focus()
+		}
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	if smearing {
+		m.input.Blur()
+		m.focusSmearStart = m.inputCursorColumn()
+	}
+	m = m.filter(m.input.Value())
+	m, previewCmd := m.refreshPreview()
+	return m, tea.Batch(focusCmd, cmd, previewCmd)
 }
 
 func scheduleStatusRefresh() tea.Cmd {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -343,6 +343,9 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = size.Height
 		return m, nil
 	}
+	if _, ok := msg.(tea.PasteMsg); ok {
+		return m.updateInput(msg)
+	}
 	key, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		var cmd tea.Cmd

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image/color"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -139,6 +140,7 @@ type teaModel struct {
 	smearTail           int
 	smearActive         bool
 	focusSmearStart     int
+	focusSmearFrame     int
 	focusSmearStep      int
 	focusSmearSteps     int
 	focusSmearDirection int
@@ -301,13 +303,17 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if _, ok := msg.(smearTickMsg); ok {
 		if m.focusSmearActive {
-			m.focusSmearStep += m.focusSmearDirection
-			if m.focusSmearDirection < 0 && m.focusSmearStep <= 0 {
-				m.focusSmearActive = false
-				return m.focusInput()
+			m.focusSmearFrame++
+			traveled := acceleratedFocusSmearStep(m.focusSmearSteps, m.focusSmearFrame)
+			m.focusSmearStep = traveled
+			if m.focusSmearDirection < 0 {
+				m.focusSmearStep = m.focusSmearSteps - traveled
 			}
-			if m.focusSmearStep >= m.focusSmearSteps {
+			if m.focusSmearFrame >= focusSmearFrameCount(m.focusSmearSteps) {
 				m.focusSmearActive = false
+				if m.focusSmearDirection < 0 {
+					return m.focusInput()
+				}
 				return m, nil
 			}
 			return m, m.smearTick()
@@ -590,17 +596,9 @@ func (m teaModel) focusList() (teaModel, tea.Cmd) {
 	if m.reduceMotion {
 		return m, nil
 	}
-	visibleRows := m.previewBodyLines()
-	if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
-		visibleRows, _ = m.stackedBodyLines()
-	}
-	start, _, moreAbove, _ := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)
-	selectedLine := m.list.Selected - start
-	if moreAbove {
-		selectedLine++
-	}
+	m.focusSmearFrame = 0
 	m.focusSmearStep = 0
-	m.focusSmearSteps = maxInt(1, listFirstRowIndex+selectedLine-filterLineIndex)
+	m.focusSmearSteps = m.focusSmearDistance()
 	m.focusSmearDirection = 1
 	m.focusSmearActive = true
 	return m, m.smearTick()
@@ -614,11 +612,41 @@ func (m teaModel) smearToInput() (teaModel, tea.Cmd) {
 		return m, nil
 	}
 	m.focusSmearStart = m.inputCursorColumn()
-	m.focusSmearSteps = listFirstRowIndex - filterLineIndex
+	m.focusSmearFrame = 0
+	m.focusSmearSteps = m.focusSmearDistance()
 	m.focusSmearStep = m.focusSmearSteps
 	m.focusSmearDirection = -1
 	m.focusSmearActive = true
 	return m, m.smearTick()
+}
+
+func (m teaModel) focusSmearDistance() int {
+	visibleRows := m.previewBodyLines()
+	if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
+		visibleRows, _ = m.stackedBodyLines()
+	}
+	start, _, moreAbove, _ := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)
+	selectedLine := m.list.Selected - start
+	if moreAbove {
+		selectedLine++
+	}
+	return maxInt(1, listFirstRowIndex+selectedLine-filterLineIndex)
+}
+
+func focusSmearFrameCount(distance int) int {
+	// Constant acceleration keeps travel time proportional to sqrt(distance).
+	return min(distance, maxInt(1, int(math.Ceil(math.Sqrt(2*float64(distance))))))
+}
+
+func acceleratedFocusSmearStep(distance, frame int) int {
+	frames := focusSmearFrameCount(distance)
+	frame = min(frame, frames)
+	denominator := frames * frames
+	if frame*2 <= frames {
+		return (2*distance*frame*frame + denominator/2) / denominator
+	}
+	remaining := frames - frame
+	return distance - (2*distance*remaining*remaining+denominator/2)/denominator
 }
 
 func (m teaModel) focusInput() (teaModel, tea.Cmd) {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -41,6 +41,8 @@ const (
 	rowNameMaxWidth    = 28
 	smearMaxLength     = 3
 	smearFrameInterval = 35 * time.Millisecond
+	filterLineIndex    = 3
+	listFirstRowIndex  = 6
 	herdrSourceIcon    = "\U000f0cc6"
 	zoxideSourceIcon   = "\uf114"
 	configSourceIcon   = "\ue615"
@@ -134,9 +136,15 @@ type teaModel struct {
 	choice sessionmodel.Session
 	chosen bool
 
-	smearTail    int
-	smearActive  bool
-	reduceMotion bool
+	listFocused         bool
+	smearTail           int
+	smearActive         bool
+	focusSmearStart     int
+	focusSmearStep      int
+	focusSmearSteps     int
+	focusSmearDirection int
+	focusSmearActive    bool
+	reduceMotion        bool
 
 	preview    string
 	previewKey string
@@ -220,6 +228,18 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusRefresh()
 	}
 	if _, ok := msg.(smearTickMsg); ok {
+		if m.focusSmearActive {
+			m.focusSmearStep += m.focusSmearDirection
+			if m.focusSmearDirection < 0 && m.focusSmearStep <= 0 {
+				m.focusSmearActive = false
+				return m.focusInput()
+			}
+			if m.focusSmearStep >= m.focusSmearSteps {
+				m.focusSmearActive = false
+				return m, nil
+			}
+			return m, smearTick()
+		}
 		if !m.smearActive {
 			return m, nil
 		}
@@ -263,19 +283,39 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Quit
 	case "up", "ctrl+p":
+		if !m.listFocused {
+			return m, nil
+		}
+		if m.list.Selected == 0 {
+			return m.smearToInput()
+		}
+		m.focusSmearActive = false
 		return m.moveSelection(-1)
 	case "down", "ctrl+n":
+		if !m.listFocused {
+			return m.focusList()
+		}
+		m.focusSmearActive = false
 		return m.moveSelection(1)
 	case "ctrl+u":
+		var focusCmd tea.Cmd
+		if m.listFocused {
+			m, focusCmd = m.focusInput()
+		}
 		m.input.SetValue("")
 		m = m.filter("")
-		return m.refreshPreview()
+		m, previewCmd := m.refreshPreview()
+		return m, tea.Batch(focusCmd, previewCmd)
 	default:
+		var focusCmd tea.Cmd
+		if m.listFocused {
+			m, focusCmd = m.focusInput()
+		}
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
 		m = m.filter(m.input.Value())
 		m, previewCmd := m.refreshPreview()
-		return m, tea.Batch(cmd, previewCmd)
+		return m, tea.Batch(focusCmd, cmd, previewCmd)
 	}
 }
 
@@ -314,12 +354,18 @@ func (m teaModel) View() tea.View {
 		helpStyle.Render("enter select   ↑/↓ move   ctrl+u clear   esc close"),
 		"",
 	)
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = fitLine(line, width)
+		}
+	}
+	m.renderFocusSmear(lines, width)
 	framed := make([]string, len(lines))
 	for i, line := range lines {
 		if line == "" {
 			continue
 		}
-		framed[i] = strings.Repeat(" ", horizontalPadding) + fitLine(line, width) + strings.Repeat(" ", horizontalPadding)
+		framed[i] = strings.Repeat(" ", horizontalPadding) + line + strings.Repeat(" ", horizontalPadding)
 	}
 	view := tea.NewView(strings.Join(framed, "\n"))
 	view.AltScreen = true
@@ -339,7 +385,8 @@ func (m teaModel) listView(width, visibleRows int) string {
 			lines = append(lines, moreStyle.Render(fmt.Sprintf("↑ %d more", start)))
 		}
 		for i := start; i < end; i++ {
-			line := strings.TrimSuffix(row(m.list.Filtered[i], i == m.list.Selected, width, m.showIcons, m.list.Query), "\n")
+			selected := m.listFocused && !m.focusSmearActive && i == m.list.Selected
+			line := strings.TrimSuffix(row(m.list.Filtered[i], selected, width, m.showIcons, m.list.Query), "\n")
 			if rail := m.smearRail(i); rail != "" {
 				line = smearTrailStyle.Render(rail+" ") + strings.TrimPrefix(line, "  ")
 			}
@@ -455,6 +502,90 @@ func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
 	return m, previewCommand(key, current, m.defaultPreviewCommand)
 }
 
+func (m teaModel) focusList() (teaModel, tea.Cmd) {
+	if _, ok := m.list.Current(); !ok {
+		return m, nil
+	}
+	m.listFocused = true
+	m.focusSmearStart = m.inputCursorColumn()
+	m.input.Blur()
+	if m.reduceMotion {
+		return m, nil
+	}
+	visibleRows := m.previewBodyLines()
+	if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
+		visibleRows, _ = m.stackedBodyLines()
+	}
+	start, _, moreAbove, _ := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)
+	selectedLine := m.list.Selected - start
+	if moreAbove {
+		selectedLine++
+	}
+	m.focusSmearStep = 0
+	m.focusSmearSteps = maxInt(1, listFirstRowIndex+selectedLine-filterLineIndex)
+	m.focusSmearDirection = 1
+	m.focusSmearActive = true
+	return m, smearTick()
+}
+
+func (m teaModel) smearToInput() (teaModel, tea.Cmd) {
+	if m.reduceMotion {
+		return m.focusInput()
+	}
+	if m.focusSmearActive && m.focusSmearDirection < 0 {
+		return m, nil
+	}
+	m.focusSmearStart = m.inputCursorColumn()
+	m.focusSmearSteps = listFirstRowIndex - filterLineIndex
+	m.focusSmearStep = m.focusSmearSteps
+	m.focusSmearDirection = -1
+	m.focusSmearActive = true
+	return m, smearTick()
+}
+
+func (m teaModel) focusInput() (teaModel, tea.Cmd) {
+	m.listFocused = false
+	m.smearActive = false
+	m.focusSmearActive = false
+	return m, m.input.Focus()
+}
+
+func (m teaModel) inputCursorColumn() int {
+	value := []rune(m.input.Value())
+	position := min(m.input.Position(), len(value))
+	column := lipgloss.Width(m.input.Prompt) + lipgloss.Width(string(value[:position]))
+	return min(column, m.contentWidth()-1)
+}
+
+func (m teaModel) renderFocusSmear(lines []string, width int) {
+	if !m.focusSmearActive || m.focusSmearSteps < 1 {
+		return
+	}
+	head := min(m.focusSmearStep, m.focusSmearSteps)
+	start, end := maxInt(0, head-smearMaxLength+1), head
+	if m.focusSmearDirection < 0 {
+		start, end = head, min(m.focusSmearSteps, head+smearMaxLength-1)
+	}
+	for step := start; step <= end; step++ {
+		lineIndex := filterLineIndex + step
+		if lineIndex < 0 || lineIndex >= len(lines) {
+			continue
+		}
+		column := m.focusSmearStart * (m.focusSmearSteps - step) / m.focusSmearSteps
+		glyph := selectionRailStyle.Render("┃")
+		if step != head {
+			glyph = "│"
+			nextStep := step + m.focusSmearDirection
+			nextColumn := m.focusSmearStart * (m.focusSmearSteps - nextStep) / m.focusSmearSteps
+			if nextColumn != column {
+				glyph = "╱"
+			}
+			glyph = smearTrailStyle.Render(glyph)
+		}
+		lines[lineIndex] = overlayCell(lines[lineIndex], column, glyph, width)
+	}
+}
+
 func (m teaModel) moveSelection(delta int) (teaModel, tea.Cmd) {
 	previous := m.list.Selected
 	m.list.Move(delta)
@@ -505,6 +636,12 @@ func (m teaModel) smearRail(index int) string {
 
 func smearTick() tea.Cmd {
 	return tea.Tick(smearFrameInterval, func(time.Time) tea.Msg { return smearTickMsg{} })
+}
+
+func overlayCell(line string, column int, cell string, width int) string {
+	column = min(maxInt(0, column), width-1)
+	line = fitLine(line, width)
+	return fitLine(ansi.Cut(line, 0, column)+cell+ansi.Cut(line, column+1, width), width)
 }
 
 func previewCommand(key string, s sessionmodel.Session, defaultPreviewCommand string) tea.Cmd {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -378,6 +378,11 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.filter("")
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(focusCmd, previewCmd)
+	case "right":
+		if m.listFocused {
+			return m.smearToInput()
+		}
+		fallthrough
 	default:
 		var focusCmd tea.Cmd
 		if m.listFocused {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -39,8 +39,6 @@ const (
 	rowSourceWidth     = 10
 	rowNameMinWidth    = 12
 	rowNameMaxWidth    = 28
-	smearMaxLength     = 3
-	smearFrameInterval = 35 * time.Millisecond
 	filterLineIndex    = 3
 	listFirstRowIndex  = 6
 	herdrSourceIcon    = "\U000f0cc6"
@@ -55,6 +53,7 @@ var (
 	amberColor  = lipgloss.Color("#E0AF68")
 	textColor   = lipgloss.Color("#C0CAF5")
 	mutedColor  = lipgloss.Color("#565F89")
+	ghostColor  = lipgloss.Color("#737AA2")
 
 	titleStyle = lipgloss.NewStyle().
 			Foreground(violetColor).
@@ -145,6 +144,7 @@ type teaModel struct {
 	focusSmearDirection int
 	focusSmearActive    bool
 	reduceMotion        bool
+	smear               smearPreset
 
 	preview    string
 	previewKey string
@@ -167,6 +167,13 @@ type agentStatusesMsg struct {
 }
 
 type smearTickMsg struct{}
+
+type smearPreset struct {
+	name          string
+	frameInterval time.Duration
+	maxLength     int
+	headGlyph     string
+}
 
 func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	list := New(items)
@@ -197,6 +204,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		showIcons:             opts.ShowIcons,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
+		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
 	if current, ok := list.Current(); ok {
 		m.previewKey = sessionmodel.Key(current)
@@ -214,6 +222,70 @@ func (m teaModel) Init() tea.Cmd {
 		cmds = append(cmds, scheduleStatusRefresh())
 	}
 	return tea.Batch(cmds...)
+}
+
+func newSmearPreset(name string) smearPreset {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "gooey":
+		return smearPreset{name: "gooey", frameInterval: 45 * time.Millisecond, maxLength: 4, headGlyph: "█"}
+	case "ghost":
+		return smearPreset{name: "ghost", frameInterval: 55 * time.Millisecond, maxLength: 3, headGlyph: "◆"}
+	default:
+		return smearPreset{name: "crisp", frameInterval: 22 * time.Millisecond, maxLength: 2, headGlyph: "┃"}
+	}
+}
+
+func (p smearPreset) column(start, step, steps, direction int) int {
+	remaining := steps - step
+	switch p.name {
+	case "gooey":
+		if direction < 0 {
+			return start * (steps*steps - step*step) / (steps * steps)
+		}
+		return start * remaining * remaining / (steps * steps)
+	case "ghost":
+		return start * (steps*steps*steps - 3*step*step*steps + 2*step*step*step) / (steps * steps * steps)
+	default:
+		return start * remaining / steps
+	}
+}
+
+func (p smearPreset) headStyle() lipgloss.Style {
+	if p.name == "ghost" {
+		return lipgloss.NewStyle().Foreground(ghostColor)
+	}
+	return selectionRailStyle
+}
+
+func (p smearPreset) trailStyle(age int) lipgloss.Style {
+	switch p.name {
+	case "gooey":
+		if age > 1 {
+			return lipgloss.NewStyle().Foreground(mutedColor)
+		}
+		return smearTrailStyle
+	case "ghost":
+		return lipgloss.NewStyle().Foreground(ghostColor)
+	default:
+		return smearTrailStyle
+	}
+}
+
+func (p smearPreset) trailGlyph(age int, diagonal bool) string {
+	switch p.name {
+	case "gooey":
+		if age > 1 {
+			return "▒"
+		}
+		return "▓"
+	case "ghost":
+		return "·"
+	default:
+		if diagonal {
+			return "╱"
+		}
+		return "│"
+	}
 }
 
 //nolint:ireturn // Bubble Tea's Model interface requires this return shape.
@@ -238,7 +310,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.focusSmearActive = false
 				return m, nil
 			}
-			return m, smearTick()
+			return m, m.smearTick()
 		}
 		if !m.smearActive {
 			return m, nil
@@ -252,7 +324,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.smearActive = false
 			return m, nil
 		}
-		return m, smearTick()
+		return m, m.smearTick()
 	}
 	if preview, ok := msg.(previewMsg); ok {
 		if preview.key == m.previewKey {
@@ -386,9 +458,10 @@ func (m teaModel) listView(width, visibleRows int) string {
 		}
 		for i := start; i < end; i++ {
 			selected := m.listFocused && !m.focusSmearActive && i == m.list.Selected
-			line := strings.TrimSuffix(row(m.list.Filtered[i], selected, width, m.showIcons, m.list.Query), "\n")
-			if rail := m.smearRail(i); rail != "" {
-				line = smearTrailStyle.Render(rail+" ") + strings.TrimPrefix(line, "  ")
+			selectedRail := m.smear.headStyle().Render(m.smear.headGlyph + " ")
+			line := strings.TrimSuffix(rowWithRail(m.list.Filtered[i], selected, width, m.showIcons, m.list.Query, selectedRail), "\n")
+			if rail, age := m.smearRail(i); rail != "" {
+				line = m.smear.trailStyle(age).Render(rail+" ") + strings.TrimPrefix(line, "  ")
 			}
 			lines = append(lines, line)
 		}
@@ -525,7 +598,7 @@ func (m teaModel) focusList() (teaModel, tea.Cmd) {
 	m.focusSmearSteps = maxInt(1, listFirstRowIndex+selectedLine-filterLineIndex)
 	m.focusSmearDirection = 1
 	m.focusSmearActive = true
-	return m, smearTick()
+	return m, m.smearTick()
 }
 
 func (m teaModel) smearToInput() (teaModel, tea.Cmd) {
@@ -540,7 +613,7 @@ func (m teaModel) smearToInput() (teaModel, tea.Cmd) {
 	m.focusSmearStep = m.focusSmearSteps
 	m.focusSmearDirection = -1
 	m.focusSmearActive = true
-	return m, smearTick()
+	return m, m.smearTick()
 }
 
 func (m teaModel) focusInput() (teaModel, tea.Cmd) {
@@ -562,25 +635,25 @@ func (m teaModel) renderFocusSmear(lines []string, width int) {
 		return
 	}
 	head := min(m.focusSmearStep, m.focusSmearSteps)
-	start, end := maxInt(0, head-smearMaxLength+1), head
+	start, end := maxInt(0, head-m.smear.maxLength+1), head
 	if m.focusSmearDirection < 0 {
-		start, end = head, min(m.focusSmearSteps, head+smearMaxLength-1)
+		start, end = head, min(m.focusSmearSteps, head+m.smear.maxLength-1)
 	}
 	for step := start; step <= end; step++ {
 		lineIndex := filterLineIndex + step
 		if lineIndex < 0 || lineIndex >= len(lines) {
 			continue
 		}
-		column := m.focusSmearStart * (m.focusSmearSteps - step) / m.focusSmearSteps
-		glyph := selectionRailStyle.Render("┃")
+		column := m.smear.column(m.focusSmearStart, step, m.focusSmearSteps, m.focusSmearDirection)
+		glyph := m.smear.headStyle().Render(m.smear.headGlyph)
 		if step != head {
-			glyph = "│"
 			nextStep := step + m.focusSmearDirection
-			nextColumn := m.focusSmearStart * (m.focusSmearSteps - nextStep) / m.focusSmearSteps
-			if nextColumn != column {
-				glyph = "╱"
+			nextColumn := m.smear.column(m.focusSmearStart, nextStep, m.focusSmearSteps, m.focusSmearDirection)
+			age := step - head
+			if age < 0 {
+				age = -age
 			}
-			glyph = smearTrailStyle.Render(glyph)
+			glyph = m.smear.trailStyle(age).Render(m.smear.trailGlyph(age, nextColumn != column))
 		}
 		lines[lineIndex] = overlayCell(lines[lineIndex], column, glyph, width)
 	}
@@ -593,10 +666,10 @@ func (m teaModel) moveSelection(delta int) (teaModel, tea.Cmd) {
 	if m.list.Selected != previous && !m.reduceMotion && !m.smearActive {
 		m.smearTail = previous
 		m.smearActive = true
-		tick = smearTick()
+		tick = m.smearTick()
 	}
 	if m.smearActive {
-		m.smearTail = min(maxInt(m.smearTail, m.list.Selected-smearMaxLength), m.list.Selected+smearMaxLength)
+		m.smearTail = min(maxInt(m.smearTail, m.list.Selected-m.smear.maxLength), m.list.Selected+m.smear.maxLength)
 	}
 	m, previewCmd := m.refreshPreview()
 	return m, tea.Batch(previewCmd, tick)
@@ -611,31 +684,41 @@ func (m teaModel) filter(query string) teaModel {
 	return m
 }
 
-func (m teaModel) smearRail(index int) string {
+func (m teaModel) smearRail(index int) (string, int) {
 	selected := m.list.Selected
 	if !m.smearActive || m.smearTail == selected {
-		return ""
+		return "", 0
+	}
+	age := selected - index
+	if age < 0 {
+		age = -age
 	}
 	if m.smearTail < selected {
 		if index < m.smearTail || index >= selected {
-			return ""
+			return "", 0
+		}
+		if m.smear.name != "crisp" {
+			return m.smear.trailGlyph(age, false), age
 		}
 		if index == m.smearTail {
-			return "╷"
+			return "╷", age
 		}
-		return "│"
+		return "│", age
 	}
 	if index <= selected || index > m.smearTail {
-		return ""
+		return "", 0
+	}
+	if m.smear.name != "crisp" {
+		return m.smear.trailGlyph(age, false), age
 	}
 	if index == m.smearTail {
-		return "╵"
+		return "╵", age
 	}
-	return "│"
+	return "│", age
 }
 
-func smearTick() tea.Cmd {
-	return tea.Tick(smearFrameInterval, func(time.Time) tea.Msg { return smearTickMsg{} })
+func (m teaModel) smearTick() tea.Cmd {
+	return tea.Tick(m.smear.frameInterval, func(time.Time) tea.Msg { return smearTickMsg{} })
 }
 
 func overlayCell(line string, column int, cell string, width int) string {
@@ -691,9 +774,13 @@ func fixedVisualLines(text string, width, count int) string {
 }
 
 func row(s sessionmodel.Session, selected bool, width int, showIcons bool, query string) string {
+	return rowWithRail(s, selected, width, showIcons, query, selectionRailStyle.Render("┃ "))
+}
+
+func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons bool, query, selectedRail string) string {
 	rail := "  "
 	if selected {
-		rail = selectionRailStyle.Render("┃ ")
+		rail = selectedRail
 	}
 	label := s.Name
 	if label == "" {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -36,15 +36,101 @@ func TestTeaModelMovesSelection(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
 	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
 	cur, ok := m.list.Current()
 	if !ok || cur.Name != "web" {
 		t.Fatalf("current = %#v ok=%v", cur, ok)
 	}
 }
 
+func TestTeaModelDownTransfersCursorFromFilterToList(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "work"})
+	m = updated.(teaModel)
+	if view := ansi.Strip(m.listView(40, 2)); strings.Contains(view, "┃") {
+		t.Fatalf("list cursor visible while filter is focused:\n%s", view)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	if m.input.Focused() {
+		t.Fatal("filter remained focused after moving into the list")
+	}
+	if m.list.Selected != 0 {
+		t.Fatalf("selected row=%d, want first filtered row", m.list.Selected)
+	}
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	startColumn := visualColumn(lines[3], "┃")
+	wantStartColumn := horizontalPadding + lipgloss.Width(defaultPrompt+"work")
+	if startColumn != wantStartColumn {
+		t.Fatalf("transfer cursor column=%d, want typed-text endpoint %d:\n%s", startColumn, wantStartColumn, strings.Join(lines, "\n"))
+	}
+
+	updated, _ = m.Update(smearTickMsg{})
+	m = updated.(teaModel)
+	lines = strings.Split(ansi.Strip(m.View().Content), "\n")
+	nextColumn := visualColumn(lines[4], "┃")
+	if nextColumn < horizontalPadding || nextColumn >= startColumn {
+		t.Fatalf("transfer cursor did not move down-left: start=%d next=%d\n%s", startColumn, nextColumn, strings.Join(lines, "\n"))
+	}
+
+	for range 10 {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+	view := ansi.Strip(m.View().Content)
+	if strings.Count(view, "┃") != 1 || !strings.Contains(ansi.Strip(m.listView(40, 2)), "┃") {
+		t.Fatalf("cursor did not settle as the single list rail:\n%s", view)
+	}
+}
+
+func TestTeaModelUpTransfersCursorFromListToFilter(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "work"})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	for range 10 {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(teaModel)
+	if m.input.Focused() {
+		t.Fatal("filter refocused before the reverse smear completed")
+	}
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	startColumn := visualColumn(lines[listFirstRowIndex], "┃")
+	if startColumn != horizontalPadding {
+		t.Fatalf("reverse cursor column=%d, want list rail %d:\n%s", startColumn, horizontalPadding, strings.Join(lines, "\n"))
+	}
+
+	updated, _ = m.Update(smearTickMsg{})
+	m = updated.(teaModel)
+	lines = strings.Split(ansi.Strip(m.View().Content), "\n")
+	nextColumn := visualColumn(lines[listFirstRowIndex-1], "┃")
+	if nextColumn <= startColumn {
+		t.Fatalf("reverse cursor did not move up-right: start=%d next=%d\n%s", startColumn, nextColumn, strings.Join(lines, "\n"))
+	}
+
+	for range 10 {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+	if !m.input.Focused() || strings.Contains(ansi.Strip(m.listView(40, 2)), "┃") {
+		t.Fatalf("cursor did not settle in the filter:\n%s", ansi.Strip(m.View().Content))
+	}
+}
+
 func TestTeaModelSmearsRapidSelectionMoves(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}, {Name: "docs"}}, Options{})
+	m.listFocused = true
+	m.input.Blur()
 	for range 2 {
 		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 		m = updated.(teaModel)
@@ -65,6 +151,8 @@ func TestTeaModelSmearRetracts(t *testing.T) {
 	t.Cleanup(func() { renderPreview = oldPreview })
 
 	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+	m.listFocused = true
+	m.input.Blur()
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 	if !strings.HasPrefix(ansi.Strip(m.listView(40, 2)), "╷ ") {
@@ -101,6 +189,8 @@ func TestTeaModelCapsSmearSettleTime(t *testing.T) {
 		items[i] = model.Session{Name: "workspace"}
 	}
 	m := newTeaModel(items, Options{})
+	m.listFocused = true
+	m.input.Blur()
 	for range len(items) - 1 {
 		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 		m = updated.(teaModel)
@@ -124,6 +214,8 @@ func TestTeaModelQueryChangeClearsSmear(t *testing.T) {
 		{Name: "workspace-3"},
 	}, Options{})
 	m.list.Selected = 2
+	m.listFocused = true
+	m.input.Blur()
 	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'w', Text: "workspace"})
@@ -139,6 +231,8 @@ func TestTeaModelReducedMotionSkipsSmear(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "1")
 	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
 	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 
 	current, ok := m.list.Current()
@@ -288,6 +382,8 @@ func TestTeaModelPreviewUsesConfiguredCommand(t *testing.T) {
 
 func TestTeaModelRefreshesPreviewWhenSelectionChanges(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}, {Name: "web", Path: "/tmp/web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 	if cmd == nil || !strings.Contains(m.preview, "Loading preview") {
@@ -492,4 +588,12 @@ func maxLineWidth(s string) int {
 		maxWidth = max(maxWidth, lipgloss.Width(line))
 	}
 	return maxWidth
+}
+
+func visualColumn(line, marker string) int {
+	index := strings.Index(line, marker)
+	if index < 0 {
+		return -1
+	}
+	return lipgloss.Width(line[:index])
 }

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -160,6 +160,42 @@ func TestTeaModelRightTransfersCursorFromListToFilter(t *testing.T) {
 	}
 }
 
+func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	items := make([]model.Session, 40)
+	for i := range items {
+		items[i] = model.Session{Name: "workspace"}
+	}
+	m := newTeaModel(items, Options{})
+	m.width = 100
+	m.height = 100
+	m.list.Selected = 30
+	m.listFocused = true
+	m.input.Blur()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	m = updated.(teaModel)
+	distance := m.focusSmearSteps
+	wantDistance := listFirstRowIndex + m.list.Selected - filterLineIndex
+	if distance != wantDistance {
+		t.Fatalf("transfer distance=%d, want selected-row distance %d", distance, wantDistance)
+	}
+	previousStep := m.focusSmearStep
+	ticks := 0
+	largestAdvance := 0
+	for m.focusSmearActive {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+		ticks++
+		largestAdvance = max(largestAdvance, previousStep-m.focusSmearStep)
+		previousStep = m.focusSmearStep
+	}
+
+	if ticks >= distance || largestAdvance <= 1 {
+		t.Fatalf("long transfer did not accelerate: distance=%d ticks=%d largestAdvance=%d", distance, ticks, largestAdvance)
+	}
+}
+
 func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	t.Setenv("HERDR_SESH_SMEAR_PRESET", "gooey")

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -134,6 +134,32 @@ func TestTeaModelUpTransfersCursorFromListToFilter(t *testing.T) {
 	}
 }
 
+func TestTeaModelRightTransfersCursorFromListToFilter(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "work"})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	for range 10 {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	m = updated.(teaModel)
+	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
+		t.Fatalf("right arrow skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
+	}
+
+	updated, _ = m.Update(smearTickMsg{})
+	m = updated.(teaModel)
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	if column := visualColumn(lines[listFirstRowIndex-1], "┃"); column <= horizontalPadding {
+		t.Fatalf("right-arrow cursor did not smear up-right: column=%d\n%s", column, strings.Join(lines, "\n"))
+	}
+}
+
 func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	t.Setenv("HERDR_SESH_SMEAR_PRESET", "gooey")

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
+
+func TestMain(m *testing.M) {
+	if err := os.Setenv("HERDR_SESH_SMEAR_PRESET", "crisp"); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
 
 func TestTeaModelFiltersMovesAndChooses(t *testing.T) {
 	m := newTeaModel([]model.Session{
@@ -123,6 +131,100 @@ func TestTeaModelUpTransfersCursorFromListToFilter(t *testing.T) {
 	}
 	if !m.input.Focused() || strings.Contains(ansi.Strip(m.listView(40, 2)), "┃") {
 		t.Fatalf("cursor did not settle in the filter:\n%s", ansi.Strip(m.View().Content))
+	}
+}
+
+func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	t.Setenv("HERDR_SESH_SMEAR_PRESET", "gooey")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "work"})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	for range 10 {
+		updated, _ = m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(teaModel)
+
+	columns := make([]int, 0, 3)
+	for frame := range 3 {
+		lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+		column := visualColumn(lines[listFirstRowIndex-frame], "█")
+		if column < 0 {
+			t.Fatalf("frame %d missing Gooey cursor:\n%s", frame, strings.Join(lines, "\n"))
+		}
+		columns = append(columns, column)
+		if frame < 2 {
+			updated, _ = m.Update(smearTickMsg{})
+			m = updated.(teaModel)
+		}
+	}
+
+	firstMove := columns[1] - columns[0]
+	secondMove := columns[2] - columns[1]
+	if firstMove <= secondMove {
+		t.Fatalf("reverse Gooey movement accelerated into the input: columns=%v moves=%d,%d", columns, firstMove, secondMove)
+	}
+}
+
+func TestTeaModelSmearPresets(t *testing.T) {
+	tests := []struct {
+		name          string
+		head          string
+		transferTrail []string
+		rowTrail      string
+		rowTrailCells int
+	}{
+		{name: "crisp", head: "┃", transferTrail: []string{"╱"}, rowTrail: "╷│╵", rowTrailCells: 2},
+		{name: "gooey", head: "█", transferTrail: []string{"▓", "▒"}, rowTrail: "▓▒", rowTrailCells: 4},
+		{name: "ghost", head: "◆", transferTrail: []string{"·"}, rowTrail: "·", rowTrailCells: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HERDR_SESH_SMEAR_PRESET", tt.name)
+			items := make([]model.Session, 6)
+			for i := range items {
+				items[i] = model.Session{Name: "workspace"}
+			}
+			m := newTeaModel(items, Options{})
+			updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+			m = updated.(teaModel)
+			for range 2 {
+				updated, _ = m.Update(smearTickMsg{})
+				m = updated.(teaModel)
+			}
+			transfer := ansi.Strip(m.View().Content)
+			for _, glyph := range append([]string{tt.head}, tt.transferTrail...) {
+				if !strings.Contains(transfer, glyph) {
+					t.Fatalf("%s transfer missing %q:\n%s", tt.name, glyph, transfer)
+				}
+			}
+
+			for range 10 {
+				updated, _ = m.Update(smearTickMsg{})
+				m = updated.(teaModel)
+			}
+			if view := ansi.Strip(m.listView(40, 6)); !strings.Contains(view, tt.head) {
+				t.Fatalf("%s settled cursor missing %q:\n%s", tt.name, tt.head, view)
+			}
+			for range len(items) - 1 {
+				updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+				m = updated.(teaModel)
+			}
+			rowView := ansi.Strip(m.listView(40, 6))
+			trailCells := 0
+			for _, glyph := range rowView {
+				if strings.ContainsRune(tt.rowTrail, glyph) {
+					trailCells++
+				}
+			}
+			if trailCells != tt.rowTrailCells {
+				t.Fatalf("%s row trail cells=%d, want %d:\n%s", tt.name, trailCells, tt.rowTrailCells, rowView)
+			}
+		})
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -184,6 +184,22 @@ func TestTeaModelTypingTransfersCursorFromListToFilter(t *testing.T) {
 	}
 }
 
+func TestTeaModelPasteTransfersCursorFromListToFilter(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	m.listFocused = true
+	m.input.Blur()
+
+	updated, _ := m.Update(tea.PasteMsg{Content: "workspace"})
+	m = updated.(teaModel)
+	if m.input.Value() != "workspace" || m.list.Query != "workspace" {
+		t.Fatalf("pasted text was not applied during transfer: input=%q query=%q", m.input.Value(), m.list.Query)
+	}
+	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
+		t.Fatalf("paste skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
+	}
+}
+
 func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	items := make([]model.Session, 40)

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -42,6 +42,115 @@ func TestTeaModelMovesSelection(t *testing.T) {
 	}
 }
 
+func TestTeaModelSmearsRapidSelectionMoves(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}, {Name: "docs"}}, Options{})
+	for range 2 {
+		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		m = updated.(teaModel)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(ansi.Strip(m.listView(40, 3)), "\n"), "\n")
+	for i, want := range []string{"╷ ", "│ ", "┃ "} {
+		if !strings.HasPrefix(lines[i], want) {
+			t.Fatalf("row %d = %q, want rail %q\n%s", i, lines[i], want, strings.Join(lines, "\n"))
+		}
+	}
+}
+
+func TestTeaModelSmearRetracts(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	oldPreview := renderPreview
+	renderPreview = func(context.Context, model.Session, string) (string, error) { return "preview", nil }
+	t.Cleanup(func() { renderPreview = oldPreview })
+
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	if !strings.HasPrefix(ansi.Strip(m.listView(40, 2)), "╷ ") {
+		t.Fatalf("moving selection did not start the smear:\n%s", ansi.Strip(m.listView(40, 2)))
+	}
+
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("move command = %T, want preview and animation batch", msg)
+	}
+	tickHandled := false
+	for _, child := range batch {
+		msg := child()
+		if _, ok := msg.(previewMsg); ok {
+			continue
+		}
+		updated, _ = m.Update(msg)
+		m = updated.(teaModel)
+		tickHandled = true
+	}
+	if !tickHandled {
+		t.Fatal("move batch did not contain an animation tick")
+	}
+	if view := ansi.Strip(m.listView(40, 2)); strings.HasPrefix(view, "╷ ") {
+		t.Fatalf("smear remained after settling:\n%s", view)
+	}
+}
+
+func TestTeaModelCapsSmearSettleTime(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	items := make([]model.Session, 100)
+	for i := range items {
+		items[i] = model.Session{Name: "workspace"}
+	}
+	m := newTeaModel(items, Options{})
+	for range len(items) - 1 {
+		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		m = updated.(teaModel)
+	}
+
+	for ticks := 1; m.smearActive; ticks++ {
+		if ticks > 3 {
+			t.Fatalf("smear still active after %d settle ticks", ticks-1)
+		}
+		updated, _ := m.Update(smearTickMsg{})
+		m = updated.(teaModel)
+	}
+}
+
+func TestTeaModelQueryChangeClearsSmear(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{
+		{Name: "workspace-0"},
+		{Name: "workspace-1"},
+		{Name: "workspace-2"},
+		{Name: "workspace-3"},
+	}, Options{})
+	m.list.Selected = 2
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'w', Text: "workspace"})
+	m = updated.(teaModel)
+
+	view := ansi.Strip(m.listView(40, 4))
+	if strings.Contains(view, "╵ ") || strings.Contains(view, "│ ") {
+		t.Fatalf("query change left a smear on reordered rows:\n%s", view)
+	}
+}
+
+func TestTeaModelReducedMotionSkipsSmear(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "1")
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+
+	current, ok := m.list.Current()
+	if !ok || current.Name != "web" {
+		t.Fatalf("current = %#v ok=%v", current, ok)
+	}
+	view := ansi.Strip(m.listView(40, 2))
+	if strings.Contains(view, "╷ ") || strings.Contains(view, "│ ") {
+		t.Fatalf("reduced motion rendered a smear:\n%s", view)
+	}
+}
+
 func TestTeaModelForwardsTextInputNonKeyMessages(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
 	updated, cmd := m.Update(cursor.Blink())

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -160,6 +160,30 @@ func TestTeaModelRightTransfersCursorFromListToFilter(t *testing.T) {
 	}
 }
 
+func TestTeaModelTypingTransfersCursorFromListToFilter(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
+	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
+	m.list.Selected = 1
+	m.listFocused = true
+	m.input.Blur()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "w"})
+	m = updated.(teaModel)
+	if m.input.Value() != "w" || m.list.Query != "w" {
+		t.Fatalf("typed key was not applied during transfer: input=%q query=%q", m.input.Value(), m.list.Query)
+	}
+	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
+		t.Fatalf("typing skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
+	}
+
+	updated, _ = m.Update(smearTickMsg{})
+	m = updated.(teaModel)
+	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+	if column := visualColumn(lines[listFirstRowIndex], "┃"); column <= horizontalPadding {
+		t.Fatalf("typed cursor did not smear up-right: column=%d\n%s", column, strings.Join(lines, "\n"))
+	}
+}
+
 func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	items := make([]model.Session, 40)


### PR DESCRIPTION
## Summary
- animate picker selection and filter/list focus transfers with configurable smear presets
- support reduced-motion behavior and document the cursor settings
- preserve typed and bracketed-paste input while focus transfers back to the filter

## Validation
- `just check`
- `go vet ./...`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add smear animations to the picker for selection and focus transfer, with configurable presets, reduced motion, and a README demo gif. Improves clarity when moving between the filter and list while preserving typed and pasted input.

- **New Features**
  - Animated cursor transfer between filter and list that eases and accelerates on longer moves, leaving a short trail.
  - Selection moves render a trailing rail that settles quickly.
  - Presets via `HERDR_SESH_SMEAR_PRESET`: `crisp` (default), `gooey`, `ghost`.
  - Reduced motion via `HERDR_SESH_REDUCE_MOTION=1` disables animation.
  - Docs updated with cursor settings; README adds a demo gif and `*.gif` assets use Git LFS.

- **Bug Fixes**
  - Right-arrow now transfers focus back to the filter correctly.
  - Keeps the smear and position consistent while typing during a transfer.
  - Handles bracketed paste during focus transfer without losing input.

<sup>Written for commit e2fbd8f2d02177cca397dc5d29770f53699e3105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

