### PR TITLE
feat(picker): align agent status indicators

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -56,9 +56,9 @@ Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
 Set `HERDR_SESH_REDUCE_MOTION=1` (or `true`) to keep cursor movement
 instantaneous without drawing any preset's trail.
 
-Open Herdr workspaces show the agent state reported by Herdr when the picker
-opens: green `●` working, amber `◆` blocked, muted `○` idle, and violet `✓`
-done. Workspaces with an unknown state have no indicator.
+Open Herdr workspaces show the agent state reported by Herdr: an animated amber
+Jump spinner (`⢄⢂⢁⡁⡈⡐⡠`) while working, red `◉` when blocked, green `✓` when idle,
+and teal `●` when done. Workspaces with an unknown state have no indicator.
 
 ## Session behavior
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -49,10 +50,13 @@ const (
 )
 
 var (
+	agentStatusSpinner = spinner.Jump
+
 	skyColor    = lipgloss.Color("#7DCFFF")
 	violetColor = lipgloss.Color("#BB9AF7")
 	greenColor  = lipgloss.Color("#9ECE6A")
 	amberColor  = lipgloss.Color("#E0AF68")
+	redColor    = lipgloss.Color("#F7768E")
 	textColor   = lipgloss.Color("#C0CAF5")
 	mutedColor  = lipgloss.Color("#565F89")
 	ghostColor  = lipgloss.Color("#737AA2")
@@ -132,12 +136,13 @@ func Run(items []sessionmodel.Session, opts Options) (sessionmodel.Session, bool
 }
 
 type teaModel struct {
-	list   Model
-	input  textinput.Model
-	width  int
-	height int
-	choice sessionmodel.Session
-	chosen bool
+	list         Model
+	input        textinput.Model
+	agentSpinner spinner.Model
+	width        int
+	height       int
+	choice       sessionmodel.Session
+	chosen       bool
 
 	listFocused         bool
 	smearTail           int
@@ -213,6 +218,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	m := teaModel{
 		list:                  list,
 		input:                 input,
+		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		showIcons:             opts.ShowIcons,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
@@ -235,7 +241,7 @@ func (m teaModel) Init() tea.Cmd {
 		cmds = append(cmds, previewCommand(m.previewKey, current, m.defaultPreviewCommand))
 	}
 	if m.refreshAgentStatuses != nil {
-		cmds = append(cmds, scheduleStatusRefresh())
+		cmds = append(cmds, scheduleStatusRefresh(), m.agentSpinner.Tick)
 	}
 	return tea.Batch(cmds...)
 }
@@ -306,6 +312,11 @@ func (p smearPreset) trailGlyph(age int, diagonal bool) string {
 
 //nolint:gocyclo,ireturn // Bubble Tea's central event dispatcher requires this return shape.
 func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(spinner.TickMsg); ok {
+		var cmd tea.Cmd
+		m.agentSpinner, cmd = m.agentSpinner.Update(msg)
+		return m, cmd
+	}
 	if _, ok := msg.(statusRefreshTickMsg); ok {
 		return m, refreshAgentStatusesCommand(m.refreshAgentStatuses)
 	}
@@ -560,7 +571,7 @@ func (m teaModel) listView(width, visibleRows int) string {
 		for i := start; i < end; i++ {
 			selected := m.listFocused && !m.focusSmearActive && i == m.list.Selected
 			selectedRail := m.smear.headStyle().Render(m.smear.headGlyph + " ")
-			line := strings.TrimSuffix(rowWithRail(m.list.Filtered[i], selected, width, m.showIcons, m.list.Query, selectedRail), "\n")
+			line := strings.TrimSuffix(rowWithRail(m.list.Filtered[i], selected, width, m.showIcons, m.list.Query, selectedRail, m.agentSpinner.View()), "\n")
 			if rail, age := m.smearRail(i); rail != "" {
 				line = m.smear.trailStyle(age).Render(rail+" ") + strings.TrimPrefix(line, "  ")
 			}
@@ -654,7 +665,7 @@ func (m teaModel) previewTitle() string {
 	if label != "" {
 		title += countStyle.Render(" · " + label)
 	}
-	if _, status := agentStatusIndicator(current.AgentStatus); status != "" {
+	if _, status := agentStatusIndicator(current.AgentStatus, m.agentSpinner.View()); status != "" {
 		title += agentStatusStyle(current.AgentStatus).Render(" · " + status)
 	}
 	return title
@@ -897,10 +908,10 @@ func fixedVisualLines(text string, width, count int) string {
 }
 
 func row(s sessionmodel.Session, selected bool, width int, showIcons bool, query string) string {
-	return rowWithRail(s, selected, width, showIcons, query, selectionRailStyle.Render("┃ "))
+	return rowWithRail(s, selected, width, showIcons, query, selectionRailStyle.Render("┃ "), agentStatusSpinner.Frames[0])
 }
 
-func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons bool, query, selectedRail string) string {
+func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons bool, query, selectedRail, workingGlyph string) string {
 	rail := "  "
 	if selected {
 		rail = selectedRail
@@ -909,7 +920,7 @@ func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons boo
 	if label == "" {
 		label = compactHome(s.Path)
 	}
-	statusGlyph, _ := agentStatusIndicator(s.AgentStatus)
+	statusGlyph, _ := agentStatusIndicator(s.AgentStatus, workingGlyph)
 	status := "  "
 	if statusGlyph != "" {
 		status = agentStatusStyle(s.AgentStatus).Render(statusGlyph + " ")
@@ -1021,16 +1032,16 @@ func sourceBadgeColor(source string) string {
 	return color
 }
 
-func agentStatusIndicator(status string) (string, string) {
+func agentStatusIndicator(status, workingGlyph string) (string, string) {
 	switch status {
 	case "working":
-		return "●", "working"
+		return workingGlyph, "working"
 	case "blocked":
-		return "◆", "blocked"
+		return "◉", "blocked"
 	case "idle":
-		return "○", "idle"
+		return "✓", "idle"
 	case "done":
-		return "✓", "done"
+		return "●", "done"
 	default:
 		return "", ""
 	}
@@ -1040,11 +1051,13 @@ func agentStatusStyle(status string) lipgloss.Style {
 	color := mutedColor
 	switch status {
 	case "working":
-		color = greenColor
-	case "blocked":
 		color = amberColor
+	case "blocked":
+		color = redColor
+	case "idle":
+		color = greenColor
 	case "done":
-		color = violetColor
+		color = skyColor
 	}
 	return lipgloss.NewStyle().Foreground(color).Bold(true)
 }

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"charm.land/bubbles/v2/cursor"
+	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -533,10 +534,10 @@ func TestRowUsesAgentStatusIndicators(t *testing.T) {
 		glyph  string
 		color  string
 	}{
-		{status: "working", glyph: "●", color: "38;2;158;206;106"},
-		{status: "blocked", glyph: "◆", color: "38;2;224;175;104"},
-		{status: "idle", glyph: "○", color: "38;2;86;95;137"},
-		{status: "done", glyph: "✓", color: "38;2;187;154;247"},
+		{status: "working", glyph: "⢄", color: "38;2;224;175;104"},
+		{status: "blocked", glyph: "◉", color: "38;2;247;118;142"},
+		{status: "idle", glyph: "✓", color: "38;2;158;206;106"},
+		{status: "done", glyph: "●", color: "38;2;125;207;255"},
 	}
 	for _, tt := range tests {
 		got := row(model.Session{Source: "herdr", Name: "api", AgentStatus: tt.status}, false, 80, true, "")
@@ -546,9 +547,36 @@ func TestRowUsesAgentStatusIndicators(t *testing.T) {
 	}
 	for _, status := range []string{"", "unknown", "future"} {
 		got := ansi.Strip(row(model.Session{Source: "herdr", Name: "api", AgentStatus: status}, false, 80, true, ""))
-		if strings.ContainsAny(got, "●◆○✓") {
+		if strings.ContainsAny(got, "⢄◉✓●") {
 			t.Fatalf("row for status %q unexpectedly contains indicator: %q", status, got)
 		}
+	}
+}
+
+func TestTeaModelAnimatesWorkingAgentStatusIndicator(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "herdr", Name: "api", AgentStatus: "working"}}, Options{})
+	before := ansi.Strip(m.listView(80, 1))
+
+	updated, cmd := m.Update(spinner.TickMsg{})
+	m = updated.(teaModel)
+	after := ansi.Strip(m.listView(80, 1))
+
+	if !strings.Contains(before, "⢄") || !strings.Contains(after, "⢂") {
+		t.Fatalf("working indicator did not advance jump frame:\nbefore: %q\nafter:  %q", before, after)
+	}
+	if cmd == nil {
+		t.Fatal("working indicator did not schedule its next jump frame")
+	}
+}
+
+func TestTeaModelStartsAgentStatusSpinner(t *testing.T) {
+	m := newTeaModel(nil, Options{RefreshAgentStatuses: func() (map[string]string, error) { return nil, nil }})
+	batch, ok := m.Init()().(tea.BatchMsg)
+	if !ok || len(batch) == 0 {
+		t.Fatalf("init command = %#v, want batch", batch)
+	}
+	if msg := batch[len(batch)-1](); reflect.TypeOf(msg) != reflect.TypeOf(spinner.TickMsg{}) {
+		t.Fatalf("last init message = %T, want spinner.TickMsg", msg)
 	}
 }
 
@@ -685,7 +713,7 @@ func TestSelectedRowUsesRailAndPreservesSourceColor(t *testing.T) {
 	if !strings.Contains(plain, "┃") {
 		t.Fatalf("selected row missing navigation rail:\n%q", got)
 	}
-	for _, want := range []string{"38;2;125;207;255", "38;2;158;206;106", herdrSourceIcon + " herdr", "herdr-plugin-sesh", "/tmp/herdr-plugin-sesh"} {
+	for _, want := range []string{"38;2;125;207;255", "38;2;224;175;104", herdrSourceIcon + " herdr", "herdr-plugin-sesh", "/tmp/herdr-plugin-sesh"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("selected row missing %q:\n%q", want, got)
 		}


### PR DESCRIPTION
## Summary

- align native-picker agent-state glyphs and Tokyo Night colors with Herdr's agents sidebar
- animate working workspaces with the Bubbles Jump spinner while status refresh remains active
- document the rendered status legend and add focused rendering, animation, and startup coverage

## Why

The picker used a separate static glyph and color mapping, so agent states did not visually match Herdr. The working state also rendered a fixed marker instead of an animated progress indicator.

## Validation

- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache mise exec -- just check`
- `mise exec -- just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the picker’s agent status glyphs and colors with Herdr’s sidebar and added an animated Jump spinner for “working” to improve clarity while statuses refresh.

- **New Features**
  - Animate “working” with `spinner.Jump` in list rows and preview title; starts ticking when status refresh is enabled.
  - Updated indicators: working=animated amber Jump, blocked=red ◉, idle=green ✓, done=teal ●; unknown=none.
  - Synced colors with the Tokyo Night palette and updated docs and tests for the new legend and animation.

<sup>Written for commit 2c614a06359e425f01b404b206b7e9a8b14176fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

