### PR TITLE
feat(picker): close Herdr workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sesh concepts map onto Herdr as follows:
 
 ## Requirements
 
-- [Herdr](https://herdr.dev/docs/installation/) 0.7.0 or newer
+- [Herdr](https://herdr.dev/docs/installation/) 0.8.0 or newer
 - Linux or macOS
 - Git and Go 1.26.4 or newer for Herdr's source-based plugin installation
 - Optional: `zoxide` for directory history and `eza` for the default preview

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 id = "fullerzz.sesh"
 name = "Sesh for Herdr"
 version = "0.6.0"
-min_herdr_version = "0.7.0"
+min_herdr_version = "0.8.0"
 description = "Sesh-style smart workspace/session manager for Herdr"
 platforms = ["linux", "macos"]
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -206,12 +206,6 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
 		pickOpts.CloseWorkspace = func(id string) error { return client.WorkspaceClose(ctx, id) }
-		pickOpts.RestoreWorkspaceFocus = func(closedID string) error {
-			if currentWorkspaceID == "" || currentWorkspaceID == closedID {
-				return nil
-			}
-			return client.WorkspaceFocus(ctx, currentWorkspaceID)
-		}
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -205,7 +205,16 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
-		pickOpts.CloseWorkspace = func(id string) error { return client.WorkspaceClose(ctx, id) }
+		pickOpts.CloseWorkspace = func(id string) error {
+			if err := client.WorkspaceClose(ctx, id); err != nil {
+				return err
+			}
+			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
+				a.warnf("could not prune workspace history: %v", err)
+			}
+			return nil
+		}
+		pickOpts.ReloadSessions = func() ([]model.Session, error) { return a.collect(ctx, cfg, "") }
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -202,9 +202,16 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		if historyErr != nil {
 			a.warnf("ignoring workspace history: %v", historyErr)
 		}
-		pickOpts.RecentWorkspaceIDs = append([]string{os.Getenv("HERDR_WORKSPACE_ID")}, history.Workspaces...)
+		currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
+		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
 		pickOpts.CloseWorkspace = func(id string) error { return client.WorkspaceClose(ctx, id) }
+		pickOpts.RestoreWorkspaceFocus = func(closedID string) error {
+			if currentWorkspaceID == "" || currentWorkspaceID == closedID {
+				return nil
+			}
+			return client.WorkspaceFocus(ctx, currentWorkspaceID)
+		}
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,7 +83,16 @@ func (a *App) loadConfig(path string) (config.Config, error) {
 }
 func (a *App) collect(ctx context.Context, cfg config.Config, target string) ([]model.Session, error) {
 	hs := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}
-	srcs := []sources.Source{ignoreSource{hs}, sources.ConfigSessions{Config: cfg}, sources.Zoxide{}}
+	return a.collectFrom(ctx, cfg, target, hs)
+}
+
+func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Config, target string) ([]model.Session, error) {
+	hs := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}
+	return a.collectFrom(ctx, cfg, target, ignoreSource{hs})
+}
+
+func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {
+	srcs := []sources.Source{herdrSource, sources.ConfigSessions{Config: cfg}, sources.Zoxide{}}
 	if target != "" {
 		srcs = append(srcs, sources.DirectPath{
 			Path:  target,
@@ -177,7 +186,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sessions, err := a.collect(ctx, cfg, "")
+	sessions, err := a.collectAllowUnavailableHerdr(ctx, cfg, "")
 	if err != nil {
 		return err
 	}
@@ -268,7 +277,7 @@ func (a *App) connect(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sessions, err := a.collect(ctx, cfg, target)
+	sessions, err := a.collectAllowUnavailableHerdr(ctx, cfg, target)
 	if err != nil {
 		return err
 	}
@@ -299,7 +308,7 @@ func (a *App) preview(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sessions, err := a.collect(ctx, cfg, target)
+	sessions, err := a.collectAllowUnavailableHerdr(ctx, cfg, target)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -204,6 +204,8 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	}
 	var selected model.Session
 	var ok bool
+	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
+	currentWorkspaceClosed := false
 	if *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf") {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
@@ -212,13 +214,13 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		if historyErr != nil {
 			a.warnf("ignoring workspace history: %v", historyErr)
 		}
-		currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
 		pickOpts.CloseWorkspace = func(closeCtx context.Context, id string) error {
 			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
 			}
+			currentWorkspaceClosed = currentWorkspaceClosed || id == currentWorkspaceID
 			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
 				a.warnf("could not prune workspace history: %v", err)
 			}
@@ -243,15 +245,21 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if err != nil || !ok {
 		return err
 	}
-	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 	res, err := connectpkg.Connect(ctx, herdr.NewCLIClient(), []model.Session{selected}, pickerTarget(selected), connectpkg.Options{
 		Namer: func(ctx context.Context, p string) string { return namer.Namer{}.Name(ctx, p, cfg.DirLength) },
 	})
 	if err != nil {
 		return err
 	}
-	a.recordWorkspaceSwitch(currentWorkspaceID, res.Session.WorkspaceID)
+	a.recordWorkspaceSwitch(pickerSwitchSource(currentWorkspaceID, currentWorkspaceClosed), res.Session.WorkspaceID)
 	return nil
+}
+
+func pickerSwitchSource(currentWorkspaceID string, currentWorkspaceClosed bool) string {
+	if currentWorkspaceClosed {
+		return ""
+	}
+	return currentWorkspaceID
 }
 
 func pickerTarget(s model.Session) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -194,6 +194,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		return a.printSessions(sessions, true)
 	}
 	pickOpts := pickerpkg.Options{
+		Context:               ctx,
 		Output:                a.Out,
 		Prompt:                cfg.TUI.Prompt,
 		Placeholder:           cfg.TUI.Placeholder,
@@ -214,8 +215,8 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
-		pickOpts.CloseWorkspace = func(id string) error {
-			if err := client.WorkspaceClose(ctx, id); err != nil {
+		pickOpts.CloseWorkspace = func(closeCtx context.Context, id string) error {
+			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
 			}
 			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
@@ -223,7 +224,9 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			}
 			return nil
 		}
-		pickOpts.ReloadSessions = func() ([]model.Session, error) { return a.collect(ctx, cfg, "") }
+		pickOpts.ReloadSessions = func(reloadCtx context.Context) ([]model.Session, error) {
+			return a.collect(reloadCtx, cfg, "")
+		}
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -204,6 +204,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		}
 		pickOpts.RecentWorkspaceIDs = append([]string{os.Getenv("HERDR_WORKSPACE_ID")}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
+		pickOpts.CloseWorkspace = func(id string) error { return client.WorkspaceClose(ctx, id) }
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
 			if err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -384,6 +384,29 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	}
 }
 
+func TestPickerSwitchDoesNotRestoreClosedCurrentWorkspace(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", d)
+	if err := state.SaveHistory(d, state.History{Workspaces: []string{"current", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RemoveWorkspace(d, "current"); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &App{Err: &bytes.Buffer{}}
+	a.recordWorkspaceSwitch(pickerSwitchSource("current", true), "target")
+
+	h, err := state.LoadHistory(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"target", "older"}
+	if !reflect.DeepEqual(h.Workspaces, want) {
+		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
+	}
+}
+
 func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {
 	t.Helper()
 	configureFakeSources(t, zoxideOutput)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -290,12 +290,20 @@ func TestCollectDirectPathUsesConfiguredDirLength(t *testing.T) {
 	cfg := config.Default()
 	cfg.DirLength = 2
 
-	sessions, err := (&App{}).collect(context.Background(), cfg, target)
+	sessions, err := (&App{}).collectAllowUnavailableHerdr(context.Background(), cfg, target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(sessions) != 1 || sessions[0].Name != filepath.Join("parent", "child") {
 		t.Fatalf("sessions = %#v", sessions)
+	}
+}
+
+func TestCollectPropagatesHerdrErrors(t *testing.T) {
+	configureFakeSources(t, "")
+
+	if _, err := (&App{}).collect(context.Background(), config.Default(), ""); err == nil {
+		t.Fatal("collect succeeded when Herdr workspace listing failed")
 	}
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -240,6 +240,10 @@ func (c *CLIClient) WorkspaceFocus(ctx context.Context, id string) error {
 	_, err := c.run(ctx, "workspace", "focus", id)
 	return err
 }
+func (c *CLIClient) WorkspaceClose(ctx context.Context, id string) error {
+	_, err := c.run(ctx, "workspace", "close", id)
+	return err
+}
 func (c *CLIClient) TabList(ctx context.Context, wid string) ([]Tab, error) {
 	args := []string{"tab", "list"}
 	if wid != "" {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -43,6 +43,18 @@ func TestCLIClientConstructsWorkspaceCreateNoFocus(t *testing.T) {
 	}
 }
 
+func TestCLIClientConstructsWorkspaceClose(t *testing.T) {
+	rr := &recRunner{}
+	c := &CLIClient{Bin: "/bin/herdr", Runner: rr}
+	if err := c.WorkspaceClose(context.Background(), "ws1"); err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{{"/bin/herdr", "workspace", "close", "ws1"}}
+	if !reflect.DeepEqual(rr.calls, want) {
+		t.Fatalf("got %#v want %#v", rr.calls, want)
+	}
+}
+
 func TestCLIClientDecodesWorkspaceListEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"workspaces":[{"workspace_id":"w1","label":"api","agent_status":"working"}]}}`)}}
 	got, err := c.WorkspaceList(context.Background())

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -116,6 +116,7 @@ type Options struct {
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
 	CloseWorkspace        func(string) error
+	ReloadSessions        func() ([]sessionmodel.Session, error)
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
 }
@@ -167,6 +168,7 @@ type teaModel struct {
 	recentWorkspaceIDs    []string
 	recentSort            bool
 	closeWorkspace        func(string) error
+	reloadSessions        func() ([]sessionmodel.Session, error)
 	closingWorkspaceID    string
 	closeError            string
 }
@@ -185,7 +187,9 @@ type agentStatusesMsg struct {
 
 type workspaceCloseMsg struct {
 	workspaceID string
-	err         error
+	sessions    []sessionmodel.Session
+	closeErr    error
+	reloadErr   error
 }
 
 type smearTickMsg struct{}
@@ -235,6 +239,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
 		recentSort:            opts.RecentWorkspaceSort,
 		closeWorkspace:        opts.CloseWorkspace,
+		reloadSessions:        opts.ReloadSessions,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -378,27 +383,38 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.closingWorkspaceID = ""
-		if closed.err != nil {
-			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.err)
+		if closed.closeErr != nil {
+			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
 			return m.refreshPreview()
 		}
 		selectedKey := ""
 		if current, currentOK := m.list.Current(); currentOK {
 			selectedKey = sessionmodel.Key(current)
 		}
-		remaining := m.list.All[:0]
-		for _, item := range m.list.All {
-			if item.Source != "herdr" || item.WorkspaceID != closed.workspaceID {
-				remaining = append(remaining, item)
+		if closed.reloadErr == nil && closed.sessions != nil {
+			m.workspaceOrder = herdrWorkspaceIDs(closed.sessions)
+			m.list.All = append(m.list.All[:0], closed.sessions...)
+			if m.recentSort {
+				sortHerdrWorkspaces(m.list.All, m.recentWorkspaceIDs)
 			}
+		} else {
+			remaining := m.list.All[:0]
+			for _, item := range m.list.All {
+				if item.Source != "herdr" || item.WorkspaceID != closed.workspaceID {
+					remaining = append(remaining, item)
+				}
+			}
+			m.list.All = remaining
 		}
-		m.list.All = remaining
 		m.list.Filter(m.list.Query)
 		for i, item := range m.list.Filtered {
 			if sessionmodel.Key(item) == selectedKey {
 				m.list.Selected = i
 				break
 			}
+		}
+		if closed.reloadErr != nil {
+			m.closeError = fmt.Sprintf("Workspace closed, but sessions could not be refreshed: %v", closed.reloadErr)
 		}
 		return m.refreshPreview()
 	}
@@ -481,12 +497,16 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	m.closeError = ""
 	m.previewKey = ""
 	m.preview = "Closing workspace..."
-	return m, closeWorkspaceCommand(m.closeWorkspace, current.WorkspaceID)
+	return m, closeWorkspaceCommand(m.closeWorkspace, m.reloadSessions, current.WorkspaceID)
 }
 
-func closeWorkspaceCommand(closeWorkspace func(string) error, workspaceID string) tea.Cmd {
+func closeWorkspaceCommand(closeWorkspace func(string) error, reloadSessions func() ([]sessionmodel.Session, error), workspaceID string) tea.Cmd {
 	return func() tea.Msg {
-		return workspaceCloseMsg{workspaceID: workspaceID, err: closeWorkspace(workspaceID)}
+		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(workspaceID)}
+		if msg.closeErr == nil && reloadSessions != nil {
+			msg.sessions, msg.reloadErr = reloadSessions()
+		}
+		return msg
 	}
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -115,6 +115,7 @@ type Options struct {
 	DefaultPreviewCommand string
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
+	CloseWorkspace        func(string) error
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
 }
@@ -165,6 +166,9 @@ type teaModel struct {
 	workspaceOrder        []string
 	recentWorkspaceIDs    []string
 	recentSort            bool
+	closeWorkspace        func(string) error
+	closingWorkspaceID    string
+	closeError            string
 }
 
 type previewMsg struct {
@@ -177,6 +181,11 @@ type statusRefreshTickMsg struct{}
 type agentStatusesMsg struct {
 	statuses map[string]string
 	err      error
+}
+
+type workspaceCloseMsg struct {
+	workspaceID string
+	err         error
 }
 
 type smearTickMsg struct{}
@@ -225,6 +234,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		workspaceOrder:        workspaceOrder,
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
 		recentSort:            opts.RecentWorkspaceSort,
+		closeWorkspace:        opts.CloseWorkspace,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -363,6 +373,35 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if closed, ok := msg.(workspaceCloseMsg); ok {
+		if closed.workspaceID != m.closingWorkspaceID {
+			return m, nil
+		}
+		m.closingWorkspaceID = ""
+		if closed.err != nil {
+			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.err)
+			return m.refreshPreview()
+		}
+		selectedKey := ""
+		if current, currentOK := m.list.Current(); currentOK {
+			selectedKey = sessionmodel.Key(current)
+		}
+		remaining := m.list.All[:0]
+		for _, item := range m.list.All {
+			if item.Source != "herdr" || item.WorkspaceID != closed.workspaceID {
+				remaining = append(remaining, item)
+			}
+		}
+		m.list.All = remaining
+		m.list.Filter(m.list.Query)
+		for i, item := range m.list.Filtered {
+			if sessionmodel.Key(item) == selectedKey {
+				m.list.Selected = i
+				break
+			}
+		}
+		return m.refreshPreview()
+	}
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width = size.Width
 		m.height = size.Height
@@ -379,11 +418,15 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m, previewCmd := m.refreshPreview()
 		return m, tea.Batch(cmd, previewCmd)
 	}
+	m.closeError = ""
 	switch key.String() {
 	case "ctrl+c", "esc":
 		return m, tea.Quit
 	case "enter":
 		if choice, ok := m.list.Current(); ok {
+			if choice.Source == "herdr" && choice.WorkspaceID == m.closingWorkspaceID {
+				return m, nil
+			}
 			m.choice = choice
 			m.chosen = true
 		}
@@ -417,6 +460,8 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(focusCmd, previewCmd)
 	case "ctrl+r":
 		return m.toggleWorkspaceSort()
+	case "ctrl+x":
+		return m.closeSelectedWorkspace()
 	case "right":
 		if m.listFocused {
 			return m.smearToInput()
@@ -424,6 +469,24 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		fallthrough
 	default:
 		return m.updateInput(msg)
+	}
+}
+
+func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
+	current, ok := m.list.Current()
+	if !ok || current.Source != "herdr" || current.WorkspaceID == "" || m.closeWorkspace == nil || m.closingWorkspaceID != "" {
+		return m, nil
+	}
+	m.closingWorkspaceID = current.WorkspaceID
+	m.closeError = ""
+	m.previewKey = ""
+	m.preview = "Closing workspace..."
+	return m, closeWorkspaceCommand(m.closeWorkspace, current.WorkspaceID)
+}
+
+func closeWorkspaceCommand(closeWorkspace func(string) error, workspaceID string) tea.Cmd {
+	return func() tea.Msg {
+		return workspaceCloseMsg{workspaceID: workspaceID, err: closeWorkspace(workspaceID)}
 	}
 }
 
@@ -496,9 +559,13 @@ func (m teaModel) View() tea.View {
 	if m.recentSort {
 		sortMode = "recent"
 	}
+	footer := helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k move · ctrl+x close · ctrl+r %s · esc exit", sortMode))
+	if m.closeError != "" {
+		footer = emptyStyle.Render(m.closeError)
+	}
 	lines = append(lines,
 		horizontalRule(width),
-		helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k move · ctrl+r %s · ctrl+u clear · esc close", sortMode)),
+		footer,
 		"",
 	)
 	for i, line := range lines {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -107,6 +107,7 @@ var (
 var renderPreview = previewpkg.Render
 
 type Options struct {
+	Context               context.Context
 	Output                io.Writer
 	Prompt                string
 	Placeholder           string
@@ -115,8 +116,8 @@ type Options struct {
 	DefaultPreviewCommand string
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
-	CloseWorkspace        func(string) error
-	ReloadSessions        func() ([]sessionmodel.Session, error)
+	CloseWorkspace        func(context.Context, string) error
+	ReloadSessions        func(context.Context) ([]sessionmodel.Session, error)
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
 }
@@ -161,16 +162,19 @@ type teaModel struct {
 	preview    string
 	previewKey string
 
-	defaultPreviewCommand string
-	showIcons             bool
-	refreshAgentStatuses  func() (map[string]string, error)
-	workspaceOrder        []string
-	recentWorkspaceIDs    []string
-	recentSort            bool
-	closeWorkspace        func(string) error
-	reloadSessions        func() ([]sessionmodel.Session, error)
-	closingWorkspaceID    string
-	closeError            string
+	defaultPreviewCommand   string
+	showIcons               bool
+	refreshAgentStatuses    func() (map[string]string, error)
+	workspaceOrder          []string
+	recentWorkspaceIDs      []string
+	recentSort              bool
+	closeWorkspace          func(context.Context, string) error
+	reloadSessions          func(context.Context) ([]sessionmodel.Session, error)
+	workspaceCloseContext   context.Context
+	closingWorkspaceID      string
+	cancelWorkspaceClose    context.CancelFunc
+	quitAfterWorkspaceClose bool
+	closeError              string
 }
 
 type previewMsg struct {
@@ -202,6 +206,10 @@ type smearPreset struct {
 }
 
 func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
+	closeContext := opts.Context
+	if closeContext == nil {
+		closeContext = context.Background()
+	}
 	workspaceOrder := herdrWorkspaceIDs(items)
 	if opts.RecentWorkspaceSort {
 		items = append([]sessionmodel.Session(nil), items...)
@@ -240,6 +248,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		recentSort:            opts.RecentWorkspaceSort,
 		closeWorkspace:        opts.CloseWorkspace,
 		reloadSessions:        opts.ReloadSessions,
+		workspaceCloseContext: closeContext,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -383,6 +392,11 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.closingWorkspaceID = ""
+		m.cancelWorkspaceClose = nil
+		if m.quitAfterWorkspaceClose {
+			m.quitAfterWorkspaceClose = false
+			return m, tea.Quit
+		}
 		if closed.closeErr != nil {
 			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
 			return m.refreshPreview()
@@ -438,6 +452,9 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch key.String() {
 	case "ctrl+c", "esc":
 		if m.closingWorkspaceID != "" {
+			m.quitAfterWorkspaceClose = true
+			m.cancelWorkspaceClose()
+			m.preview = "Cancelling workspace close..."
 			return m, nil
 		}
 		return m, tea.Quit
@@ -500,14 +517,23 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	m.closeError = ""
 	m.previewKey = ""
 	m.preview = "Closing workspace..."
-	return m, closeWorkspaceCommand(m.closeWorkspace, m.reloadSessions, current.WorkspaceID)
+	closeCtx, cancel := context.WithCancel(m.workspaceCloseContext)
+	m.cancelWorkspaceClose = cancel
+	return m, closeWorkspaceCommand(closeCtx, cancel, m.closeWorkspace, m.reloadSessions, current.WorkspaceID)
 }
 
-func closeWorkspaceCommand(closeWorkspace func(string) error, reloadSessions func() ([]sessionmodel.Session, error), workspaceID string) tea.Cmd {
+func closeWorkspaceCommand(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	closeWorkspace func(context.Context, string) error,
+	reloadSessions func(context.Context) ([]sessionmodel.Session, error),
+	workspaceID string,
+) tea.Cmd {
 	return func() tea.Msg {
-		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(workspaceID)}
+		defer cancel()
+		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(ctx, workspaceID)}
 		if msg.closeErr == nil && reloadSessions != nil {
-			msg.sessions, msg.reloadErr = reloadSessions()
+			msg.sessions, msg.reloadErr = reloadSessions(ctx)
 		}
 		return msg
 	}

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -437,12 +437,15 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.closeError = ""
 	switch key.String() {
 	case "ctrl+c", "esc":
+		if m.closingWorkspaceID != "" {
+			return m, nil
+		}
 		return m, tea.Quit
 	case "enter":
+		if m.closingWorkspaceID != "" {
+			return m, nil
+		}
 		if choice, ok := m.list.Current(); ok {
-			if choice.Source == "herdr" && choice.WorkspaceID == m.closingWorkspaceID {
-				return m, nil
-			}
 			m.choice = choice
 			m.chosen = true
 		}

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -116,6 +116,7 @@ type Options struct {
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
 	CloseWorkspace        func(string) error
+	RestoreWorkspaceFocus func(string) error
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
 }
@@ -167,6 +168,7 @@ type teaModel struct {
 	recentWorkspaceIDs    []string
 	recentSort            bool
 	closeWorkspace        func(string) error
+	restoreWorkspaceFocus func(string) error
 	closingWorkspaceID    string
 	closeError            string
 }
@@ -184,8 +186,9 @@ type agentStatusesMsg struct {
 }
 
 type workspaceCloseMsg struct {
-	workspaceID string
-	err         error
+	workspaceID     string
+	closeErr        error
+	restoreFocusErr error
 }
 
 type smearTickMsg struct{}
@@ -235,6 +238,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
 		recentSort:            opts.RecentWorkspaceSort,
 		closeWorkspace:        opts.CloseWorkspace,
+		restoreWorkspaceFocus: opts.RestoreWorkspaceFocus,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -378,9 +382,12 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.closingWorkspaceID = ""
-		if closed.err != nil {
-			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.err)
+		if closed.closeErr != nil {
+			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
 			return m.refreshPreview()
+		}
+		if closed.restoreFocusErr != nil {
+			m.closeError = fmt.Sprintf("Workspace closed, but failed to restore picker focus: %v", closed.restoreFocusErr)
 		}
 		selectedKey := ""
 		if current, currentOK := m.list.Current(); currentOK {
@@ -481,12 +488,16 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	m.closeError = ""
 	m.previewKey = ""
 	m.preview = "Closing workspace..."
-	return m, closeWorkspaceCommand(m.closeWorkspace, current.WorkspaceID)
+	return m, closeWorkspaceCommand(m.closeWorkspace, m.restoreWorkspaceFocus, current.WorkspaceID)
 }
 
-func closeWorkspaceCommand(closeWorkspace func(string) error, workspaceID string) tea.Cmd {
+func closeWorkspaceCommand(closeWorkspace, restoreWorkspaceFocus func(string) error, workspaceID string) tea.Cmd {
 	return func() tea.Msg {
-		return workspaceCloseMsg{workspaceID: workspaceID, err: closeWorkspace(workspaceID)}
+		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(workspaceID)}
+		if msg.closeErr == nil && restoreWorkspaceFocus != nil {
+			msg.restoreFocusErr = restoreWorkspaceFocus(workspaceID)
+		}
+		return msg
 	}
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -116,7 +116,6 @@ type Options struct {
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
 	CloseWorkspace        func(string) error
-	RestoreWorkspaceFocus func(string) error
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
 }
@@ -168,7 +167,6 @@ type teaModel struct {
 	recentWorkspaceIDs    []string
 	recentSort            bool
 	closeWorkspace        func(string) error
-	restoreWorkspaceFocus func(string) error
 	closingWorkspaceID    string
 	closeError            string
 }
@@ -186,9 +184,8 @@ type agentStatusesMsg struct {
 }
 
 type workspaceCloseMsg struct {
-	workspaceID     string
-	closeErr        error
-	restoreFocusErr error
+	workspaceID string
+	err         error
 }
 
 type smearTickMsg struct{}
@@ -238,7 +235,6 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
 		recentSort:            opts.RecentWorkspaceSort,
 		closeWorkspace:        opts.CloseWorkspace,
-		restoreWorkspaceFocus: opts.RestoreWorkspaceFocus,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
@@ -382,12 +378,9 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.closingWorkspaceID = ""
-		if closed.closeErr != nil {
-			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
+		if closed.err != nil {
+			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.err)
 			return m.refreshPreview()
-		}
-		if closed.restoreFocusErr != nil {
-			m.closeError = fmt.Sprintf("Workspace closed, but failed to restore picker focus: %v", closed.restoreFocusErr)
 		}
 		selectedKey := ""
 		if current, currentOK := m.list.Current(); currentOK {
@@ -488,16 +481,12 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	m.closeError = ""
 	m.previewKey = ""
 	m.preview = "Closing workspace..."
-	return m, closeWorkspaceCommand(m.closeWorkspace, m.restoreWorkspaceFocus, current.WorkspaceID)
+	return m, closeWorkspaceCommand(m.closeWorkspace, current.WorkspaceID)
 }
 
-func closeWorkspaceCommand(closeWorkspace, restoreWorkspaceFocus func(string) error, workspaceID string) tea.Cmd {
+func closeWorkspaceCommand(closeWorkspace func(string) error, workspaceID string) tea.Cmd {
 	return func() tea.Msg {
-		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(workspaceID)}
-		if msg.closeErr == nil && restoreWorkspaceFocus != nil {
-			msg.restoreFocusErr = restoreWorkspaceFocus(workspaceID)
-		}
-		return msg
+		return workspaceCloseMsg{workspaceID: workspaceID, err: closeWorkspace(workspaceID)}
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -131,6 +131,38 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 	}
 }
 
+func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		move bool
+	}{
+		{name: "enter another workspace", key: tea.KeyPressMsg{Code: tea.KeyEnter}, move: true},
+		{name: "escape", key: tea.KeyPressMsg{Code: tea.KeyEscape}},
+		{name: "control c", key: tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTeaModel([]model.Session{
+				{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+			}, Options{CloseWorkspace: func(string) error { return nil }})
+			updated, _ := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+			m = updated.(teaModel)
+			if tt.move {
+				m.list.Move(1)
+			}
+
+			updated, cmd := m.Update(tt.key)
+			m = updated.(teaModel)
+
+			if cmd != nil || m.chosen || m.closingWorkspaceID != "w1" {
+				t.Fatalf("pending close quit picker: cmd=%v chosen=%v closing=%q", cmd, m.chosen, m.closingWorkspaceID)
+			}
+		})
+	}
+}
+
 func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -159,6 +159,28 @@ func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+	}, Options{
+		CloseWorkspace: func(string) error { return nil },
+		ReloadSessions: func() ([]model.Session, error) { return nil, errors.New("workspace list failed") },
+	})
+
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(closeCmd())
+	m = updated.(teaModel)
+
+	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sessions=%v want %v", got, want)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "workspace list failed") {
+		t.Fatalf("view missing reload failure:\n%s", view)
+	}
+}
+
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -132,16 +132,11 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 }
 
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
-	restoredFocus := false
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
 		CloseWorkspace: func(string) error { return errors.New("close failed") },
-		RestoreWorkspaceFocus: func(string) error {
-			restoredFocus = true
-			return nil
-		},
 	})
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -160,33 +155,8 @@ func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	if len(m.list.All) != 2 {
 		t.Fatalf("workspace removed after close failure: %#v", m.list.All)
 	}
-	if restoredFocus {
-		t.Fatal("focus restored after close failure")
-	}
 	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "close failed") {
 		t.Fatalf("view missing close failure after selection and preview changed:\n%s", view)
-	}
-}
-
-func TestTeaModelCtrlXRemovesWorkspaceWhenFocusRestoreFails(t *testing.T) {
-	m := newTeaModel([]model.Session{
-		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
-		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
-	}, Options{
-		CloseWorkspace:        func(string) error { return nil },
-		RestoreWorkspaceFocus: func(string) error { return errors.New("focus failed") },
-	})
-
-	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
-	m = updated.(teaModel)
-	updated, _ = m.Update(cmd())
-	m = updated.(teaModel)
-
-	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("remaining sessions=%v want %v", got, want)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "focus failed") {
-		t.Fatalf("view missing focus restore failure:\n%s", view)
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -131,6 +131,34 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+	}, Options{
+		CloseWorkspace: func(string) error { return nil },
+		ReloadSessions: func() ([]model.Session, error) {
+			return []model.Session{
+				{Source: "config", Name: "api", Path: "/configured/api"},
+				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+			}, nil
+		},
+	})
+
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	m.list.Move(1)
+	updated, _ = m.Update(closeCmd())
+	m = updated.(teaModel)
+
+	if got, want := sessionNames(m.list.All), []string{"api", "web"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sessions=%v want %v", got, want)
+	}
+	if current, ok := m.list.Current(); !ok || current.Name != "web" {
+		t.Fatalf("current=%#v ok=%v, want web", current, ok)
+	}
+}
+
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -70,7 +71,7 @@ func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
 	if current, ok := m.list.Current(); !ok || current.Name != "api" {
 		t.Fatalf("current = %#v ok=%v, want api", current, ok)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k move · ctrl+r workspace · ctrl+u clear · esc close") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k move · ctrl+x close · ctrl+r workspace · esc exit") {
 		t.Fatalf("default-width view missing complete navigation help:\n%s", view)
 	}
 }
@@ -85,6 +86,108 @@ func TestTeaModelCtrlKDeletesAfterFilterCursor(t *testing.T) {
 
 	if got := m.input.Value(); got != "api" {
 		t.Fatalf("input=%q, want %q", got, "api")
+	}
+}
+
+func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
+	var closed string
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api-close", WorkspaceID: "w1"},
+		{Source: "config", Name: "api-selected"},
+		{Source: "herdr", Name: "api-other", WorkspaceID: "w2"},
+	}, Options{CloseWorkspace: func(id string) error {
+		closed = id
+		return nil
+	}})
+	m.list.Filter("api")
+	m, _ = m.refreshPreview()
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if cmd == nil {
+		t.Fatal("ctrl+x did not return a close command")
+	}
+	updated, enterCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(teaModel)
+	if enterCmd != nil || m.chosen {
+		t.Fatalf("closing workspace remained selectable: cmd=%v chosen=%v", enterCmd, m.chosen)
+	}
+	m.list.Move(1)
+	m, _ = m.refreshPreview()
+	updated, _ = m.Update(cmd())
+	m = updated.(teaModel)
+
+	if closed != "w1" {
+		t.Fatalf("closed workspace=%q, want w1", closed)
+	}
+	if got, want := sessionNames(m.list.All), []string{"api-selected", "api-other"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("remaining sessions=%v want %v", got, want)
+	}
+	if current, ok := m.list.Current(); !ok || current.Name != "api-selected" {
+		t.Fatalf("current=%#v ok=%v, want api-selected", current, ok)
+	}
+	if current, _ := m.list.Current(); m.previewKey != model.Key(current) {
+		t.Fatalf("preview key=%q, want selected session %q", m.previewKey, model.Key(current))
+	}
+}
+
+func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+	}, Options{
+		CloseWorkspace: func(string) error { return errors.New("close failed") },
+	})
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	m.list.Move(1)
+	m, _ = m.refreshPreview()
+	stalePreview := previewMsg{key: m.previewKey, text: "stale preview"}
+	updated, previewCmd := m.Update(cmd())
+	m = updated.(teaModel)
+	if m.preview == "Closing workspace..." {
+		t.Fatalf("failed close left stale preview: cmd=%v", previewCmd)
+	}
+	updated, _ = m.Update(stalePreview)
+	m = updated.(teaModel)
+
+	if len(m.list.All) != 2 {
+		t.Fatalf("workspace removed after close failure: %#v", m.list.All)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "close failed") {
+		t.Fatalf("view missing close failure after selection and preview changed:\n%s", view)
+	}
+}
+
+func TestTeaModelCtrlXRefreshesPreviewWhenCloseFails(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "herdr", Name: "api", WorkspaceID: "w1"}}, Options{
+		CloseWorkspace: func(string) error { return errors.New("close failed") },
+	})
+
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, previewCmd := m.Update(closeCmd())
+	m = updated.(teaModel)
+
+	if previewCmd == nil || m.preview == "Closing workspace..." {
+		t.Fatalf("failed close did not refresh preview: preview=%q cmd=%v", m.preview, previewCmd)
+	}
+}
+
+func TestTeaModelCtrlXIgnoresNonHerdrSession(t *testing.T) {
+	called := false
+	m := newTeaModel([]model.Session{{Source: "config", Name: "api"}}, Options{
+		CloseWorkspace: func(string) error {
+			called = true
+			return nil
+		},
+	})
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	_ = updated.(teaModel)
+	if cmd != nil || called {
+		t.Fatalf("non-Herdr ctrl+x returned cmd=%v called=%v", cmd, called)
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -132,11 +132,16 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 }
 
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
+	restoredFocus := false
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
 		CloseWorkspace: func(string) error { return errors.New("close failed") },
+		RestoreWorkspaceFocus: func(string) error {
+			restoredFocus = true
+			return nil
+		},
 	})
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -155,8 +160,33 @@ func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	if len(m.list.All) != 2 {
 		t.Fatalf("workspace removed after close failure: %#v", m.list.All)
 	}
+	if restoredFocus {
+		t.Fatal("focus restored after close failure")
+	}
 	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "close failed") {
 		t.Fatalf("view missing close failure after selection and preview changed:\n%s", view)
+	}
+}
+
+func TestTeaModelCtrlXRemovesWorkspaceWhenFocusRestoreFails(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+	}, Options{
+		CloseWorkspace:        func(string) error { return nil },
+		RestoreWorkspaceFocus: func(string) error { return errors.New("focus failed") },
+	})
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(cmd())
+	m = updated.(teaModel)
+
+	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("remaining sessions=%v want %v", got, want)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "focus failed") {
+		t.Fatalf("view missing focus restore failure:\n%s", view)
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -95,7 +95,7 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 		{Source: "herdr", Name: "api-close", WorkspaceID: "w1"},
 		{Source: "config", Name: "api-selected"},
 		{Source: "herdr", Name: "api-other", WorkspaceID: "w2"},
-	}, Options{CloseWorkspace: func(id string) error {
+	}, Options{CloseWorkspace: func(_ context.Context, id string) error {
 		closed = id
 		return nil
 	}})
@@ -146,7 +146,7 @@ func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
 			m := newTeaModel([]model.Session{
 				{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
-			}, Options{CloseWorkspace: func(string) error { return nil }})
+			}, Options{CloseWorkspace: func(context.Context, string) error { return nil }})
 			updated, _ := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 			m = updated.(teaModel)
 			if tt.move {
@@ -163,13 +163,54 @@ func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlCCancelsWorkspaceCloseAndQuitsAfterResult(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{name: "close", opts: Options{CloseWorkspace: func(ctx context.Context, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}}},
+		{name: "reload", opts: Options{
+			CloseWorkspace: func(context.Context, string) error { return nil },
+			ReloadSessions: func(ctx context.Context) ([]model.Session, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTeaModel([]model.Session{
+				{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+			}, tt.opts)
+			updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+			m = updated.(teaModel)
+			updated, _ = m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+			m = updated.(teaModel)
+
+			updated, quitCmd := m.Update(closeCmd())
+			_ = updated.(teaModel)
+			if quitCmd == nil {
+				t.Fatal("picker did not quit after cancelled close returned")
+			}
+			msg := quitCmd()
+			if _, ok := msg.(tea.QuitMsg); !ok {
+				t.Fatalf("command returned %T, want tea.QuitMsg", msg)
+			}
+		})
+	}
+}
+
 func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
-		CloseWorkspace: func(string) error { return nil },
-		ReloadSessions: func() ([]model.Session, error) {
+		CloseWorkspace: func(context.Context, string) error { return nil },
+		ReloadSessions: func(context.Context) ([]model.Session, error) {
 			return []model.Session{
 				{Source: "config", Name: "api", Path: "/configured/api"},
 				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
@@ -196,8 +237,8 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
-		CloseWorkspace: func(string) error { return nil },
-		ReloadSessions: func() ([]model.Session, error) { return nil, errors.New("workspace list failed") },
+		CloseWorkspace: func(context.Context, string) error { return nil },
+		ReloadSessions: func(context.Context) ([]model.Session, error) { return nil, errors.New("workspace list failed") },
 	})
 
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -218,7 +259,7 @@ func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
-		CloseWorkspace: func(string) error { return errors.New("close failed") },
+		CloseWorkspace: func(context.Context, string) error { return errors.New("close failed") },
 	})
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -244,7 +285,7 @@ func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 
 func TestTeaModelCtrlXRefreshesPreviewWhenCloseFails(t *testing.T) {
 	m := newTeaModel([]model.Session{{Source: "herdr", Name: "api", WorkspaceID: "w1"}}, Options{
-		CloseWorkspace: func(string) error { return errors.New("close failed") },
+		CloseWorkspace: func(context.Context, string) error { return errors.New("close failed") },
 	})
 
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -260,7 +301,7 @@ func TestTeaModelCtrlXRefreshesPreviewWhenCloseFails(t *testing.T) {
 func TestTeaModelCtrlXIgnoresNonHerdrSession(t *testing.T) {
 	called := false
 	m := newTeaModel([]model.Session{{Source: "config", Name: "api"}}, Options{
-		CloseWorkspace: func(string) error {
+		CloseWorkspace: func(context.Context, string) error {
 			called = true
 			return nil
 		},

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -64,6 +64,24 @@ func RecordSwitch(dir, fromWorkspaceID, toWorkspaceID string) error {
 	return SaveHistory(dir, h)
 }
 
+func RemoveWorkspace(dir, workspaceID string) error {
+	if workspaceID == "" {
+		return nil
+	}
+	h, err := loadHistoryForWrite(dir)
+	if err != nil {
+		return err
+	}
+	workspaces := h.Workspaces[:0]
+	for _, id := range h.Workspaces {
+		if id != workspaceID {
+			workspaces = append(workspaces, id)
+		}
+	}
+	h.Workspaces = workspaces
+	return SaveHistory(dir, h)
+}
+
 func loadHistoryForWrite(dir string) (History, error) {
 	h, err := LoadHistory(dir)
 	if err == nil {

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -100,6 +100,24 @@ func TestRecordSwitchRotatesPreviousWorkspace(t *testing.T) {
 	}
 }
 
+func TestRemoveWorkspacePrunesHistory(t *testing.T) {
+	d := t.TempDir()
+	if err := SaveHistory(d, History{Workspaces: []string{"current", "closed", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveWorkspace(d, "closed"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := LoadHistory(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"current", "older"}
+	if !reflect.DeepEqual(h.Workspaces, want) {
+		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
+	}
+}
+
 func TestRecordSwitchDeduplicatesAndCapsHistory(t *testing.T) {
 	d := t.TempDir()
 	workspaces := []string{"target", "from"}


### PR DESCRIPTION
## Summary

- add `ctrl+x` support to close the selected Herdr workspace from the native picker
- keep the picker open after successful closes, preserve the current selection, and surface close failures
- require Herdr 0.8.0 and rely on its corrected background-workspace closing behavior instead of refocusing manually

Closes #65

## Validation

- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `herdr --version` (`herdr 0.8.0`)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

