### PR TITLE
chore: configure Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This repository has no persistent services or tunnels to restore.
+echo "herdr-sesh orb ready."

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Setting up herdr-sesh development tools..."
+
+mise_bin="$HOME/.local/bin/mise"
+if [[ ! -x "$mise_bin" ]]; then
+  echo "Installing mise..."
+  install_script="$(mktemp)"
+  trap 'rm -f "$install_script"' EXIT
+  wget -qO "$install_script" https://mise.run
+  bash "$install_script"
+  rm -f "$install_script"
+  trap - EXIT
+fi
+
+profile_marker="# herdr-sesh mise environment"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<'EOF'
+
+# herdr-sesh mise environment
+if [[ -x "$HOME/.local/bin/mise" ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+  eval "$("$HOME/.local/bin/mise" activate bash)"
+fi
+EOF
+fi
+
+export PATH="$HOME/.local/bin:$PATH"
+eval "$("$mise_bin" activate bash)"
+
+echo "Installing tools pinned in mise.toml..."
+"$mise_bin" trust --yes mise.toml
+"$mise_bin" install --yes
+
+echo "Downloading Go modules..."
+"$mise_bin" exec -- go mod download
+
+echo "Orb setup complete."

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
 echo "Setting up herdr-sesh development tools..."
 
+mise_version="2026.8.2"
+mise_archive_sha256="febda574ac4e036bf91e1ef9d33ec5e24dbfad6839eb0defa6abc12125186b74"
 mise_bin="$HOME/.local/bin/mise"
-if [[ ! -x "$mise_bin" ]]; then
-  echo "Installing mise..."
-  install_script="$(mktemp)"
-  trap 'rm -f "$install_script"' EXIT
-  wget -qO "$install_script" https://mise.run
-  bash "$install_script"
-  rm -f "$install_script"
+installed_mise_version=""
+if [[ -x "$mise_bin" ]]; then
+  installed_mise_version="$("$mise_bin" --version 2>/dev/null | awk '{print $1}')" || true
+fi
+if [[ "$installed_mise_version" != "$mise_version" ]]; then
+  echo "Installing mise ${mise_version}..."
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' EXIT
+  archive="$temp_dir/mise.tar.gz"
+  wget -qO "$archive" \
+    "https://github.com/jdx/mise/releases/download/v${mise_version}/mise-v${mise_version}-linux-x64.tar.gz"
+  printf '%s  %s\n' "$mise_archive_sha256" "$archive" | sha256sum -c -
+  tar -xzf "$archive" -C "$temp_dir" mise/bin/mise
+  mkdir -p "$(dirname -- "$mise_bin")"
+  install -m 0755 "$temp_dir/mise/bin/mise" "$mise_bin"
+  rm -rf "$temp_dir"
   trap - EXIT
 fi
 


### PR DESCRIPTION
## Summary

- add executable Amp orb setup and resume lifecycle scripts
- install and persist the repository's mise-based development environment
- pin and checksum-verify the mise bootstrap for reproducible fresh and cached orbs

## Validation

- ran .agents/setup twice to verify idempotency
- tested cold installation with an empty temporary home
- tested replacement of a stale mise installation
- verified setup from outside the repository working directory
- verified tools from a clean non-interactive login shell
- ran just test (145 tests passed)
- ran just build and CLI smoke checks
- timed .agents/resume under 10 seconds

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

