### PR TITLE
feat(picker): add workspace sort modes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -43,6 +43,7 @@ the state directory.
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
+| `default_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press `ctrl+s` to switch modes while the picker is open. |
 
 Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
 
@@ -128,6 +129,7 @@ blacklist = ["^scratch$"]
 show_icons = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
+default_sort = "recent"
 
 [default_session]
 startup_command = "git status"

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,7 +43,7 @@ the state directory.
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
-| `default_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press `ctrl+s` to switch modes while the picker is open. |
+| `default_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press `ctrl+r` to switch modes while the picker is open. |
 
 Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -198,6 +198,12 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
 		client := herdr.NewCLIClient()
+		history, historyErr := state.LoadHistory(os.Getenv("HERDR_PLUGIN_STATE_DIR"))
+		if historyErr != nil {
+			a.warnf("ignoring workspace history: %v", historyErr)
+		}
+		pickOpts.RecentWorkspaceIDs = append([]string{os.Getenv("HERDR_WORKSPACE_ID")}, history.Workspaces...)
+		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import "github.com/fullerzz/herdr-plugin-sesh/internal/model"
 
-const DefaultPreviewCommand = "eza --icons=always -la {}"
+const (
+	DefaultPreviewCommand = "eza --icons=always -la {}"
+	DefaultWorkspaceSort  = "workspace"
+)
 
 type Config struct {
 	Cache                bool                 `toml:"cache"`
@@ -37,6 +40,7 @@ type TUIConfig struct {
 	ShowIcons   bool   `toml:"show_icons"`
 	Prompt      string `toml:"prompt"`
 	Placeholder string `toml:"placeholder"`
+	DefaultSort string `toml:"default_sort"`
 }
 
 type WildcardConfig struct {
@@ -52,5 +56,6 @@ func Default() Config {
 		DirLength:            1,
 		SortOrder:            []string{"herdr", "config", "zoxide", "dir"},
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
+		TUI:                  TUIConfig{DefaultSort: DefaultWorkspaceSort},
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -35,6 +35,9 @@ func Load(opts LoadOptions) (Config, string, error) {
 		return cfg, path, err
 	}
 	attachDefaults(&cfg)
+	if cfg.TUI.DefaultSort != "workspace" && cfg.TUI.DefaultSort != "recent" {
+		return cfg, path, fmt.Errorf("load %s: tui.default_sort must be \"workspace\" or \"recent\"", path)
+	}
 	return cfg, path, nil
 }
 
@@ -96,6 +99,7 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 			Prompt      *string `toml:"prompt"`
 			Placeholder *string `toml:"placeholder"`
 			ShowIcons   *bool   `toml:"show_icons"`
+			DefaultSort *string `toml:"default_sort"`
 		} `toml:"tui"`
 	}
 	_ = toml.Unmarshal(data, &probe)
@@ -123,11 +127,12 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 		probe.TUI.Prompt != nil,
 		probe.TUI.Placeholder != nil,
 		probe.TUI.ShowIcons != nil,
+		probe.TUI.DefaultSort != nil,
 	)
 	return nil
 }
 
-func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet bool) {
+func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, defaultSortSet bool) {
 	if src.Cache {
 		dst.Cache = true
 	}
@@ -155,6 +160,9 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	if placeholderSet {
 		dst.TUI.Placeholder = src.TUI.Placeholder
 	}
+	if defaultSortSet {
+		dst.TUI.DefaultSort = src.TUI.DefaultSort
+	}
 	if src.DefaultSessionConfig.StartupCommand != "" {
 		dst.DefaultSessionConfig.StartupCommand = src.DefaultSessionConfig.StartupCommand
 	}
@@ -175,6 +183,9 @@ func attachDefaults(cfg *Config) {
 	}
 	if cfg.DefaultSessionConfig.PreviewCommand == "" {
 		cfg.DefaultSessionConfig.PreviewCommand = DefaultPreviewCommand
+	}
+	if cfg.TUI.DefaultSort == "" {
+		cfg.TUI.DefaultSort = DefaultWorkspaceSort
 	}
 }
 func ExpandHome(p, home string) string {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -187,6 +187,26 @@ func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
 	}
 }
 
+func TestLoadTUIDefaultSort(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "sesh.toml")
+	mustWrite(t, p, "[tui]\ndefault_sort = \"recent\"\n")
+	cfg, _, err := Load(LoadOptions{Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.DefaultSort != "recent" {
+		t.Fatalf("default sort = %q", cfg.TUI.DefaultSort)
+	}
+}
+
+func TestLoadRejectsInvalidTUIDefaultSort(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "sesh.toml")
+	mustWrite(t, p, "[tui]\ndefault_sort = \"newest\"\n")
+	if _, _, err := Load(LoadOptions{Path: p}); err == nil {
+		t.Fatal("expected invalid default sort error")
+	}
+}
+
 func TestDefaultPreviewCommandUsesEzaIcons(t *testing.T) {
 	cfg := Default()
 	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -401,7 +401,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.filter("")
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(focusCmd, previewCmd)
-	case "ctrl+s":
+	case "ctrl+r":
 		return m.toggleWorkspaceSort()
 	case "right":
 		if m.listFocused {
@@ -484,7 +484,7 @@ func (m teaModel) View() tea.View {
 	}
 	lines = append(lines,
 		horizontalRule(width),
-		helpStyle.Render(fmt.Sprintf("enter select   ↑/↓ move   ctrl+s sort: %s   ctrl+u clear   esc close", sortMode)),
+		helpStyle.Render(fmt.Sprintf("enter select   ↑/↓ move   ctrl+r sort: %s   ctrl+u clear   esc close", sortMode)),
 		"",
 	)
 	for i, line := range lines {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,6 +111,8 @@ type Options struct {
 	DefaultPreviewCommand string
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
+	RecentWorkspaceIDs    []string
+	RecentWorkspaceSort   bool
 }
 
 func Run(items []sessionmodel.Session, opts Options) (sessionmodel.Session, bool, error) {
@@ -154,6 +157,9 @@ type teaModel struct {
 	defaultPreviewCommand string
 	showIcons             bool
 	refreshAgentStatuses  func() (map[string]string, error)
+	workspaceOrder        []string
+	recentWorkspaceIDs    []string
+	recentSort            bool
 }
 
 type previewMsg struct {
@@ -178,6 +184,11 @@ type smearPreset struct {
 }
 
 func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
+	workspaceOrder := herdrWorkspaceIDs(items)
+	if opts.RecentWorkspaceSort {
+		items = append([]sessionmodel.Session(nil), items...)
+		sortHerdrWorkspaces(items, opts.RecentWorkspaceIDs)
+	}
 	list := New(items)
 	list.SeparatorAware = opts.SeparatorAware
 	prompt := opts.Prompt
@@ -205,6 +216,9 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		showIcons:             opts.ShowIcons,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
+		workspaceOrder:        workspaceOrder,
+		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
+		recentSort:            opts.RecentWorkspaceSort,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -290,7 +304,7 @@ func (p smearPreset) trailGlyph(age int, diagonal bool) string {
 	}
 }
 
-//nolint:ireturn // Bubble Tea's Model interface requires this return shape.
+//nolint:gocyclo,ireturn // Bubble Tea's central event dispatcher requires this return shape.
 func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if _, ok := msg.(statusRefreshTickMsg); ok {
 		return m, refreshAgentStatusesCommand(m.refreshAgentStatuses)
@@ -387,6 +401,8 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.filter("")
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(focusCmd, previewCmd)
+	case "ctrl+s":
+		return m.toggleWorkspaceSort()
 	case "right":
 		if m.listFocused {
 			return m.smearToInput()
@@ -395,6 +411,20 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	default:
 		return m.updateInput(msg)
 	}
+}
+
+func (m teaModel) toggleWorkspaceSort() (teaModel, tea.Cmd) {
+	m.recentSort = !m.recentSort
+	order := m.workspaceOrder
+	if m.recentSort {
+		order = m.recentWorkspaceIDs
+	}
+	sortHerdrWorkspaces(m.list.All, order)
+	m.list.Selected = 0
+	m.list.Filter(m.list.Query)
+	m.smearActive = false
+	m.focusSmearActive = false
+	return m.refreshPreview()
 }
 
 func (m teaModel) updateInput(msg tea.Msg) (teaModel, tea.Cmd) {
@@ -448,9 +478,13 @@ func (m teaModel) View() tea.View {
 		lines = append(lines, strings.Split(strings.TrimSuffix(m.listView(listWidth, listRows), "\n"), "\n")...)
 		lines = append(lines, strings.Split(m.previewView(width, previewLines), "\n")...)
 	}
+	sortMode := "workspace"
+	if m.recentSort {
+		sortMode = "recent"
+	}
 	lines = append(lines,
 		horizontalRule(width),
-		helpStyle.Render("enter select   ↑/↓ move   ctrl+u clear   esc close"),
+		helpStyle.Render(fmt.Sprintf("enter select   ↑/↓ move   ctrl+s sort: %s   ctrl+u clear   esc close", sortMode)),
 		"",
 	)
 	for i, line := range lines {
@@ -469,6 +503,46 @@ func (m teaModel) View() tea.View {
 	view := tea.NewView(strings.Join(framed, "\n"))
 	view.AltScreen = true
 	return view
+}
+
+func herdrWorkspaceIDs(items []sessionmodel.Session) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Source == "herdr" {
+			ids = append(ids, item.WorkspaceID)
+		}
+	}
+	return ids
+}
+
+func sortHerdrWorkspaces(items []sessionmodel.Session, order []string) {
+	rank := make(map[string]int, len(order))
+	for i, id := range order {
+		if _, exists := rank[id]; id != "" && !exists {
+			rank[id] = i
+		}
+	}
+	workspaces := make([]sessionmodel.Session, 0, len(items))
+	for _, item := range items {
+		if item.Source == "herdr" {
+			workspaces = append(workspaces, item)
+		}
+	}
+	sort.SliceStable(workspaces, func(i, j int) bool {
+		iRank, iFound := rank[workspaces[i].WorkspaceID]
+		jRank, jFound := rank[workspaces[j].WorkspaceID]
+		if iFound != jFound {
+			return iFound
+		}
+		return iFound && iRank < jRank
+	})
+	workspace := 0
+	for i := range items {
+		if items[i].Source == "herdr" {
+			items[i] = workspaces[workspace]
+			workspace++
+		}
+	}
 }
 
 func (m teaModel) listView(width, visibleRows int) string {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -3,6 +3,7 @@ package picker
 import (
 	"context"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -753,6 +754,46 @@ func TestTeaModelHeaderShowsFilteredCountWhenAllRowsMatch(t *testing.T) {
 	}
 }
 
+func TestTeaModelCyclesHerdrWorkspaceSortModes(t *testing.T) {
+	items := []model.Session{
+		{Source: "config", Name: "configured"},
+		{Source: "herdr", Name: "first", WorkspaceID: "w1"},
+		{Source: "zoxide", Name: "recent-directory"},
+		{Source: "herdr", Name: "second", WorkspaceID: "w2"},
+		{Source: "herdr", Name: "third", WorkspaceID: "w3"},
+	}
+	m := newTeaModel(items, Options{RecentWorkspaceIDs: []string{"w3", "w1"}})
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if got, want := sessionNames(m.list.All), []string{"configured", "third", "recent-directory", "first", "second"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent order=%v want %v", got, want)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+s sort: recent") {
+		t.Fatalf("view missing recent sort mode:\n%s", view)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if got, want := sessionNames(m.list.All), []string{"configured", "first", "recent-directory", "second", "third"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("workspace order=%v want %v", got, want)
+	}
+}
+
+func TestTeaModelStartsWithConfiguredWorkspaceSort(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "first", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "second", WorkspaceID: "w2"},
+	}, Options{RecentWorkspaceIDs: []string{"w2", "w1"}, RecentWorkspaceSort: true})
+
+	if got, want := sessionNames(m.list.All), []string{"second", "first"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("initial order=%v want %v", got, want)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+s sort: recent") {
+		t.Fatalf("view missing recent sort mode:\n%s", view)
+	}
+}
+
 func TestTeaModelSearchRailDoesNotTruncateAtWindowEdge(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 28})
@@ -800,4 +841,12 @@ func visualColumn(line, marker string) int {
 		return -1
 	}
 	return lipgloss.Width(line[:index])
+}
+
+func sessionNames(items []model.Session) []string {
+	names := make([]string, len(items))
+	for i := range items {
+		names[i] = items[i].Name
+	}
+	return names
 }

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -764,16 +764,16 @@ func TestTeaModelCyclesHerdrWorkspaceSortModes(t *testing.T) {
 	}
 	m := newTeaModel(items, Options{RecentWorkspaceIDs: []string{"w3", "w1"}})
 
-	updated, _ := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	if got, want := sessionNames(m.list.All), []string{"configured", "third", "recent-directory", "first", "second"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("recent order=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+s sort: recent") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r sort: recent") {
 		t.Fatalf("view missing recent sort mode:\n%s", view)
 	}
 
-	updated, _ = m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	if got, want := sessionNames(m.list.All), []string{"configured", "first", "recent-directory", "second", "third"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("workspace order=%v want %v", got, want)
@@ -789,7 +789,7 @@ func TestTeaModelStartsWithConfiguredWorkspaceSort(t *testing.T) {
 	if got, want := sessionNames(m.list.All), []string{"second", "first"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("initial order=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+s sort: recent") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r sort: recent") {
 		t.Fatalf("view missing recent sort mode:\n%s", view)
 	}
 }


### PR DESCRIPTION
## Summary

- add native picker sorting by Herdr workspace order or most-recent visit
- let users toggle sort modes with `ctrl+s` without moving non-Herdr rows
- add `[tui] default_sort` configuration with import-aware merging and validation
- document the new setting and cover sorting/config behavior with focused regressions

## Validation

- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check`
- `go vet ./...`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace sort modes to the native picker so `herdr` workspaces can be ordered by workspace order or most-recent visit. Toggle with ctrl+r; initial mode is set via `tui.default_sort`.

- New Features
  - Only reorders `herdr` rows; other sources stay in place.
  - `tui.default_sort`: `workspace` (default) or `recent`; invalid values fail config load.
  - “Recent” uses the current workspace first plus history from `HERDR_PLUGIN_STATE_DIR`.
  - Help shows the active sort mode; import-aware merge preserves explicit `default_sort`. Docs updated.

<sup>Written for commit 280466269a6c340aa1c837e45894da39c5814432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

