### PR TITLE
chore: Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report a reproducible problem with herdr-sesh
+title: "bug: "
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a bug.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include the command, configuration, and smallest sequence that reproduces the problem.
+      placeholder: |
+        1. Run `...`
+        2. Select `...`
+        3. See `...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include herdr-sesh and Herdr versions, operating system, and any relevant terminal or shell details.
+      placeholder: |
+        herdr-sesh version:
+        Herdr version:
+        OS:
+        Terminal/shell:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or additional context
+      description: Paste relevant output or attach screenshots. Remove secrets and other sensitive information first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an improvement to herdr-sesh
+title: "feat: "
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping improve herdr-sesh.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem or limitation are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you would like and how it should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative approaches you considered.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, screenshots, or related links that would help explain the request.
+


### PR DESCRIPTION
## Summary

- Add structured bug report and feature request forms
- Capture reproduction steps, environment details, proposed solutions, and supporting context
- Keep blank issues enabled for cases that do not fit the templates

## Testing

- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub issue templates for bug reports and feature requests in `herdr-sesh` to standardize submissions and speed up triage. Forms include fields for description, repro steps, environment, logs, and for problem, proposal, alternatives, context; default titles use bug: and feat:, and blank issues stay enabled.

<sup>Written for commit 0ec7763cd0af9c0fe13485b26f96fc022b92306f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

