### PR TITLE
feat(config): add validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The plugin binary also exposes its underlying operations directly:
 | `herdr-sesh window [PATH]` | List tabs or create one for a path. |
 | `herdr-sesh config path` | Print the resolved plugin config path. |
 | `herdr-sesh config init` | Create a starter config if one does not exist. |
+| `herdr-sesh config validate [PATH]` | Validate the active or specified config and print its resolved path. |
 | `herdr-sesh config migrate` | Convert a legacy Sesh-style config to the native format. |
 
 The binary lives inside Herdr's managed plugin checkout after installation; the

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,9 @@ as legacy. `config path` prints the file that would load, or the native
 starter file only when no config exists anywhere in the lookup order; an
 existing config (legacy included) is printed instead so init can never shadow
 it. With `HERDR_SESH_CONFIG` set to a missing path, init creates the starter
-at that exact path.
+at that exact path. `config validate [PATH]` strictly validates the active or
+specified config and prints its resolved path on success. It returns an error
+when no config exists; legacy files remain valid but emit the migration warning.
 
 For a linked Herdr plugin, create or inspect the plugin-owned config with:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -540,7 +540,7 @@ func (a *App) plugin(ctx context.Context, args []string) error {
 }
 func (a *App) config(_ context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("config requires path, init, or migrate")
+		return errors.New("config requires path, init, validate, or migrate")
 	}
 	dir := os.Getenv("HERDR_PLUGIN_CONFIG_DIR")
 	if dir == "" {
@@ -584,6 +584,8 @@ func (a *App) config(_ context.Context, args []string) error {
 		}
 		_, err = fmt.Fprintln(a.Out, p)
 		return err
+	case "validate":
+		return a.validateConfig(args[1:])
 	case "migrate":
 		fs := flag.NewFlagSet("config migrate", flag.ContinueOnError)
 		fs.SetOutput(a.Err)
@@ -632,4 +634,26 @@ func (a *App) config(_ context.Context, args []string) error {
 	default:
 		return errors.New("unknown config command")
 	}
+}
+
+func (a *App) validateConfig(args []string) error {
+	if len(args) > 1 {
+		return errors.New("config validate accepts at most one path")
+	}
+	var path string
+	if len(args) == 1 {
+		path = args[0] //nolint:gosec // len(args) is exactly one.
+		if path == "" {
+			return errors.New("config validate path must not be empty")
+		}
+	}
+	_, resolved, err := config.Load(config.LoadOptions{Path: path, Warn: a.Err, StrictLegacy: true})
+	if err != nil {
+		return err
+	}
+	if resolved == "" {
+		return errors.New("no config file found")
+	}
+	_, err = fmt.Fprintln(a.Out, resolved)
+	return err
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -59,6 +59,122 @@ func TestConfigPathCommand(t *testing.T) {
 	}
 }
 
+func TestConfigValidatePrintsResolvedNativePath(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)
+	t.Setenv("HERDR_SESH_CONFIG", "")
+	t.Setenv("HOME", d)
+	native := filepath.Join(d, config.NativeFileName)
+	if err := os.WriteFile(native, []byte("version = 1\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	a := &App{Out: &out, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), []string{"config", "validate"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != native {
+		t.Fatalf("stdout = %q, want %q", out.String(), native)
+	}
+}
+
+func TestConfigValidateWarnsForLegacyConfig(t *testing.T) {
+	legacy := filepath.Join(t.TempDir(), config.LegacyFileName)
+	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errb bytes.Buffer
+	a := &App{Out: &out, Err: &errb}
+	if err := a.Run(context.Background(), []string{"config", "validate", legacy}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != legacy {
+		t.Fatalf("stdout = %q, want %q", out.String(), legacy)
+	}
+	if !strings.Contains(errb.String(), "deprecated Sesh-compatible schema") {
+		t.Fatalf("stderr = %q, want legacy deprecation warning", errb.String())
+	}
+}
+
+func TestConfigValidateRejectsUnknownLegacyKey(t *testing.T) {
+	legacy := filepath.Join(t.TempDir(), config.LegacyFileName)
+	if err := os.WriteFile(legacy, []byte("cahe = true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate", legacy})
+	if err == nil || !strings.Contains(err.Error(), "cahe") {
+		t.Fatalf("err = %v, want unknown legacy key", err)
+	}
+}
+
+func TestConfigValidateRejectsUnknownLegacyKeyInImport(t *testing.T) {
+	d := t.TempDir()
+	if err := os.WriteFile(filepath.Join(d, "extra.toml"), []byte("cahe = true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(d, config.LegacyFileName)
+	if err := os.WriteFile(legacy, []byte("import = [\"extra.toml\"]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate", legacy})
+	if err == nil || !strings.Contains(err.Error(), "cahe") {
+		t.Fatalf("err = %v, want unknown imported legacy key", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidNativeConfig(t *testing.T) {
+	native := filepath.Join(t.TempDir(), config.NativeFileName)
+	if err := os.WriteFile(native, []byte("version = 1\nunknown = true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate", native})
+	if err == nil || !strings.Contains(err.Error(), "unknown keys") {
+		t.Fatalf("err = %v, want native validation error", err)
+	}
+}
+
+func TestConfigValidateRequiresExistingConfig(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)
+	t.Setenv("HERDR_SESH_CONFIG", "")
+	t.Setenv("HOME", d)
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate"})
+	if err == nil || !strings.Contains(err.Error(), "no config file found") {
+		t.Fatalf("err = %v, want missing config error", err)
+	}
+}
+
+func TestConfigValidateAcceptsAtMostOnePath(t *testing.T) {
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate", "first.toml", "second.toml"})
+	if err == nil || !strings.Contains(err.Error(), "accepts at most one path") {
+		t.Fatalf("err = %v, want extra path error", err)
+	}
+}
+
+func TestConfigValidateRejectsEmptyPath(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)
+	t.Setenv("HERDR_SESH_CONFIG", "")
+	t.Setenv("HOME", d)
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"config", "validate", ""})
+	if err == nil || !strings.Contains(err.Error(), "path must not be empty") {
+		t.Fatalf("err = %v, want empty path error", err)
+	}
+}
+
 func TestConfigInitDoesNotShadowActiveLegacyConfig(t *testing.T) {
 	d := t.TempDir()
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -12,9 +12,10 @@ import (
 )
 
 type LoadOptions struct {
-	Path string
-	Env  map[string]string
-	Home string
+	Path         string
+	Env          map[string]string
+	Home         string
+	StrictLegacy bool
 	// Warn receives legacy-schema deprecation warnings; nil means os.Stderr.
 	Warn io.Writer
 }
@@ -71,15 +72,15 @@ func Load(opts LoadOptions) (Config, string, error) {
 		warn = os.Stderr
 	}
 	_, _ = fmt.Fprintf(warn, "warning: %s uses the deprecated Sesh-compatible schema; run 'herdr-sesh config migrate' to convert it (see docs/config.md)\n", path)
-	if err := decodeLegacy(&cfg, path); err != nil {
+	if err := decodeLegacy(&cfg, path, opts.StrictLegacy); err != nil {
 		return cfg, path, err
 	}
 	return cfg, path, nil
 }
 
-func decodeLegacy(cfg *Config, path string) error {
+func decodeLegacy(cfg *Config, path string, strict bool) error {
 	seen := map[string]bool{}
-	if err := loadInto(cfg, path, seen, false); err != nil {
+	if err := loadInto(cfg, path, seen, strict); err != nil {
 		return err
 	}
 	attachDefaults(cfg)
@@ -109,7 +110,7 @@ func resolve(opts LoadOptions) (string, fileKind, error) {
 		p := ExpandHome(opts.Path, home)
 		if err := statConfigFile(p); err != nil {
 			if os.IsNotExist(err) {
-				return "", kindExplicit, os.ErrNotExist
+				return "", kindExplicit, fmt.Errorf("config path %s: %w", p, os.ErrNotExist)
 			}
 			return "", kindExplicit, err
 		}
@@ -202,6 +203,10 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 	}
 	var next Config
 	if err := dec.Decode(&next); err != nil {
+		var missing *toml.StrictMissingError
+		if errors.As(err, &missing) {
+			return fmt.Errorf("load %s: unknown keys:\n%s", path, missing.String())
+		}
 		return fmt.Errorf("load %s: %w", path, err)
 	}
 	base := filepath.Dir(abs)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,12 +1,24 @@
 package config
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestLoadMissingExplicitPathIncludesPath(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "missing.toml")
+	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want os.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), p) {
+		t.Fatalf("err = %v, want missing path %q", err, p)
+	}
+}
 
 func TestLoadExplicitSessionAndWindows(t *testing.T) {
 	d := t.TempDir()

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -92,7 +92,7 @@ func Migrate(opts LoadOptions, fallbackDir string, force bool) (legacyPath, nati
 		return "", "", fmt.Errorf("%s is already a native config", path)
 	}
 	cfg := Default()
-	if err := decodeLegacy(&cfg, path); err != nil {
+	if err := decodeLegacy(&cfg, path, false); err != nil {
 		return "", "", err
 	}
 	// A legacy file that never mentions show_icons migrates to the

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-go = "1.26"
+go = "1.27"
 cargo-binstall = "1.21.1"
-golangci-lint = "v2.12.2"
+golangci-lint = "v2.13.1"
 gotestsum = "1.13.0"
 just = "1.58.0"
 fzf = "0.74.3"


### PR DESCRIPTION
## Summary
- add `herdr-sesh config validate [PATH]` for active or explicit configuration files
- strictly validate native and legacy configuration, including legacy imports, with readable key and path errors
- document the command and cover success, warning, invalid, missing, and argument cases
- include the Go and golangci-lint tool updates already present on `dev`

## Validation
- `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-golangci-cache just check` (266 tests)
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `./bin/herdr-sesh config validate testdata/herdr-sesh.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

