### PR TITLE
feat: show last workspace in picker

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,7 @@ the state directory.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 | `default_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press `ctrl+r` to switch modes while the picker is open. |
+| `show_last_workspace` | Shows the workspace targeted by `herdr-sesh last` in the picker footer. The default is `true`; set it to `false` to disable the feature. |
 | `show_last_workspace_path` | Shows the Herdr workspace working directory beside the last workspace name. The default is `true`; set it to `false` to show only the workspace name. |
 
 Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
@@ -131,6 +132,7 @@ show_icons = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
 default_sort = "recent"
+show_last_workspace = true
 show_last_workspace_path = false
 
 [default_session]

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,7 @@ the state directory.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 | `default_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press `ctrl+r` to switch modes while the picker is open. |
+| `show_last_workspace_path` | Shows the Herdr workspace working directory beside the last workspace name. The default is `true`; set it to `false` to show only the workspace name. |
 
 Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
 
@@ -130,6 +131,7 @@ show_icons = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
 default_sort = "recent"
+show_last_workspace_path = false
 
 [default_session]
 startup_command = "git status"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -244,6 +244,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		Prompt:                cfg.TUI.Prompt,
 		Placeholder:           cfg.TUI.Placeholder,
 		ShowIcons:             cfg.TUI.ShowIcons,
+		HideLastWorkspacePath: !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:        cfg.SeparatorAware,
 		DefaultPreviewCommand: cfg.DefaultSessionConfig.PreviewCommand,
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,13 +91,23 @@ func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Confi
 	return a.collectFrom(ctx, cfg, target, ignoreSource{hs})
 }
 
-func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error, error) {
+type pickerCollection struct {
+	Sessions        []model.Session
+	HerdrWorkspaces []model.Session
+	// HerdrErr reports a failed Herdr workspace listing that the merge
+	// tolerated; callers must surface it or the picker looks empty for no
+	// visible reason.
+	HerdrErr error
+}
+
+func (a *App) collectPicker(ctx context.Context, cfg config.Config) (pickerCollection, error) {
 	herdrSource := &capturingSource{Source: sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}}
 	sessions, err := a.collectFrom(ctx, cfg, "", herdrSource)
-	if herdrSource.err != nil {
-		return sessions, nil, herdrSource.err, err
+	col := pickerCollection{Sessions: sessions, HerdrErr: herdrSource.err}
+	if herdrSource.err == nil {
+		col.HerdrWorkspaces = herdrSource.sessions.Ordered()
 	}
-	return sessions, herdrSource.sessions.Ordered(), nil, err
+	return col, err
 }
 
 func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {
@@ -215,7 +225,12 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if useFZF || *jsonOut {
 		sessions, err = a.collectAllowUnavailableHerdr(ctx, cfg, "")
 	} else {
-		sessions, herdrWorkspaces, _, err = a.collectPicker(ctx, cfg)
+		var col pickerCollection
+		col, err = a.collectPicker(ctx, cfg)
+		sessions, herdrWorkspaces = col.Sessions, col.HerdrWorkspaces
+		if col.HerdrErr != nil {
+			a.warnf("herdr workspaces unavailable: %v", col.HerdrErr)
+		}
 	}
 	if err != nil {
 		return err
@@ -253,39 +268,23 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		}
 		pickOpts.LastWorkspaceID = lastWorkspaceID
 		pickOpts.LastWorkspaceUnknown = lastWorkspaceErr != nil
+		// Warnings raised while the alt-screen TUI owns the terminal would be
+		// overwritten and lost; buffer them and flush after the picker exits.
+		var deferredWarnings []string
+		deferWarn := func(format string, args ...any) {
+			deferredWarnings = append(deferredWarnings, fmt.Sprintf(format, args...))
+		}
 		pickOpts.CloseWorkspace = func(closeCtx context.Context, id string) error {
 			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
 			}
 			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
-				a.warnf("could not prune workspace history: %v", err)
+				deferWarn("could not prune workspace history: %v", err)
 			}
 			return nil
 		}
 		pickOpts.ReloadPicker = func(reloadCtx context.Context) (pickerpkg.ReloadResult, error) {
-			reloaded, workspaces, herdrErr, reloadErr := a.collectPicker(reloadCtx, cfg)
-			if reloadErr == nil {
-				reloadErr = herdrErr
-			}
-			focusedPane, focusErr := client.PaneFocused(reloadCtx)
-			pickerWorkspaceID = focusedPane.WorkspaceID
-			if focusErr == nil && pickerWorkspaceID == "" {
-				focusErr = errors.New("focused pane has no workspace ID")
-			}
-			lastID, _, lastErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), pickerWorkspaceID)
-			if focusErr != nil {
-				pickerWorkspaceID = ""
-				lastErr = fmt.Errorf("find focused workspace after close: %w", focusErr)
-			}
-			if lastErr != nil {
-				a.warnf("could not determine last workspace: %v", lastErr)
-			}
-			return pickerpkg.ReloadResult{
-				Sessions:             reloaded,
-				HerdrWorkspaces:      workspaces,
-				LastWorkspaceID:      lastID,
-				LastWorkspaceUnknown: lastErr != nil,
-			}, reloadErr
+			return a.reloadPickerState(reloadCtx, cfg, client, &pickerWorkspaceID, deferWarn)
 		}
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
@@ -299,6 +298,9 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			return statuses, nil
 		}
 		selected, ok, err = pickerpkg.Run(sessions, pickOpts)
+		for _, warning := range deferredWarnings {
+			a.warnf("%s", warning)
+		}
 	}
 	if err != nil || !ok {
 		return err
@@ -311,6 +313,37 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	}
 	a.recordWorkspaceSwitch(pickerWorkspaceID, res.Session.WorkspaceID)
 	return nil
+}
+
+// reloadPickerState re-collects picker sessions after a workspace close and
+// re-resolves which workspace hosts the picker, since the close may have
+// destroyed the workspace that launched it. On focus failure
+// pickerWorkspaceID is cleared so the eventual switch is recorded without a
+// stale "from" workspace.
+func (a *App) reloadPickerState(ctx context.Context, cfg config.Config, client *herdr.CLIClient, pickerWorkspaceID *string, warnf func(string, ...any)) (pickerpkg.ReloadResult, error) {
+	col, reloadErr := a.collectPicker(ctx, cfg)
+	if reloadErr == nil {
+		reloadErr = col.HerdrErr
+	}
+	focusedPane, focusErr := client.PaneFocused(ctx)
+	*pickerWorkspaceID = focusedPane.WorkspaceID
+	if focusErr == nil && *pickerWorkspaceID == "" {
+		focusErr = errors.New("focused pane has no workspace ID")
+	}
+	lastID, _, lastErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), *pickerWorkspaceID)
+	if focusErr != nil {
+		*pickerWorkspaceID = ""
+		lastErr = fmt.Errorf("find focused workspace after close: %w", focusErr)
+	}
+	if lastErr != nil {
+		warnf("could not determine last workspace: %v", lastErr)
+	}
+	return pickerpkg.ReloadResult{
+		Sessions:             col.Sessions,
+		HerdrWorkspaces:      col.HerdrWorkspaces,
+		LastWorkspaceID:      lastID,
+		LastWorkspaceUnknown: lastErr != nil,
+	}, reloadErr
 }
 
 func pickerTarget(s model.Session) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,11 +93,14 @@ func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Confi
 
 func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error, error) {
 	herdrSessions, herdrErr := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}.List(ctx)
+	var workspaces []model.Session
 	if herdrErr != nil {
 		herdrSessions = model.NewSessions()
+	} else {
+		workspaces = herdrSessions.Ordered()
 	}
 	sessions, err := a.collectFrom(ctx, cfg, "", loadedSource{name: "herdr", sessions: herdrSessions})
-	return sessions, herdrSessions.Ordered(), herdrErr, err
+	return sessions, workspaces, herdrErr, err
 }
 
 func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,6 +91,15 @@ func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Confi
 	return a.collectFrom(ctx, cfg, target, ignoreSource{hs})
 }
 
+func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error) {
+	herdrSessions, err := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}.List(ctx)
+	if err != nil {
+		herdrSessions = model.NewSessions()
+	}
+	sessions, err := a.collectFrom(ctx, cfg, "", loadedSource{name: "herdr", sessions: herdrSessions})
+	return sessions, herdrSessions.Ordered(), err
+}
+
 func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {
 	srcs := []sources.Source{herdrSource, sources.ConfigSessions{Config: cfg}, sources.Zoxide{}}
 	if target != "" {
@@ -116,6 +125,15 @@ func (i ignoreSource) List(ctx context.Context) (model.Sessions, error) {
 	}
 	return ss, nil
 }
+
+type loadedSource struct {
+	name     string
+	sessions model.Sessions
+}
+
+func (s loadedSource) Name() string { return s.name }
+
+func (s loadedSource) List(context.Context) (model.Sessions, error) { return s.sessions, nil }
 
 func (a *App) list(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
@@ -186,7 +204,13 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sessions, err := a.collectAllowUnavailableHerdr(ctx, cfg, "")
+	useFZF := *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf")
+	var sessions, herdrWorkspaces []model.Session
+	if useFZF || *jsonOut {
+		sessions, err = a.collectAllowUnavailableHerdr(ctx, cfg, "")
+	} else {
+		sessions, herdrWorkspaces, err = a.collectPicker(ctx, cfg)
+	}
 	if err != nil {
 		return err
 	}
@@ -206,7 +230,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	var ok bool
 	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
 	currentWorkspaceClosed := false
-	if *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf") {
+	if useFZF {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
 		client := herdr.NewCLIClient()
@@ -216,6 +240,13 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		}
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
+		pickOpts.HerdrWorkspaces = herdrWorkspaces
+		lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), currentWorkspaceID)
+		if lastWorkspaceErr != nil {
+			a.warnf("could not determine last workspace: %v", lastWorkspaceErr)
+		}
+		pickOpts.LastWorkspaceID = lastWorkspaceID
+		pickOpts.LastWorkspaceUnknown = lastWorkspaceErr != nil
 		pickOpts.CloseWorkspace = func(closeCtx context.Context, id string) error {
 			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
@@ -226,8 +257,24 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			}
 			return nil
 		}
-		pickOpts.ReloadSessions = func(reloadCtx context.Context) ([]model.Session, error) {
-			return a.collect(reloadCtx, cfg, "")
+		pickOpts.ReloadPicker = func(reloadCtx context.Context) (pickerpkg.ReloadResult, error) {
+			reloaded, workspaces, reloadErr := a.collectPicker(reloadCtx, cfg)
+			lastID, _, lastErr := pickerLastWorkspace(
+				reloadCtx,
+				client,
+				os.Getenv("HERDR_PLUGIN_STATE_DIR"),
+				currentWorkspaceID,
+				currentWorkspaceClosed,
+			)
+			if lastErr != nil {
+				a.warnf("could not determine last workspace: %v", lastErr)
+			}
+			return pickerpkg.ReloadResult{
+				Sessions:             reloaded,
+				HerdrWorkspaces:      workspaces,
+				LastWorkspaceID:      lastID,
+				LastWorkspaceUnknown: lastErr != nil,
+			}, reloadErr
 		}
 		pickOpts.RefreshAgentStatuses = func() (map[string]string, error) {
 			workspaces, err := client.WorkspaceList(ctx)
@@ -379,10 +426,7 @@ func gitRoot(ctx context.Context, dir string) (string, error) {
 func (a *App) last(ctx context.Context, _ []string) error {
 	stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
 	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
-	id, ok, err := state.Previous(stateDir, currentWorkspaceID)
-	if currentWorkspaceID == "" {
-		id, ok, err = state.Last(stateDir)
-	}
+	id, ok, err := lastWorkspace(stateDir, currentWorkspaceID)
 	if err != nil {
 		return err
 	}
@@ -396,6 +440,37 @@ func (a *App) last(ctx context.Context, _ []string) error {
 		a.warnf("could not record workspace history: %v", err)
 	}
 	return nil
+}
+
+func lastWorkspace(stateDir, currentWorkspaceID string) (string, bool, error) {
+	if currentWorkspaceID == "" {
+		return state.Last(stateDir)
+	}
+	return state.Previous(stateDir, currentWorkspaceID)
+}
+
+type currentPaneClient interface {
+	PaneCurrent(context.Context) (herdr.Pane, error)
+}
+
+func pickerLastWorkspace(
+	ctx context.Context,
+	client currentPaneClient,
+	stateDir, launchWorkspaceID string,
+	launchWorkspaceClosed bool,
+) (string, bool, error) {
+	currentWorkspaceID := launchWorkspaceID
+	if launchWorkspaceClosed {
+		pane, err := client.PaneCurrent(ctx)
+		if err != nil {
+			return "", false, fmt.Errorf("find focused workspace after close: %w", err)
+		}
+		if pane.WorkspaceID == "" {
+			return "", false, errors.New("focused pane has no workspace ID")
+		}
+		currentWorkspaceID = pane.WorkspaceID
+	}
+	return lastWorkspace(stateDir, currentWorkspaceID)
 }
 
 func (a *App) recordWorkspaceSwitch(fromWorkspaceID, toWorkspaceID string) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -244,6 +244,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		Prompt:                cfg.TUI.Prompt,
 		Placeholder:           cfg.TUI.Placeholder,
 		ShowIcons:             cfg.TUI.ShowIcons,
+		HideLastWorkspace:     !cfg.TUI.ShowLastWorkspace,
 		HideLastWorkspacePath: !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:        cfg.SeparatorAware,
 		DefaultPreviewCommand: cfg.DefaultSessionConfig.PreviewCommand,
@@ -262,13 +263,15 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		}
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
-		pickOpts.HerdrWorkspaces = herdrWorkspaces
-		lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), currentWorkspaceID)
-		if lastWorkspaceErr != nil {
-			a.warnf("could not determine last workspace: %v", lastWorkspaceErr)
+		if cfg.TUI.ShowLastWorkspace {
+			pickOpts.HerdrWorkspaces = herdrWorkspaces
+			lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), currentWorkspaceID)
+			if lastWorkspaceErr != nil {
+				a.warnf("could not determine last workspace: %v", lastWorkspaceErr)
+			}
+			pickOpts.LastWorkspaceID = lastWorkspaceID
+			pickOpts.LastWorkspaceUnknown = lastWorkspaceErr != nil
 		}
-		pickOpts.LastWorkspaceID = lastWorkspaceID
-		pickOpts.LastWorkspaceUnknown = lastWorkspaceErr != nil
 		// Warnings raised while the alt-screen TUI owns the terminal would be
 		// overwritten and lost; buffer them and flush after the picker exits.
 		var deferredWarnings []string
@@ -331,10 +334,18 @@ func (a *App) reloadPickerState(ctx context.Context, cfg config.Config, client *
 	if focusErr == nil && *pickerWorkspaceID == "" {
 		focusErr = errors.New("focused pane has no workspace ID")
 	}
-	lastID, _, lastErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), *pickerWorkspaceID)
+	var lastID string
+	var lastErr error
+	if cfg.TUI.ShowLastWorkspace {
+		lastID, _, lastErr = lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), *pickerWorkspaceID)
+	}
 	if focusErr != nil {
 		*pickerWorkspaceID = ""
-		lastErr = fmt.Errorf("find focused workspace after close: %w", focusErr)
+		if cfg.TUI.ShowLastWorkspace {
+			lastErr = fmt.Errorf("find focused workspace after close: %w", focusErr)
+		} else {
+			warnf("could not determine picker workspace after close: %v", focusErr)
+		}
 	}
 	if lastErr != nil {
 		warnf("could not determine last workspace: %v", lastErr)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,13 +91,13 @@ func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Confi
 	return a.collectFrom(ctx, cfg, target, ignoreSource{hs})
 }
 
-func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error) {
-	herdrSessions, err := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}.List(ctx)
-	if err != nil {
+func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error, error) {
+	herdrSessions, herdrErr := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}.List(ctx)
+	if herdrErr != nil {
 		herdrSessions = model.NewSessions()
 	}
 	sessions, err := a.collectFrom(ctx, cfg, "", loadedSource{name: "herdr", sessions: herdrSessions})
-	return sessions, herdrSessions.Ordered(), err
+	return sessions, herdrSessions.Ordered(), herdrErr, err
 }
 
 func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {
@@ -209,7 +209,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if useFZF || *jsonOut {
 		sessions, err = a.collectAllowUnavailableHerdr(ctx, cfg, "")
 	} else {
-		sessions, herdrWorkspaces, err = a.collectPicker(ctx, cfg)
+		sessions, herdrWorkspaces, _, err = a.collectPicker(ctx, cfg)
 	}
 	if err != nil {
 		return err
@@ -258,7 +258,10 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			return nil
 		}
 		pickOpts.ReloadPicker = func(reloadCtx context.Context) (pickerpkg.ReloadResult, error) {
-			reloaded, workspaces, reloadErr := a.collectPicker(reloadCtx, cfg)
+			reloaded, workspaces, herdrErr, reloadErr := a.collectPicker(reloadCtx, cfg)
+			if reloadErr == nil {
+				reloadErr = herdrErr
+			}
 			lastID, _, lastErr := pickerLastWorkspace(
 				reloadCtx,
 				client,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -92,15 +92,12 @@ func (a *App) collectAllowUnavailableHerdr(ctx context.Context, cfg config.Confi
 }
 
 func (a *App) collectPicker(ctx context.Context, cfg config.Config) ([]model.Session, []model.Session, error, error) {
-	herdrSessions, herdrErr := sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}.List(ctx)
-	var workspaces []model.Session
-	if herdrErr != nil {
-		herdrSessions = model.NewSessions()
-	} else {
-		workspaces = herdrSessions.Ordered()
+	herdrSource := &capturingSource{Source: sources.HerdrWorkspaces{Client: herdr.NewCLIClient()}}
+	sessions, err := a.collectFrom(ctx, cfg, "", herdrSource)
+	if herdrSource.err != nil {
+		return sessions, nil, herdrSource.err, err
 	}
-	sessions, err := a.collectFrom(ctx, cfg, "", loadedSource{name: "herdr", sessions: herdrSessions})
-	return sessions, workspaces, herdrErr, err
+	return sessions, herdrSource.sessions.Ordered(), nil, err
 }
 
 func (a *App) collectFrom(ctx context.Context, cfg config.Config, target string, herdrSource sources.Source) ([]model.Session, error) {
@@ -129,14 +126,20 @@ func (i ignoreSource) List(ctx context.Context) (model.Sessions, error) {
 	return ss, nil
 }
 
-type loadedSource struct {
-	name     string
+type capturingSource struct {
+	sources.Source
+
 	sessions model.Sessions
+	err      error
 }
 
-func (s loadedSource) Name() string { return s.name }
-
-func (s loadedSource) List(context.Context) (model.Sessions, error) { return s.sessions, nil }
+func (s *capturingSource) List(ctx context.Context) (model.Sessions, error) {
+	s.sessions, s.err = s.Source.List(ctx)
+	if s.err != nil {
+		return model.NewSessions(), nil
+	}
+	return s.sessions, nil
+}
 
 func (a *App) list(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
@@ -232,7 +235,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	var selected model.Session
 	var ok bool
 	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
-	currentWorkspaceClosed := false
+	pickerWorkspaceID := currentWorkspaceID
 	if useFZF {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
@@ -254,7 +257,6 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
 			}
-			currentWorkspaceClosed = currentWorkspaceClosed || id == currentWorkspaceID
 			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
 				a.warnf("could not prune workspace history: %v", err)
 			}
@@ -265,13 +267,16 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			if reloadErr == nil {
 				reloadErr = herdrErr
 			}
-			lastID, _, lastErr := pickerLastWorkspace(
-				reloadCtx,
-				client,
-				os.Getenv("HERDR_PLUGIN_STATE_DIR"),
-				currentWorkspaceID,
-				currentWorkspaceClosed,
-			)
+			focusedPane, focusErr := client.PaneFocused(reloadCtx)
+			pickerWorkspaceID = focusedPane.WorkspaceID
+			if focusErr == nil && pickerWorkspaceID == "" {
+				focusErr = errors.New("focused pane has no workspace ID")
+			}
+			lastID, _, lastErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), pickerWorkspaceID)
+			if focusErr != nil {
+				pickerWorkspaceID = ""
+				lastErr = fmt.Errorf("find focused workspace after close: %w", focusErr)
+			}
 			if lastErr != nil {
 				a.warnf("could not determine last workspace: %v", lastErr)
 			}
@@ -304,15 +309,8 @@ func (a *App) picker(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	a.recordWorkspaceSwitch(pickerSwitchSource(currentWorkspaceID, currentWorkspaceClosed), res.Session.WorkspaceID)
+	a.recordWorkspaceSwitch(pickerWorkspaceID, res.Session.WorkspaceID)
 	return nil
-}
-
-func pickerSwitchSource(currentWorkspaceID string, currentWorkspaceClosed bool) string {
-	if currentWorkspaceClosed {
-		return ""
-	}
-	return currentWorkspaceID
 }
 
 func pickerTarget(s model.Session) string {
@@ -453,30 +451,6 @@ func lastWorkspace(stateDir, currentWorkspaceID string) (string, bool, error) {
 		return state.Last(stateDir)
 	}
 	return state.Previous(stateDir, currentWorkspaceID)
-}
-
-type currentPaneClient interface {
-	PaneCurrent(context.Context) (herdr.Pane, error)
-}
-
-func pickerLastWorkspace(
-	ctx context.Context,
-	client currentPaneClient,
-	stateDir, launchWorkspaceID string,
-	launchWorkspaceClosed bool,
-) (string, bool, error) {
-	currentWorkspaceID := launchWorkspaceID
-	if launchWorkspaceClosed {
-		pane, err := client.PaneCurrent(ctx)
-		if err != nil {
-			return "", false, fmt.Errorf("find focused workspace after close: %w", err)
-		}
-		if pane.WorkspaceID == "" {
-			return "", false, errors.New("focused pane has no workspace ID")
-		}
-		currentWorkspaceID = pane.WorkspaceID
-	}
-	return lastWorkspace(stateDir, currentWorkspaceID)
 }
 
 func (a *App) recordWorkspaceSwitch(fromWorkspaceID, toWorkspaceID string) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -318,7 +318,7 @@ func TestCollectPickerPreservesHerdrError(t *testing.T) {
 	if herdrErr == nil {
 		t.Fatal("collectPicker discarded Herdr workspace listing error")
 	}
-	if len(sessions) != 0 || len(workspaces) != 0 {
+	if len(sessions) != 0 || workspaces != nil {
 		t.Fatalf("sessions=%#v workspaces=%#v", sessions, workspaces)
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
+	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 )
@@ -382,6 +383,36 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	if !reflect.DeepEqual(h.Workspaces, want) {
 		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
 	}
+}
+
+func TestPickerLastWorkspaceUsesFocusedWorkspaceAfterLaunchWorkspaceCloses(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"focused", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	id, ok, err := pickerLastWorkspace(
+		context.Background(),
+		stubCurrentPaneClient{pane: herdr.Pane{WorkspaceID: "focused"}},
+		stateDir,
+		"closed-launch-workspace",
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || id != "older" {
+		t.Fatalf("last workspace=%q ok=%v, want older", id, ok)
+	}
+}
+
+type stubCurrentPaneClient struct {
+	pane herdr.Pane
+	err  error
+}
+
+func (c stubCurrentPaneClient) PaneCurrent(context.Context) (herdr.Pane, error) {
+	return c.pane, c.err
 }
 
 func TestPickerSwitchDoesNotRestoreClosedCurrentWorkspace(t *testing.T) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -308,6 +308,21 @@ func TestCollectPropagatesHerdrErrors(t *testing.T) {
 	}
 }
 
+func TestCollectPickerPreservesHerdrError(t *testing.T) {
+	configureFakeSources(t, "")
+
+	sessions, workspaces, herdrErr, err := (&App{}).collectPicker(context.Background(), config.Default())
+	if err != nil {
+		t.Fatalf("collect picker sources: %v", err)
+	}
+	if herdrErr == nil {
+		t.Fatal("collectPicker discarded Herdr workspace listing error")
+	}
+	if len(sessions) != 0 || len(workspaces) != 0 {
+		t.Fatalf("sessions=%#v workspaces=%#v", sessions, workspaces)
+	}
+}
+
 func TestPreviewCommandUsesExplicitConfig(t *testing.T) {
 	d := t.TempDir()
 	targetDir := filepath.Join(d, "target")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
-	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 )
@@ -323,6 +322,42 @@ func TestCollectPickerPreservesHerdrError(t *testing.T) {
 	}
 }
 
+func TestCollectPickerLoadsHerdrAndZoxideConcurrently(t *testing.T) {
+	d := t.TempDir()
+	marker := filepath.Join(d, "zoxide-started")
+	herdrScript := `#!/bin/sh
+if [ "$1 $2" = "workspace list" ]; then
+  i=0
+  while [ ! -f "$CONCURRENT_SOURCE_MARKER" ] && [ "$i" -lt 100 ]; do
+    sleep 0.01
+    i=$((i + 1))
+  done
+  [ -f "$CONCURRENT_SOURCE_MARKER" ] || exit 1
+fi
+printf '[]\n'
+`
+	zoxideScript := `#!/bin/sh
+: > "$CONCURRENT_SOURCE_MARKER"
+`
+	for name, script := range map[string]string{"herdr": herdrScript, "zoxide": zoxideScript} {
+		//nolint:gosec // test creates local executable fixtures.
+		if err := os.WriteFile(filepath.Join(d, name), []byte(script), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HERDR_BIN_PATH", filepath.Join(d, "herdr"))
+	t.Setenv("CONCURRENT_SOURCE_MARKER", marker)
+	t.Setenv("PATH", d+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, _, herdrErr, err := (&App{}).collectPicker(context.Background(), config.Default())
+	if err != nil {
+		t.Fatalf("collect picker sources: %v", err)
+	}
+	if herdrErr != nil {
+		t.Fatalf("Herdr ran before zoxide: %v", herdrErr)
+	}
+}
+
 func TestPreviewCommandUsesExplicitConfig(t *testing.T) {
 	d := t.TempDir()
 	targetDir := filepath.Join(d, "target")
@@ -395,59 +430,6 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{"previous", "current", "older"}
-	if !reflect.DeepEqual(h.Workspaces, want) {
-		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
-	}
-}
-
-func TestPickerLastWorkspaceUsesFocusedWorkspaceAfterLaunchWorkspaceCloses(t *testing.T) {
-	stateDir := t.TempDir()
-	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"focused", "older"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	id, ok, err := pickerLastWorkspace(
-		context.Background(),
-		stubCurrentPaneClient{pane: herdr.Pane{WorkspaceID: "focused"}},
-		stateDir,
-		"closed-launch-workspace",
-		true,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || id != "older" {
-		t.Fatalf("last workspace=%q ok=%v, want older", id, ok)
-	}
-}
-
-type stubCurrentPaneClient struct {
-	pane herdr.Pane
-	err  error
-}
-
-func (c stubCurrentPaneClient) PaneCurrent(context.Context) (herdr.Pane, error) {
-	return c.pane, c.err
-}
-
-func TestPickerSwitchDoesNotRestoreClosedCurrentWorkspace(t *testing.T) {
-	d := t.TempDir()
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", d)
-	if err := state.SaveHistory(d, state.History{Workspaces: []string{"current", "older"}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := state.RemoveWorkspace(d, "current"); err != nil {
-		t.Fatal(err)
-	}
-
-	a := &App{Err: &bytes.Buffer{}}
-	a.recordWorkspaceSwitch(pickerSwitchSource("current", true), "target")
-
-	h, err := state.LoadHistory(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"target", "older"}
 	if !reflect.DeepEqual(h.Workspaces, want) {
 		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
+	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 )
@@ -310,15 +311,106 @@ func TestCollectPropagatesHerdrErrors(t *testing.T) {
 func TestCollectPickerPreservesHerdrError(t *testing.T) {
 	configureFakeSources(t, "")
 
-	sessions, workspaces, herdrErr, err := (&App{}).collectPicker(context.Background(), config.Default())
+	col, err := (&App{}).collectPicker(context.Background(), config.Default())
 	if err != nil {
 		t.Fatalf("collect picker sources: %v", err)
 	}
-	if herdrErr == nil {
+	if col.HerdrErr == nil {
 		t.Fatal("collectPicker discarded Herdr workspace listing error")
 	}
-	if len(sessions) != 0 || workspaces != nil {
-		t.Fatalf("sessions=%#v workspaces=%#v", sessions, workspaces)
+	if len(col.Sessions) != 0 || col.HerdrWorkspaces != nil {
+		t.Fatalf("sessions=%#v workspaces=%#v", col.Sessions, col.HerdrWorkspaces)
+	}
+}
+
+func TestCollectPickerReturnsRawHerdrWorkspaces(t *testing.T) {
+	configureHerdrScript(t, `#!/bin/sh
+case "$1 $2" in
+"workspace list") printf '[{"id":"w1","label":"api","cwd":"/live/api"}]\n' ;;
+"pane list") printf '[]\n' ;;
+*) exit 1 ;;
+esac
+`)
+
+	col, err := (&App{}).collectPicker(context.Background(), config.Default())
+	if err != nil || col.HerdrErr != nil {
+		t.Fatalf("collect picker: err=%v herdrErr=%v", err, col.HerdrErr)
+	}
+	want := []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "w1"}}
+	if !reflect.DeepEqual(col.HerdrWorkspaces, want) {
+		t.Fatalf("herdr workspaces=%#v want %#v", col.HerdrWorkspaces, want)
+	}
+}
+
+func TestReloadPickerStateResolvesFocusedWorkspace(t *testing.T) {
+	tests := []struct {
+		name        string
+		paneCurrent string
+		wantID      string
+		wantLast    string
+		wantUnknown bool
+		wantWarning string
+	}{
+		{
+			name:        "records focused workspace",
+			paneCurrent: `printf '{"id":"p1","workspace_id":"focused"}\n'`,
+			wantID:      "focused",
+			wantLast:    "previous",
+		},
+		{
+			name:        "clears workspace when focus fails",
+			paneCurrent: "exit 1",
+			wantUnknown: true,
+			wantWarning: "find focused workspace after close",
+		},
+		{
+			name:        "clears workspace when focused pane has no workspace",
+			paneCurrent: `printf '{"id":"p1"}\n'`,
+			wantUnknown: true,
+			wantWarning: "focused pane has no workspace ID",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configureHerdrScript(t, fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+"workspace list") printf '[]\n' ;;
+"pane list") printf '[]\n' ;;
+"pane current") %s ;;
+*) exit 1 ;;
+esac
+`, tt.paneCurrent))
+			stateDir := filepath.Join(t.TempDir(), "state")
+			if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"focused", "previous"}}); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+			pickerWorkspaceID := "closed-workspace"
+			var warnings []string
+			warn := func(format string, args ...any) {
+				warnings = append(warnings, fmt.Sprintf(format, args...))
+			}
+
+			result, err := (&App{}).reloadPickerState(context.Background(), config.Default(), herdr.NewCLIClient(), &pickerWorkspaceID, warn)
+			if err != nil {
+				t.Fatalf("reload picker state: %v", err)
+			}
+			if pickerWorkspaceID != tt.wantID {
+				t.Fatalf("picker workspace=%q, want %q", pickerWorkspaceID, tt.wantID)
+			}
+			if result.LastWorkspaceUnknown != tt.wantUnknown {
+				t.Fatalf("last workspace unknown=%v, want %v", result.LastWorkspaceUnknown, tt.wantUnknown)
+			}
+			if !tt.wantUnknown && result.LastWorkspaceID != tt.wantLast {
+				t.Fatalf("last workspace=%q, want %q", result.LastWorkspaceID, tt.wantLast)
+			}
+			if tt.wantWarning == "" && len(warnings) > 0 {
+				t.Fatalf("unexpected warnings: %v", warnings)
+			}
+			if tt.wantWarning != "" && (len(warnings) != 1 || !strings.Contains(warnings[0], tt.wantWarning)) {
+				t.Fatalf("warnings=%v, want one containing %q", warnings, tt.wantWarning)
+			}
+		})
 	}
 }
 
@@ -349,12 +441,12 @@ printf '[]\n'
 	t.Setenv("CONCURRENT_SOURCE_MARKER", marker)
 	t.Setenv("PATH", d+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	_, _, herdrErr, err := (&App{}).collectPicker(context.Background(), config.Default())
+	col, err := (&App{}).collectPicker(context.Background(), config.Default())
 	if err != nil {
 		t.Fatalf("collect picker sources: %v", err)
 	}
-	if herdrErr != nil {
-		t.Fatalf("Herdr ran before zoxide: %v", herdrErr)
+	if col.HerdrErr != nil {
+		t.Fatalf("Herdr ran before zoxide: %v", col.HerdrErr)
 	}
 }
 
@@ -466,6 +558,21 @@ func runListJSON(t *testing.T, cfgPath, zoxideOutput string, extraArgs ...string
 		t.Fatalf("decode list JSON: %v\n%s", err, out.String())
 	}
 	return sessions
+}
+
+func configureHerdrScript(t *testing.T, script string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	//nolint:gosec // test creates local executable fixtures.
+	if err := os.WriteFile(filepath.Join(fakeBin, "herdr"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // test creates local executable fixtures.
+	if err := os.WriteFile(filepath.Join(fakeBin, "zoxide"), []byte("#!/bin/sh\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func configureFakeSources(t *testing.T, zoxideOutput string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,11 @@ type SessionConfig struct {
 }
 
 type TUIConfig struct {
-	ShowIcons   bool   `toml:"show_icons"`
-	Prompt      string `toml:"prompt"`
-	Placeholder string `toml:"placeholder"`
-	DefaultSort string `toml:"default_sort"`
+	ShowIcons             bool   `toml:"show_icons"`
+	ShowLastWorkspacePath bool   `toml:"show_last_workspace_path"`
+	Prompt                string `toml:"prompt"`
+	Placeholder           string `toml:"placeholder"`
+	DefaultSort           string `toml:"default_sort"`
 }
 
 type WildcardConfig struct {
@@ -56,6 +57,9 @@ func Default() Config {
 		DirLength:            1,
 		SortOrder:            []string{"herdr", "config", "zoxide", "dir"},
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
-		TUI:                  TUIConfig{DefaultSort: DefaultWorkspaceSort},
+		TUI: TUIConfig{
+			DefaultSort:           DefaultWorkspaceSort,
+			ShowLastWorkspacePath: true,
+		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type SessionConfig struct {
 
 type TUIConfig struct {
 	ShowIcons             bool   `toml:"show_icons"`
+	ShowLastWorkspace     bool   `toml:"show_last_workspace"`
 	ShowLastWorkspacePath bool   `toml:"show_last_workspace_path"`
 	Prompt                string `toml:"prompt"`
 	Placeholder           string `toml:"placeholder"`
@@ -59,6 +60,7 @@ func Default() Config {
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
+			ShowLastWorkspace:     true,
 			ShowLastWorkspacePath: true,
 		},
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -96,10 +96,11 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 			PreviewCommand *string `toml:"preview_command"`
 		} `toml:"default_session"`
 		TUI struct {
-			Prompt      *string `toml:"prompt"`
-			Placeholder *string `toml:"placeholder"`
-			ShowIcons   *bool   `toml:"show_icons"`
-			DefaultSort *string `toml:"default_sort"`
+			Prompt                *string `toml:"prompt"`
+			Placeholder           *string `toml:"placeholder"`
+			ShowIcons             *bool   `toml:"show_icons"`
+			ShowLastWorkspacePath *bool   `toml:"show_last_workspace_path"`
+			DefaultSort           *string `toml:"default_sort"`
 		} `toml:"tui"`
 	}
 	_ = toml.Unmarshal(data, &probe)
@@ -127,12 +128,13 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 		probe.TUI.Prompt != nil,
 		probe.TUI.Placeholder != nil,
 		probe.TUI.ShowIcons != nil,
+		probe.TUI.ShowLastWorkspacePath != nil,
 		probe.TUI.DefaultSort != nil,
 	)
 	return nil
 }
 
-func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, defaultSortSet bool) {
+func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, showLastWorkspacePathSet, defaultSortSet bool) {
 	if src.Cache {
 		dst.Cache = true
 	}
@@ -153,6 +155,9 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	}
 	if showIconsSet {
 		dst.TUI.ShowIcons = src.TUI.ShowIcons
+	}
+	if showLastWorkspacePathSet {
+		dst.TUI.ShowLastWorkspacePath = src.TUI.ShowLastWorkspacePath
 	}
 	if promptSet {
 		dst.TUI.Prompt = src.TUI.Prompt

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -99,6 +99,7 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 			Prompt                *string `toml:"prompt"`
 			Placeholder           *string `toml:"placeholder"`
 			ShowIcons             *bool   `toml:"show_icons"`
+			ShowLastWorkspace     *bool   `toml:"show_last_workspace"`
 			ShowLastWorkspacePath *bool   `toml:"show_last_workspace_path"`
 			DefaultSort           *string `toml:"default_sort"`
 		} `toml:"tui"`
@@ -128,13 +129,14 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 		probe.TUI.Prompt != nil,
 		probe.TUI.Placeholder != nil,
 		probe.TUI.ShowIcons != nil,
+		probe.TUI.ShowLastWorkspace != nil,
 		probe.TUI.ShowLastWorkspacePath != nil,
 		probe.TUI.DefaultSort != nil,
 	)
 	return nil
 }
 
-func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, showLastWorkspacePathSet, defaultSortSet bool) {
+func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, showLastWorkspaceSet, showLastWorkspacePathSet, defaultSortSet bool) {
 	if src.Cache {
 		dst.Cache = true
 	}
@@ -155,6 +157,9 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	}
 	if showIconsSet {
 		dst.TUI.ShowIcons = src.TUI.ShowIcons
+	}
+	if showLastWorkspaceSet {
+		dst.TUI.ShowLastWorkspace = src.TUI.ShowLastWorkspace
 	}
 	if showLastWorkspacePathSet {
 		dst.TUI.ShowLastWorkspacePath = src.TUI.ShowLastWorkspacePath

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -201,9 +201,24 @@ func TestLoadExplicitFalseShowLastWorkspacePathOverridesImportedValue(t *testing
 	}
 }
 
+func TestLoadExplicitFalseShowLastWorkspaceOverridesImportedValue(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), "[tui]\nshow_last_workspace = true\n")
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_last_workspace = false\n")
+	cfg, _, err := Load(LoadOptions{Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.ShowLastWorkspace {
+		t.Fatal("show_last_workspace = true, want false")
+	}
+}
+
 func TestDefaultShowsLastWorkspacePath(t *testing.T) {
-	if !Default().TUI.ShowLastWorkspacePath {
-		t.Fatal("show_last_workspace_path = false, want true")
+	cfg := Default()
+	if !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath {
+		t.Fatalf("last workspace defaults = show %v, show path %v; want true", cfg.TUI.ShowLastWorkspace, cfg.TUI.ShowLastWorkspacePath)
 	}
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -187,6 +187,26 @@ func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
 	}
 }
 
+func TestLoadExplicitFalseShowLastWorkspacePathOverridesImportedValue(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), "[tui]\nshow_last_workspace_path = true\n")
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_last_workspace_path = false\n")
+	cfg, _, err := Load(LoadOptions{Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.ShowLastWorkspacePath {
+		t.Fatal("show_last_workspace_path = true, want false")
+	}
+}
+
+func TestDefaultShowsLastWorkspacePath(t *testing.T) {
+	if !Default().TUI.ShowLastWorkspacePath {
+		t.Fatal("show_last_workspace_path = false, want true")
+	}
+}
+
 func TestLoadTUIDefaultSort(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "sesh.toml")
 	mustWrite(t, p, "[tui]\ndefault_sort = \"recent\"\n")

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -112,14 +112,30 @@ type Runner interface {
 }
 type ExecRunner struct{}
 
+type omitCallerPaneKey struct{}
+
 func (ExecRunner) Run(ctx context.Context, bin string, args ...string) ([]byte, []byte, error) {
 	//nolint:gosec // HERDR_BIN_PATH may intentionally point at a user-selected herdr binary.
 	c := exec.CommandContext(ctx, bin, args...)
+	if omit, _ := ctx.Value(omitCallerPaneKey{}).(bool); omit {
+		c.Env = environmentWithout(os.Environ(), "HERDR_PANE_ID")
+	}
 	var out, errb bytes.Buffer
 	c.Stdout = &out
 	c.Stderr = &errb
 	err := c.Run()
 	return out.Bytes(), errb.Bytes(), err
+}
+
+func environmentWithout(environ []string, name string) []string {
+	prefix := name + "="
+	filtered := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		if !strings.HasPrefix(entry, prefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }
 
 type CLIClient struct {
@@ -350,6 +366,12 @@ func (c *CLIClient) PaneList(ctx context.Context, wid string) ([]Pane, error) {
 	return panes, nil
 }
 func (c *CLIClient) PaneCurrent(ctx context.Context) (Pane, error) {
+	return c.paneCurrent(ctx)
+}
+func (c *CLIClient) PaneFocused(ctx context.Context) (Pane, error) {
+	return c.paneCurrent(context.WithValue(ctx, omitCallerPaneKey{}, true))
+}
+func (c *CLIClient) paneCurrent(ctx context.Context) (Pane, error) {
 	out, err := c.run(ctx, "pane", "current")
 	if err != nil {
 		return Pane{}, err

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -3,6 +3,8 @@ package herdr
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -129,6 +131,36 @@ func TestCLIClientDecodesPaneCurrentEnvelope(t *testing.T) {
 	}
 	if got.ID != "p1" || got.WorkspaceID != "w1" || got.TabID != "w1:t1" || got.CWD != "/tmp/api" {
 		t.Fatalf("pane=%#v", got)
+	}
+}
+
+func TestCLIClientPaneFocusedOmitsCallerPane(t *testing.T) {
+	d := t.TempDir()
+	bin := filepath.Join(d, "herdr")
+	script := `#!/bin/sh
+if [ -n "$HERDR_PANE_ID" ]; then
+  printf '{"workspace_id":"caller"}\n'
+else
+  printf '{"workspace_id":"focused"}\n'
+fi
+`
+	//nolint:gosec // test creates a local executable fixture.
+	if err := os.WriteFile(bin, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PANE_ID", "stale-pane")
+	c := &CLIClient{Bin: bin, Runner: ExecRunner{}}
+
+	caller, err := c.PaneCurrent(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	focused, err := c.PaneFocused(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if caller.WorkspaceID != "caller" || focused.WorkspaceID != "focused" {
+		t.Fatalf("caller=%q focused=%q", caller.WorkspaceID, focused.WorkspaceID)
 	}
 }
 func TestFakeClientRecordsPaneRun(t *testing.T) {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -421,6 +421,9 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastWorkspaceID = closed.result.LastWorkspaceID
 			m.lastWorkspaceUnknown = closed.result.LastWorkspaceUnknown
 		}
+		if closed.result.HerdrWorkspaces != nil {
+			m.herdrWorkspaces = workspaceSessionsByID(closed.result.HerdrWorkspaces)
+		}
 		selectedKey := ""
 		if current, currentOK := m.list.Current(); currentOK {
 			selectedKey = sessionmodel.Key(current)
@@ -428,7 +431,6 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if closed.reloadErr == nil && closed.result.Sessions != nil {
 			m.workspaceOrder = herdrWorkspaceIDs(closed.result.Sessions)
 			m.list.All = append(m.list.All[:0], closed.result.Sessions...)
-			m.herdrWorkspaces = workspaceSessionsByID(closed.result.HerdrWorkspaces)
 			if m.recentSort {
 				sortHerdrWorkspaces(m.list.All, m.recentWorkspaceIDs)
 			}

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -117,9 +117,19 @@ type Options struct {
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
 	CloseWorkspace        func(context.Context, string) error
-	ReloadSessions        func(context.Context) ([]sessionmodel.Session, error)
+	ReloadPicker          func(context.Context) (ReloadResult, error)
 	RecentWorkspaceIDs    []string
 	RecentWorkspaceSort   bool
+	LastWorkspaceID       string
+	LastWorkspaceUnknown  bool
+	HerdrWorkspaces       []sessionmodel.Session
+}
+
+type ReloadResult struct {
+	Sessions             []sessionmodel.Session
+	HerdrWorkspaces      []sessionmodel.Session
+	LastWorkspaceID      string
+	LastWorkspaceUnknown bool
 }
 
 func Run(items []sessionmodel.Session, opts Options) (sessionmodel.Session, bool, error) {
@@ -168,8 +178,11 @@ type teaModel struct {
 	workspaceOrder          []string
 	recentWorkspaceIDs      []string
 	recentSort              bool
+	lastWorkspaceID         string
+	lastWorkspaceUnknown    bool
+	herdrWorkspaces         map[string]sessionmodel.Session
 	closeWorkspace          func(context.Context, string) error
-	reloadSessions          func(context.Context) ([]sessionmodel.Session, error)
+	reloadPicker            func(context.Context) (ReloadResult, error)
 	workspaceCloseContext   context.Context
 	closingWorkspaceID      string
 	cancelWorkspaceClose    context.CancelFunc
@@ -191,7 +204,7 @@ type agentStatusesMsg struct {
 
 type workspaceCloseMsg struct {
 	workspaceID string
-	sessions    []sessionmodel.Session
+	result      ReloadResult
 	closeErr    error
 	reloadErr   error
 }
@@ -246,8 +259,11 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		workspaceOrder:        workspaceOrder,
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
 		recentSort:            opts.RecentWorkspaceSort,
+		lastWorkspaceID:       opts.LastWorkspaceID,
+		lastWorkspaceUnknown:  opts.LastWorkspaceUnknown,
+		herdrWorkspaces:       workspaceSessionsByID(opts.HerdrWorkspaces),
 		closeWorkspace:        opts.CloseWorkspace,
-		reloadSessions:        opts.ReloadSessions,
+		reloadPicker:          opts.ReloadPicker,
 		workspaceCloseContext: closeContext,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
@@ -401,13 +417,18 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
 			return m.refreshPreview()
 		}
+		if m.reloadPicker != nil {
+			m.lastWorkspaceID = closed.result.LastWorkspaceID
+			m.lastWorkspaceUnknown = closed.result.LastWorkspaceUnknown
+		}
 		selectedKey := ""
 		if current, currentOK := m.list.Current(); currentOK {
 			selectedKey = sessionmodel.Key(current)
 		}
-		if closed.reloadErr == nil && closed.sessions != nil {
-			m.workspaceOrder = herdrWorkspaceIDs(closed.sessions)
-			m.list.All = append(m.list.All[:0], closed.sessions...)
+		if closed.reloadErr == nil && closed.result.Sessions != nil {
+			m.workspaceOrder = herdrWorkspaceIDs(closed.result.Sessions)
+			m.list.All = append(m.list.All[:0], closed.result.Sessions...)
+			m.herdrWorkspaces = workspaceSessionsByID(closed.result.HerdrWorkspaces)
 			if m.recentSort {
 				sortHerdrWorkspaces(m.list.All, m.recentWorkspaceIDs)
 			}
@@ -519,21 +540,21 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	m.preview = "Closing workspace..."
 	closeCtx, cancel := context.WithCancel(m.workspaceCloseContext)
 	m.cancelWorkspaceClose = cancel
-	return m, closeWorkspaceCommand(closeCtx, cancel, m.closeWorkspace, m.reloadSessions, current.WorkspaceID)
+	return m, closeWorkspaceCommand(closeCtx, cancel, m.closeWorkspace, m.reloadPicker, current.WorkspaceID)
 }
 
 func closeWorkspaceCommand(
 	ctx context.Context,
 	cancel context.CancelFunc,
 	closeWorkspace func(context.Context, string) error,
-	reloadSessions func(context.Context) ([]sessionmodel.Session, error),
+	reloadPicker func(context.Context) (ReloadResult, error),
 	workspaceID string,
 ) tea.Cmd {
 	return func() tea.Msg {
 		defer cancel()
 		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(ctx, workspaceID)}
-		if msg.closeErr == nil && reloadSessions != nil {
-			msg.sessions, msg.reloadErr = reloadSessions(ctx)
+		if msg.closeErr == nil && reloadPicker != nil {
+			msg.result, msg.reloadErr = reloadPicker(ctx)
 		}
 		return msg
 	}
@@ -608,13 +629,13 @@ func (m teaModel) View() tea.View {
 	if m.recentSort {
 		sortMode = "recent"
 	}
-	footer := helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k move · ctrl+x close · ctrl+r %s · esc exit", sortMode))
+	footer := helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k · ctrl+r %s · ctrl+x close · esc exit", sortMode))
 	if m.closeError != "" {
 		footer = emptyStyle.Render(m.closeError)
 	}
 	lines = append(lines,
 		horizontalRule(width),
-		footer,
+		m.footerLine(footer, width),
 		"",
 	)
 	for i, line := range lines {
@@ -673,6 +694,16 @@ func sortHerdrWorkspaces(items []sessionmodel.Session, order []string) {
 			workspace++
 		}
 	}
+}
+
+func workspaceSessionsByID(items []sessionmodel.Session) map[string]sessionmodel.Session {
+	workspaces := make(map[string]sessionmodel.Session, len(items))
+	for _, item := range items {
+		if item.Source == "herdr" && item.WorkspaceID != "" {
+			workspaces[item.WorkspaceID] = item
+		}
+	}
+	return workspaces
 }
 
 func (m teaModel) listView(width, visibleRows int) string {
@@ -756,6 +787,41 @@ func (m teaModel) header(width int) string {
 		gap = 1
 	}
 	return fitLine(title+strings.Repeat(" ", gap)+count, width)
+}
+
+func (m teaModel) lastWorkspaceText() string {
+	title := sectionStyle.Render("LAST WORKSPACE")
+	label := "None recorded"
+	path := ""
+	if m.lastWorkspaceUnknown {
+		label = "Unavailable"
+	} else if m.lastWorkspaceID != "" {
+		label = m.lastWorkspaceID
+		if item, ok := m.herdrWorkspaces[m.lastWorkspaceID]; ok {
+			if item.Name != "" {
+				label = item.Name
+			} else if item.Path != "" {
+				label = compactHome(item.Path)
+			}
+			path = item.Path
+		}
+	}
+	line := title + countStyle.Render(" · ") + rowLabelStyle.Render(label)
+	displayPath := compactHome(path)
+	if displayPath != "" && displayPath != label {
+		line += pathStyle.Render("  " + displayPath)
+	}
+	return line
+}
+
+func (m teaModel) footerLine(help string, width int) string {
+	last := m.lastWorkspaceText()
+	lastWidth := min(lipgloss.Width(last), maxInt(1, width/2))
+	last = ansi.Truncate(last, lastWidth, "…")
+	helpWidth := maxInt(0, width-lipgloss.Width(last)-2)
+	help = ansi.Truncate(help, helpWidth, "…")
+	gap := maxInt(1, width-lipgloss.Width(help)-lipgloss.Width(last))
+	return fitLine(help+strings.Repeat(" ", gap)+last, width)
 }
 
 func (m teaModel) previewView(width, maxLines int) string {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -112,6 +112,7 @@ type Options struct {
 	Prompt                string
 	Placeholder           string
 	ShowIcons             bool
+	HideLastWorkspacePath bool
 	SeparatorAware        bool
 	DefaultPreviewCommand string
 	FZFCommand            string
@@ -179,6 +180,7 @@ type teaModel struct {
 
 	defaultPreviewCommand   string
 	showIcons               bool
+	hideLastWorkspacePath   bool
 	refreshAgentStatuses    func() (map[string]string, error)
 	workspaceOrder          []string
 	recentWorkspaceIDs      []string
@@ -261,6 +263,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		showIcons:             opts.ShowIcons,
+		hideLastWorkspacePath: opts.HideLastWorkspacePath,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
 		workspaceOrder:        workspaceOrder,
 		recentWorkspaceIDs:    append([]string(nil), opts.RecentWorkspaceIDs...),
@@ -820,7 +823,7 @@ func (m teaModel) lastWorkspaceText() string {
 	label, path := m.lastWorkspaceStatus()
 	line := sectionStyle.Render("LAST WORKSPACE") + countStyle.Render(" · ") + rowLabelStyle.Render(label)
 	displayPath := compactHome(path)
-	if displayPath != "" && displayPath != label {
+	if !m.hideLastWorkspacePath && displayPath != "" && displayPath != label {
 		line += pathStyle.Render("  " + displayPath)
 	}
 	return line

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -117,12 +117,17 @@ type Options struct {
 	FZFCommand            string
 	RefreshAgentStatuses  func() (map[string]string, error)
 	CloseWorkspace        func(context.Context, string) error
-	ReloadPicker          func(context.Context) (ReloadResult, error)
-	RecentWorkspaceIDs    []string
-	RecentWorkspaceSort   bool
-	LastWorkspaceID       string
-	LastWorkspaceUnknown  bool
-	HerdrWorkspaces       []sessionmodel.Session
+	// ReloadPicker refreshes picker state after a workspace close. Its
+	// ReloadResult is consumed even when it returns an error: the
+	// last-workspace fields must always be valid (set LastWorkspaceUnknown
+	// when unsure), and a nil HerdrWorkspaces means "keep the existing
+	// metadata" while an empty slice means "no workspaces".
+	ReloadPicker         func(context.Context) (ReloadResult, error)
+	RecentWorkspaceIDs   []string
+	RecentWorkspaceSort  bool
+	LastWorkspaceID      string
+	LastWorkspaceUnknown bool
+	HerdrWorkspaces      []sessionmodel.Session
 }
 
 type ReloadResult struct {
@@ -205,6 +210,7 @@ type agentStatusesMsg struct {
 type workspaceCloseMsg struct {
 	workspaceID string
 	result      ReloadResult
+	reloadRan   bool
 	closeErr    error
 	reloadErr   error
 }
@@ -417,7 +423,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.closeError = fmt.Sprintf("Failed to close workspace: %v", closed.closeErr)
 			return m.refreshPreview()
 		}
-		if m.reloadPicker != nil {
+		if closed.reloadRan {
 			m.lastWorkspaceID = closed.result.LastWorkspaceID
 			m.lastWorkspaceUnknown = closed.result.LastWorkspaceUnknown
 		}
@@ -557,6 +563,7 @@ func closeWorkspaceCommand(
 		msg := workspaceCloseMsg{workspaceID: workspaceID, closeErr: closeWorkspace(ctx, workspaceID)}
 		if msg.closeErr == nil && reloadPicker != nil {
 			msg.result, msg.reloadErr = reloadPicker(ctx)
+			msg.reloadRan = true
 		}
 		return msg
 	}
@@ -791,10 +798,8 @@ func (m teaModel) header(width int) string {
 	return fitLine(title+strings.Repeat(" ", gap)+count, width)
 }
 
-func (m teaModel) lastWorkspaceText() string {
-	title := sectionStyle.Render("LAST WORKSPACE")
-	label := "None recorded"
-	path := ""
+func (m teaModel) lastWorkspaceStatus() (label, path string) {
+	label = "None recorded"
 	if m.lastWorkspaceUnknown {
 		label = "Unavailable"
 	} else if m.lastWorkspaceID != "" {
@@ -808,7 +813,12 @@ func (m teaModel) lastWorkspaceText() string {
 			path = item.Path
 		}
 	}
-	line := title + countStyle.Render(" · ") + rowLabelStyle.Render(label)
+	return label, path
+}
+
+func (m teaModel) lastWorkspaceText() string {
+	label, path := m.lastWorkspaceStatus()
+	line := sectionStyle.Render("LAST WORKSPACE") + countStyle.Render(" · ") + rowLabelStyle.Render(label)
 	displayPath := compactHome(path)
 	if displayPath != "" && displayPath != label {
 		line += pathStyle.Render("  " + displayPath)
@@ -816,14 +826,28 @@ func (m teaModel) lastWorkspaceText() string {
 	return line
 }
 
-func (m teaModel) footerLine(help string, width int) string {
+func (m teaModel) lastWorkspaceCompactText() string {
+	label, _ := m.lastWorkspaceStatus()
+	return sectionStyle.Render("last:") + rowLabelStyle.Render(" "+label)
+}
+
+// footerLine keeps the keybind help (or a close error, which gets the whole
+// row) intact and fits the last-workspace status into the remaining width,
+// compacting or dropping it rather than truncating the help.
+func (m teaModel) footerLine(footer string, width int) string {
+	if m.closeError != "" {
+		return fitLine(footer, width)
+	}
+	available := width - lipgloss.Width(footer) - 2
 	last := m.lastWorkspaceText()
-	lastWidth := min(lipgloss.Width(last), maxInt(1, width/2))
-	last = ansi.Truncate(last, lastWidth, "…")
-	helpWidth := maxInt(0, width-lipgloss.Width(last)-2)
-	help = ansi.Truncate(help, helpWidth, "…")
-	gap := maxInt(1, width-lipgloss.Width(help)-lipgloss.Width(last))
-	return fitLine(help+strings.Repeat(" ", gap)+last, width)
+	if lipgloss.Width(last) > available {
+		last = m.lastWorkspaceCompactText()
+	}
+	if lipgloss.Width(last) > available {
+		return fitLine(footer, width)
+	}
+	gap := maxInt(1, width-lipgloss.Width(footer)-lipgloss.Width(last))
+	return fitLine(footer+strings.Repeat(" ", gap)+last, width)
 }
 
 func (m teaModel) previewView(width, maxLines int) string {

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -112,6 +112,7 @@ type Options struct {
 	Prompt                string
 	Placeholder           string
 	ShowIcons             bool
+	HideLastWorkspace     bool
 	HideLastWorkspacePath bool
 	SeparatorAware        bool
 	DefaultPreviewCommand string
@@ -180,6 +181,7 @@ type teaModel struct {
 
 	defaultPreviewCommand   string
 	showIcons               bool
+	hideLastWorkspace       bool
 	hideLastWorkspacePath   bool
 	refreshAgentStatuses    func() (map[string]string, error)
 	workspaceOrder          []string
@@ -263,6 +265,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		showIcons:             opts.ShowIcons,
+		hideLastWorkspace:     opts.HideLastWorkspace,
 		hideLastWorkspacePath: opts.HideLastWorkspacePath,
 		refreshAgentStatuses:  opts.RefreshAgentStatuses,
 		workspaceOrder:        workspaceOrder,
@@ -838,7 +841,7 @@ func (m teaModel) lastWorkspaceCompactText() string {
 // row) intact and fits the last-workspace status into the remaining width,
 // compacting or dropping it rather than truncating the help.
 func (m teaModel) footerLine(footer string, width int) string {
-	if m.closeError != "" {
+	if m.closeError != "" || m.hideLastWorkspace {
 		return fitLine(footer, width)
 	}
 	available := width - lipgloss.Width(footer) - 2

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -71,8 +71,11 @@ func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
 	if current, ok := m.list.Current(); !ok || current.Name != "api" {
 		t.Fatalf("current = %#v ok=%v, want api", current, ok)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k") || !strings.Contains(view, "LAST WORKSPACE · None recorded") {
-		t.Fatalf("default-width view missing navigation help or last workspace:\n%s", view)
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
+	view := ansi.Strip(m.View().Content)
+	if !strings.Contains(view, "enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit") || !strings.Contains(view, "LAST WORKSPACE · None recorded") {
+		t.Fatalf("view missing complete navigation help or last workspace:\n%s", view)
 	}
 }
 
@@ -152,6 +155,8 @@ func TestTeaModelCtrlXUpdatesLastWorkspace(t *testing.T) {
 		},
 	})
 
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	updated, _ = m.Update(closeCmd())
@@ -277,6 +282,8 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 		},
 	})
 
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	updated, _ = m.Update(closeCmd())
@@ -285,9 +292,12 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sessions=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "Workspace closed, but sessions could not be r…") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "Workspace closed, but sessions could not be refreshed: workspace list failed") {
 		t.Fatalf("view missing reload failure:\n%s", view)
-	} else if !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
+	}
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
 		t.Fatalf("view did not refresh last workspace after reload failure:\n%s", view)
 	}
 }
@@ -308,6 +318,8 @@ func TestTeaModelCtrlXRefreshesHerdrMetadataWhenSessionReloadFails(t *testing.T)
 		},
 	})
 
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	updated, _ = m.Update(closeCmd())
@@ -316,6 +328,8 @@ func TestTeaModelCtrlXRefreshesHerdrMetadataWhenSessionReloadFails(t *testing.T)
 	if got, want := sessionNames(m.list.All), []string{"old label"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sessions=%v want retained rows %v", got, want)
 	}
+	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
 	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · new label") {
 		t.Fatalf("view kept stale Herdr metadata:\n%s", view)
 	}
@@ -828,6 +842,8 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 
 func TestTeaModelLastWorkspaceFallsBackToRecordedID(t *testing.T) {
 	m := newTeaModel([]model.Session{{Source: "herdr", Name: "current", WorkspaceID: "current"}}, Options{LastWorkspaceID: "unavailable-workspace"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
 	if !strings.Contains(view, "LAST WORKSPACE · unavailable-workspace") {
@@ -840,6 +856,8 @@ func TestTeaModelLastWorkspaceUsesRawHerdrMetadata(t *testing.T) {
 		LastWorkspaceID: "ws-api",
 		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "ws-api"}},
 	})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
 	if !strings.Contains(view, "LAST WORKSPACE · api  /live/api") {
@@ -867,8 +885,51 @@ func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
 	t.Fatalf("view missing last workspace footer:\n%s", view)
 }
 
+func TestFooterLinePrioritizesKeybindHelpAtNarrowWidths(t *testing.T) {
+	m := newTeaModel(nil, Options{
+		LastWorkspaceID: "ws-api",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "a-rather-long-workspace-name", Path: "/home/test/some/deep/project/path", WorkspaceID: "ws-api"}},
+	})
+	help := helpStyle.Render("enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit")
+	for _, width := range []int{10, 20, 40, 80, 120} {
+		line := m.footerLine(help, width)
+		if got := lipgloss.Width(line); got != width {
+			t.Fatalf("width %d: footer width=%d:\n%q", width, got, line)
+		}
+		if plain := ansi.Strip(line); width >= lipgloss.Width(help) && !strings.Contains(plain, "esc exit") {
+			t.Fatalf("width %d: keybind help truncated: %q", width, plain)
+		}
+	}
+}
+
+func TestFooterLineCompactsLastWorkspaceBeforeDroppingIt(t *testing.T) {
+	m := newTeaModel(nil, Options{
+		LastWorkspaceID: "api",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "api", Path: "/some/long/path/to/the/project", WorkspaceID: "api"}},
+	})
+	help := helpStyle.Render("enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit")
+	line := ansi.Strip(m.footerLine(help, 80))
+	if !strings.Contains(line, "last: api") || strings.Contains(line, "LAST WORKSPACE") {
+		t.Fatalf("footer did not compact last workspace: %q", line)
+	}
+	if !strings.Contains(line, "esc exit") {
+		t.Fatalf("compact footer truncated keybind help: %q", line)
+	}
+}
+
+func TestFooterLineGivesCloseErrorWholeRow(t *testing.T) {
+	m := newTeaModel(nil, Options{LastWorkspaceID: "ws-api"})
+	m.closeError = "Failed to close workspace: herdr workspace close w1: boom"
+	line := ansi.Strip(m.footerLine(emptyStyle.Render(m.closeError), 80))
+	if !strings.Contains(line, "close w1: boom") || strings.Contains(line, "LAST WORKSPACE") || strings.Contains(line, "last:") {
+		t.Fatalf("close error did not get the whole footer row: %q", line)
+	}
+}
+
 func TestTeaModelLastWorkspaceUnavailable(t *testing.T) {
 	m := newTeaModel(nil, Options{LastWorkspaceUnknown: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 
 	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
 		t.Fatalf("view missing unavailable state:\n%s", view)
@@ -881,6 +942,8 @@ func TestTeaModelUnnamedLastWorkspaceDoesNotRepeatCompactedPath(t *testing.T) {
 		LastWorkspaceID: "ws-api",
 		HerdrWorkspaces: []model.Session{{Source: "herdr", Path: "/home/test/api", WorkspaceID: "ws-api"}},
 	})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
 	if strings.Count(view, "~/api") != 1 {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -880,6 +880,21 @@ func TestTeaModelCanHideLastWorkspacePath(t *testing.T) {
 	}
 }
 
+func TestTeaModelCanHideLastWorkspace(t *testing.T) {
+	m := newTeaModel(nil, Options{
+		HideLastWorkspace: true,
+		LastWorkspaceID:   "ws-api",
+		HerdrWorkspaces:   []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "ws-api"}},
+	})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 24})
+	m = updated.(teaModel)
+
+	view := ansi.Strip(m.View().Content)
+	if strings.Contains(view, "LAST WORKSPACE") || strings.Contains(view, "last: api") || strings.Contains(view, "/live/api") {
+		t.Fatalf("view did not hide last workspace feature:\n%s", view)
+	}
+}
+
 func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
 	m := newTeaModel(nil, Options{LastWorkspaceID: "ws-api"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -865,6 +865,21 @@ func TestTeaModelLastWorkspaceUsesRawHerdrMetadata(t *testing.T) {
 	}
 }
 
+func TestTeaModelCanHideLastWorkspacePath(t *testing.T) {
+	m := newTeaModel(nil, Options{
+		HideLastWorkspacePath: true,
+		LastWorkspaceID:       "ws-api",
+		HerdrWorkspaces:       []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "ws-api"}},
+	})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 24})
+	m = updated.(teaModel)
+
+	view := ansi.Strip(m.View().Content)
+	if !strings.Contains(view, "LAST WORKSPACE · api") || strings.Contains(view, "/live/api") {
+		t.Fatalf("view did not hide last workspace path:\n%s", view)
+	}
+}
+
 func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
 	m := newTeaModel(nil, Options{LastWorkspaceID: "ws-api"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -292,6 +292,35 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlXRefreshesHerdrMetadataWhenSessionReloadFails(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "closing", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "old label", WorkspaceID: "w2"},
+	}, Options{
+		LastWorkspaceID: "w2",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "old label", WorkspaceID: "w2"}},
+		CloseWorkspace:  func(context.Context, string) error { return nil },
+		ReloadPicker: func(context.Context) (ReloadResult, error) {
+			return ReloadResult{
+				HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "new label", WorkspaceID: "w2"}},
+				LastWorkspaceID: "w2",
+			}, errors.New("config refresh failed")
+		},
+	})
+
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(closeCmd())
+	m = updated.(teaModel)
+
+	if got, want := sessionNames(m.list.All), []string{"old label"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sessions=%v want retained rows %v", got, want)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · new label") {
+		t.Fatalf("view kept stale Herdr metadata:\n%s", view)
+	}
+}
+
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -71,8 +71,8 @@ func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
 	if current, ok := m.list.Current(); !ok || current.Name != "api" {
 		t.Fatalf("current = %#v ok=%v, want api", current, ok)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k move · ctrl+x close · ctrl+r workspace · esc exit") {
-		t.Fatalf("default-width view missing complete navigation help:\n%s", view)
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "enter select · ctrl+j/k") || !strings.Contains(view, "LAST WORKSPACE · None recorded") {
+		t.Fatalf("default-width view missing navigation help or last workspace:\n%s", view)
 	}
 }
 
@@ -131,6 +131,40 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 	}
 }
 
+func TestTeaModelCtrlXUpdatesLastWorkspace(t *testing.T) {
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "previous", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "older", WorkspaceID: "w2"},
+	}, Options{
+		RecentWorkspaceIDs: []string{"current", "current", "w1", "w2"},
+		LastWorkspaceID:    "w1",
+		HerdrWorkspaces: []model.Session{
+			{Source: "herdr", Name: "previous", WorkspaceID: "w1"},
+			{Source: "herdr", Name: "older", WorkspaceID: "w2"},
+		},
+		CloseWorkspace: func(context.Context, string) error { return nil },
+		ReloadPicker: func(context.Context) (ReloadResult, error) {
+			return ReloadResult{
+				Sessions:        []model.Session{{Source: "herdr", Name: "older", WorkspaceID: "w2"}},
+				HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "older", WorkspaceID: "w2"}},
+				LastWorkspaceID: "w2",
+			}, nil
+		},
+	})
+
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(closeCmd())
+	m = updated.(teaModel)
+
+	if m.lastWorkspaceID != "w2" {
+		t.Fatalf("last workspace=%q, want w2", m.lastWorkspaceID)
+	}
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · older") {
+		t.Fatalf("view missing updated last workspace:\n%s", view)
+	}
+}
+
 func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
 	tests := []struct {
 		name string
@@ -174,9 +208,9 @@ func TestTeaModelCtrlCCancelsWorkspaceCloseAndQuitsAfterResult(t *testing.T) {
 		}}},
 		{name: "reload", opts: Options{
 			CloseWorkspace: func(context.Context, string) error { return nil },
-			ReloadSessions: func(ctx context.Context) ([]model.Session, error) {
+			ReloadPicker: func(ctx context.Context) (ReloadResult, error) {
 				<-ctx.Done()
-				return nil, ctx.Err()
+				return ReloadResult{}, ctx.Err()
 			},
 		}},
 	}
@@ -210,11 +244,11 @@ func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
 		CloseWorkspace: func(context.Context, string) error { return nil },
-		ReloadSessions: func(context.Context) ([]model.Session, error) {
-			return []model.Session{
+		ReloadPicker: func(context.Context) (ReloadResult, error) {
+			return ReloadResult{Sessions: []model.Session{
 				{Source: "config", Name: "api", Path: "/configured/api"},
 				{Source: "herdr", Name: "web", WorkspaceID: "w2"},
-			}, nil
+			}}, nil
 		},
 	})
 
@@ -238,7 +272,9 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
 	}, Options{
 		CloseWorkspace: func(context.Context, string) error { return nil },
-		ReloadSessions: func(context.Context) ([]model.Session, error) { return nil, errors.New("workspace list failed") },
+		ReloadPicker: func(context.Context) (ReloadResult, error) {
+			return ReloadResult{LastWorkspaceUnknown: true}, errors.New("workspace list failed")
+		},
 	})
 
 	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
@@ -249,8 +285,10 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sessions=%v want %v", got, want)
 	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "workspace list failed") {
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "Workspace closed, but sessions could not be r…") {
 		t.Fatalf("view missing reload failure:\n%s", view)
+	} else if !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
+		t.Fatalf("view did not refresh last workspace after reload failure:\n%s", view)
 	}
 }
 
@@ -731,20 +769,22 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	t.Cleanup(func() { renderPreview = oldPreview })
 
 	m := newTeaModel([]model.Session{
-		{Source: "herdr", Name: "workspace-api", Path: "/tmp/workspace-api", AgentStatus: "working"},
+		{Source: "herdr", Name: "workspace-api", Path: "/tmp/workspace-api", WorkspaceID: "ws-api", AgentStatus: "working"},
 		{Source: "zoxide", Name: "tools", Path: "/tmp/tools"},
 		{Source: "config", Name: "api", Path: "/tmp/api"},
 	}, Options{
-		Prompt:      "Find> ",
-		Placeholder: "Search sessions",
-		ShowIcons:   true,
+		Prompt:          "Find> ",
+		Placeholder:     "Search sessions",
+		ShowIcons:       true,
+		LastWorkspaceID: "ws-api",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "workspace-api", Path: "/tmp/workspace-api", WorkspaceID: "ws-api"}},
 	})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 30})
 	m = updated.(teaModel)
 	updated, _ = m.Update(previewCommand(m.previewKey, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)())
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
-	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "WORKSPACES", "PREVIEW · workspace-api · working", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
+	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "LAST WORKSPACE · workspace-api  /tmp/workspace-api", "WORKSPACES", "PREVIEW · workspace-api · working", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}
@@ -754,6 +794,68 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	}
 	if got, want := maxLineWidth(view), 160; got != want {
 		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
+	}
+}
+
+func TestTeaModelLastWorkspaceFallsBackToRecordedID(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "herdr", Name: "current", WorkspaceID: "current"}}, Options{LastWorkspaceID: "unavailable-workspace"})
+
+	view := ansi.Strip(m.View().Content)
+	if !strings.Contains(view, "LAST WORKSPACE · unavailable-workspace") {
+		t.Fatalf("view missing recorded workspace ID:\n%s", view)
+	}
+}
+
+func TestTeaModelLastWorkspaceUsesRawHerdrMetadata(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "config", Name: "api", Path: "/configured/api"}}, Options{
+		LastWorkspaceID: "ws-api",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "ws-api"}},
+	})
+
+	view := ansi.Strip(m.View().Content)
+	if !strings.Contains(view, "LAST WORKSPACE · api  /live/api") {
+		t.Fatalf("view did not use raw Herdr workspace metadata:\n%s", view)
+	}
+}
+
+func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
+	m := newTeaModel(nil, Options{LastWorkspaceID: "ws-api"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = updated.(teaModel)
+
+	view := ansi.Strip(m.View().Content)
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "LAST WORKSPACE") {
+			if !strings.Contains(line, "enter select") {
+				t.Fatalf("last workspace is not on keybind row: %q", line)
+			}
+			if want := "LAST WORKSPACE · ws-api"; !strings.HasSuffix(strings.TrimSpace(line), want) {
+				t.Fatalf("last workspace is not right-aligned: %q", line)
+			}
+			return
+		}
+	}
+	t.Fatalf("view missing last workspace footer:\n%s", view)
+}
+
+func TestTeaModelLastWorkspaceUnavailable(t *testing.T) {
+	m := newTeaModel(nil, Options{LastWorkspaceUnknown: true})
+
+	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
+		t.Fatalf("view missing unavailable state:\n%s", view)
+	}
+}
+
+func TestTeaModelUnnamedLastWorkspaceDoesNotRepeatCompactedPath(t *testing.T) {
+	t.Setenv("HOME", "/home/test")
+	m := newTeaModel(nil, Options{
+		LastWorkspaceID: "ws-api",
+		HerdrWorkspaces: []model.Session{{Source: "herdr", Path: "/home/test/api", WorkspaceID: "ws-api"}},
+	})
+
+	view := ansi.Strip(m.View().Content)
+	if strings.Count(view, "~/api") != 1 {
+		t.Fatalf("view repeated compacted workspace path:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- show the workspace targeted by `herdr-sesh last` in the picker footer
- resolve workspace metadata independently of picker deduplication and refresh it after closes
- keep the last-workspace status right-aligned alongside responsive keybind help

## Validation
- `just test`
- `just lint`
- `just fmt-check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

