### PR TITLE
feat(picker): add Ctrl+J/K navigation

### DIFF
--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -388,8 +388,11 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.chosen = true
 		}
 		return m, tea.Quit
-	case "up", "ctrl+p":
+	case "up", "ctrl+p", "ctrl+k":
 		if !m.listFocused {
+			if key.String() == "ctrl+k" {
+				return m.updateInput(msg)
+			}
 			return m, nil
 		}
 		if m.list.Selected == 0 {
@@ -397,7 +400,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.focusSmearActive = false
 		return m.moveSelection(-1)
-	case "down", "ctrl+n":
+	case "down", "ctrl+n", "ctrl+j":
 		if !m.listFocused {
 			return m.focusList()
 		}
@@ -495,7 +498,7 @@ func (m teaModel) View() tea.View {
 	}
 	lines = append(lines,
 		horizontalRule(width),
-		helpStyle.Render(fmt.Sprintf("enter select   ↑/↓ move   ctrl+r sort: %s   ctrl+u clear   esc close", sortMode)),
+		helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k move · ctrl+r %s · ctrl+u clear · esc close", sortMode)),
 		"",
 	)
 	for i, line := range lines {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -54,6 +54,40 @@ func TestTeaModelMovesSelection(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if current, ok := m.list.Current(); !ok || current.Name != "web" {
+		t.Fatalf("current = %#v ok=%v, want web", current, ok)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if current, ok := m.list.Current(); !ok || current.Name != "api" {
+		t.Fatalf("current = %#v ok=%v, want api", current, ok)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k move · ctrl+r workspace · ctrl+u clear · esc close") {
+		t.Fatalf("default-width view missing complete navigation help:\n%s", view)
+	}
+}
+
+func TestTeaModelCtrlKDeletesAfterFilterCursor(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api-web"}}, Options{})
+	m.input.SetValue("api-web")
+	m.input.SetCursor(3)
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+
+	if got := m.input.Value(); got != "api" {
+		t.Fatalf("input=%q, want %q", got, "api")
+	}
+}
+
 func TestTeaModelDownTransfersCursorFromFilterToList(t *testing.T) {
 	t.Setenv("HERDR_SESH_REDUCE_MOTION", "")
 	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
@@ -797,7 +831,7 @@ func TestTeaModelCyclesHerdrWorkspaceSortModes(t *testing.T) {
 	if got, want := sessionNames(m.list.All), []string{"configured", "third", "recent-directory", "first", "second"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("recent order=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r sort: recent") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r recent") {
 		t.Fatalf("view missing recent sort mode:\n%s", view)
 	}
 
@@ -817,7 +851,7 @@ func TestTeaModelStartsWithConfiguredWorkspaceSort(t *testing.T) {
 	if got, want := sessionNames(m.list.All), []string{"second", "first"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("initial order=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r sort: recent") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r recent") {
 		t.Fatalf("view missing recent sort mode:\n%s", view)
 	}
 }


### PR DESCRIPTION
## Summary

- add `Ctrl+J` and `Ctrl+K` navigation to the native picker
- preserve the filter input's existing `Ctrl+K` delete-after-cursor behavior
- simplify the picker help footer with dot-separated action groups
- add regressions for navigation, filter editing, sort-mode help, and default-width rendering

Closes #61