### PR TITLE
feat(picker): inherit Herdr theme colors

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -82,10 +82,18 @@ and teal `●` when done. Workspaces with an unknown state have no indicator.
 
 ## Picker colors
 
-The native picker inherits colors from Herdr's own `[theme.custom]` tokens so it
-matches the running Herdr theme. The picker reads the same config file Herdr
-uses (`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr/config.toml`, then
-`~/.config/herdr/config.toml`).
+The native picker inherits colors from Herdr's own theme so it matches the
+running Herdr UI. It reads the same config file Herdr uses
+(`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr/config.toml`, then
+`~/.config/herdr/config.toml`) and resolves `[theme] name` against Herdr's
+built-in themes:
+
+`catppuccin` (default), `catppuccin-latte`, `tokyo-night`, `tokyo-night-day`,
+`dracula`, `nord`, `gruvbox`, `gruvbox-light`, `one-dark`, `one-light`,
+`solarized`, `solarized-light`, `kanagawa`, `kanagawa-lotus`, `rose-pine`,
+`rose-pine-dawn`, and `vesper`. Common aliases (`catppuccin-mocha`,
+`tokyonight`, `onedark`, …) are accepted, as are `[theme.custom]` overrides on
+top of any base theme.
 
 | Herdr token | Picker role |
 | --- | --- |
@@ -98,10 +106,11 @@ uses (`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr/config.toml`, then
 | `red` | Blocked agents (`◉`) |
 | `overlay1` | Ghost cursor trail |
 
-Tokens that are absent, unknown, or not a `#RGB`/`#RRGGBB` hex value leave that
+Custom tokens that are unknown or not a `#RGB`/`#RRGGBB` hex value leave that
 role's built-in color in place, so partial `[theme.custom]` tables only affect
-the roles they define. Named themes without custom tokens are not resolved;
-add explicit `[theme.custom]` entries to tint the picker.
+the roles they define. The ANSI-based `terminal` theme has no fixed palette to
+inherit; the picker keeps its built-in colors there unless you add explicit
+overrides.
 
 ## `[workspace_defaults]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -80,6 +80,29 @@ Open Herdr workspaces show the agent state reported by Herdr: an animated amber
 Jump spinner (`⢄⢂⢁⡁⡈⡐⡠`) while working, red `◉` when blocked, green `✓` when idle,
 and teal `●` when done. Workspaces with an unknown state have no indicator.
 
+## Picker colors
+
+The native picker inherits colors from Herdr's own `[theme.custom]` tokens so it
+matches the running Herdr theme. The picker reads the same config file Herdr
+uses (`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr/config.toml`, then
+`~/.config/herdr/config.toml`).
+
+| Herdr token | Picker role |
+| --- | --- |
+| `accent` | Prompt, cursor, and selection rail |
+| `mauve` | Title, section headers, search matches, smear trail |
+| `text` | Row labels |
+| `subtext0` | Paths, counts, help text |
+| `green` | Idle agents (`✓`) |
+| `yellow` | Working agents (spinner) and the empty-state message |
+| `red` | Blocked agents (`◉`) |
+| `overlay1` | Ghost cursor trail |
+
+Tokens that are absent, unknown, or not a `#RGB`/`#RRGGBB` hex value leave that
+role's built-in color in place, so partial `[theme.custom]` tables only affect
+the roles they define. Named themes without custom tokens are not resolved;
+add explicit `[theme.custom]` entries to tint the picker.
+
 ## `[workspace_defaults]`
 
 | Field | Runtime effect |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -232,6 +232,8 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		return err
 	}
 	useFZF := *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf")
+	// Inherit Herdr's theme so both pickers render with its colors.
+	pickerpkg.ApplyHerdrThemeFromConfig()
 	var sessions, herdrWorkspaces []model.Session
 	if useFZF || *jsonOut {
 		sessions, err = a.collectAllowUnavailableHerdr(ctx, cfg, "")

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -5,14 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	toml "github.com/pelletier/go-toml/v2"
 )
 
-// herdrTokenRoles maps Herdr [theme.custom] token names to the picker color
-// roles they feed. Tokens that are absent or invalid leave the built-in
-// default in place.
 var herdrTokenRoles = map[string]*color.Color{
 	"text":     &textColor,
 	"subtext0": &mutedColor,
@@ -24,15 +22,226 @@ var herdrTokenRoles = map[string]*color.Color{
 	"overlay1": &ghostColor,
 }
 
+// herdrThemePalettes mirrors Herdr's built-in palettes (herdrdev/herdr
+// src/app/state.rs) for the tokens the picker consumes.
+var herdrThemePalettes = map[string]map[string]string{
+	"catppuccin": {
+		"accent":   "#89b4fa",
+		"mauve":    "#cba6f7",
+		"text":     "#cdd6f4",
+		"subtext0": "#a6adc8",
+		"green":    "#a6e3a1",
+		"yellow":   "#f9e2af",
+		"red":      "#f38ba8",
+		"overlay1": "#7f849c",
+	},
+	"catppuccin-latte": {
+		"accent":   "#1e66f5",
+		"mauve":    "#8839ef",
+		"text":     "#4c4f69",
+		"subtext0": "#6c6f85",
+		"green":    "#40a02b",
+		"yellow":   "#df8e1d",
+		"red":      "#d20f39",
+		"overlay1": "#8c8fa1",
+	},
+	"tokyo-night": {
+		"accent":   "#7aa2f7",
+		"mauve":    "#bb9af7",
+		"text":     "#c0caf5",
+		"subtext0": "#a9b1d6",
+		"green":    "#9ece6a",
+		"yellow":   "#e0af68",
+		"red":      "#f7768e",
+		"overlay1": "#697196",
+	},
+	"tokyo-night-day": {
+		"accent":   "#2e7de9",
+		"mauve":    "#7847bd",
+		"text":     "#3760bf",
+		"subtext0": "#6172b0",
+		"green":    "#587539",
+		"yellow":   "#8c6c3e",
+		"red":      "#f52a65",
+		"overlay1": "#68709a",
+	},
+	"dracula": {
+		"accent":   "#bd93f9",
+		"mauve":    "#ff79c6",
+		"text":     "#f8f8f2",
+		"subtext0": "#d2d2dc",
+		"green":    "#50fa7b",
+		"yellow":   "#f1fa8c",
+		"red":      "#ff5555",
+		"overlay1": "#828cb4",
+	},
+	"nord": {
+		"accent":   "#88c0d0",
+		"mauve":    "#b48ead",
+		"text":     "#eceff4",
+		"subtext0": "#d8dee9",
+		"green":    "#a3be8c",
+		"yellow":   "#ebcb8b",
+		"red":      "#bf616a",
+		"overlay1": "#646e82",
+	},
+	"gruvbox": {
+		"accent":   "#d79921",
+		"mauve":    "#d3869b",
+		"text":     "#ebdbb2",
+		"subtext0": "#d5c4a1",
+		"green":    "#b8bb26",
+		"yellow":   "#fabd2f",
+		"red":      "#fb4934",
+		"overlay1": "#a89984",
+	},
+	"gruvbox-light": {
+		"accent":   "#076678",
+		"mauve":    "#8f3f71",
+		"text":     "#3c3836",
+		"subtext0": "#504945",
+		"green":    "#79740e",
+		"yellow":   "#b57614",
+		"red":      "#9d0006",
+		"overlay1": "#7c6f64",
+	},
+	"one-dark": {
+		"accent":   "#61afef",
+		"mauve":    "#c678dd",
+		"text":     "#abb2bf",
+		"subtext0": "#969ca8",
+		"green":    "#98c379",
+		"yellow":   "#e5c07b",
+		"red":      "#e06c75",
+		"overlay1": "#737a87",
+	},
+	"one-light": {
+		"accent":   "#4078f2",
+		"mauve":    "#a626a4",
+		"text":     "#383a42",
+		"subtext0": "#686b77",
+		"green":    "#50a14f",
+		"yellow":   "#c18401",
+		"red":      "#e45649",
+		"overlay1": "#686b77",
+	},
+	"solarized": {
+		"accent":   "#268bd2",
+		"mauve":    "#d33682",
+		"text":     "#93a1a1",
+		"subtext0": "#839496",
+		"green":    "#859900",
+		"yellow":   "#b58900",
+		"red":      "#dc322f",
+		"overlay1": "#657b83",
+	},
+	"solarized-light": {
+		"accent":   "#268bd2",
+		"mauve":    "#d33682",
+		"text":     "#657b83",
+		"subtext0": "#839496",
+		"green":    "#859900",
+		"yellow":   "#b58900",
+		"red":      "#dc322f",
+		"overlay1": "#586e75",
+	},
+	"kanagawa": {
+		"accent":   "#7e9cd8",
+		"mauve":    "#957fb8",
+		"text":     "#dcd7ba",
+		"subtext0": "#c8c3aa",
+		"green":    "#76946a",
+		"yellow":   "#c0a36e",
+		"red":      "#c34043",
+		"overlay1": "#87867d",
+	},
+	"kanagawa-lotus": {
+		"accent":   "#4d699b",
+		"mauve":    "#624c83",
+		"text":     "#545464",
+		"subtext0": "#43436c",
+		"green":    "#6f894e",
+		"yellow":   "#77713f",
+		"red":      "#c84053",
+		"overlay1": "#8a8980",
+	},
+	"rose-pine": {
+		"accent":   "#c4a7e7",
+		"mauve":    "#c4a7e7",
+		"text":     "#e0def4",
+		"subtext0": "#c8c5dc",
+		"green":    "#31748f",
+		"yellow":   "#f6c177",
+		"red":      "#eb6f92",
+		"overlay1": "#908caa",
+	},
+	"rose-pine-dawn": {
+		"accent":   "#907aa9",
+		"mauve":    "#907aa9",
+		"text":     "#464261",
+		"subtext0": "#797593",
+		"green":    "#286983",
+		"yellow":   "#ea9d34",
+		"red":      "#b4637a",
+		"overlay1": "#797593",
+	},
+	"vesper": {
+		"accent":   "#ffc799",
+		"mauve":    "#ffd1a8",
+		"text":     "#ffffff",
+		"subtext0": "#a0a0a0",
+		"green":    "#99ffe4",
+		"yellow":   "#ffc799",
+		"red":      "#ff8080",
+		"overlay1": "#7e7e7e",
+	},
+}
+
+const defaultHerdrTheme = "catppuccin"
+
+var herdrThemeAliases = map[string]string{
+	"catppuccin":       "catppuccin",
+	"catppuccin-mocha": "catppuccin",
+	"latte":            "catppuccin-latte",
+	"light":            "catppuccin-latte",
+	"terminal":         "terminal",
+	"tokyo-night":      "tokyo-night",
+	"tokyonight":       "tokyo-night",
+	"tokyo-night-day":  "tokyo-night-day",
+	"tokyo-day":        "tokyo-night-day",
+	"tokyonight-day":   "tokyo-night-day",
+	"dracula":          "dracula",
+	"nord":             "nord",
+	"gruvbox":          "gruvbox",
+	"gruvbox-dark":     "gruvbox",
+	"gruvbox-light":    "gruvbox-light",
+	"one-dark":         "one-dark",
+	"onedark":          "one-dark",
+	"one-light":        "one-light",
+	"onelight":         "one-light",
+	"solarized":        "solarized",
+	"solarized-dark":   "solarized",
+	"solarized-light":  "solarized-light",
+	"kanagawa":         "kanagawa",
+	"kanagawa-lotus":   "kanagawa-lotus",
+	"lotus":            "kanagawa-lotus",
+	"rose-pine":        "rose-pine",
+	"rosepine":         "rose-pine",
+	"rose-pine-dawn":   "rose-pine-dawn",
+	"rosepine-dawn":    "rose-pine-dawn",
+	"dawn":             "rose-pine-dawn",
+	"vesper":           "vesper",
+}
+
 var hexColorPattern = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
 
 type herdrThemeConfig struct {
 	Theme struct {
+		Name   string            `toml:"name"`
 		Custom map[string]string `toml:"custom"`
 	} `toml:"theme"`
 }
 
-// herdrConfigPath mirrors Herdr's own lookup order for its config file.
 func herdrConfigPath() string {
 	if path := os.Getenv("HERDR_CONFIG_PATH"); path != "" {
 		return path
@@ -48,31 +257,54 @@ func herdrConfigPath() string {
 	return filepath.Join(configDir, "herdr", "config.toml")
 }
 
-// loadHerdrThemeCustom reads the [theme.custom] token table from a Herdr
-// config file. A missing file, missing table, or unparsable file yields nil.
-func loadHerdrThemeCustom(path string) map[string]string {
+func loadHerdrThemeConfig(path string) (string, map[string]string) {
 	if path == "" {
-		return nil
+		return "", nil
 	}
 	//nolint:gosec // the config path is user-selected by design.
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		return "", nil
 	}
 	var parsed herdrThemeConfig
 	if err := toml.Unmarshal(data, &parsed); err != nil {
-		return nil
+		return "", nil
 	}
-	return parsed.Theme.Custom
+	return parsed.Theme.Name, parsed.Theme.Custom
 }
 
-// validHexColor reports whether value is a #RGB or #RRGGBB hex color.
 func validHexColor(value string) bool {
 	return hexColorPattern.MatchString(value)
 }
 
-// rebuildPickerStyles recreates every style that captured a color variable at
-// package initialization time.
+func resolveHerdrThemeTokens(name string, custom map[string]string) map[string]string {
+	tokens := map[string]string{}
+	switch key := herdrThemeAliases[canonicalHerdrThemeName(name)]; {
+	case key == "terminal":
+	case key != "":
+		for token, value := range herdrThemePalettes[key] {
+			tokens[token] = value
+		}
+	default:
+		for token, value := range herdrThemePalettes[defaultHerdrTheme] {
+			tokens[token] = value
+		}
+	}
+	for token, value := range custom {
+		if value == "" {
+			continue
+		}
+		tokens[token] = value
+	}
+	return tokens
+}
+
+func canonicalHerdrThemeName(raw string) string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	name = strings.ReplaceAll(name, " ", "-")
+	return strings.ReplaceAll(name, "_", "-")
+}
+
 func rebuildPickerStyles() {
 	titleStyle = lipgloss.NewStyle().
 		Foreground(violetColor).
@@ -117,14 +349,11 @@ func rebuildPickerStyles() {
 		Foreground(mutedColor)
 }
 
-// applyHerdrTheme overrides the picker palette from Herdr [theme.custom]
-// tokens and refreshes the dependent styles. Unknown or invalid tokens are
-// ignored, so partial tables only affect the roles they define.
-func applyHerdrTheme(custom map[string]string) {
-	if len(custom) == 0 {
+func applyHerdrTheme(tokens map[string]string) {
+	if len(tokens) == 0 {
 		return
 	}
-	for token, value := range custom {
+	for token, value := range tokens {
 		target, ok := herdrTokenRoles[token]
 		if !ok || !validHexColor(value) {
 			continue
@@ -134,9 +363,7 @@ func applyHerdrTheme(custom map[string]string) {
 	rebuildPickerStyles()
 }
 
-// ApplyHerdrThemeFromConfig loads Herdr's own config file and applies its
-// [theme.custom] tokens to the picker palette. A missing or malformed file
-// leaves the built-in palette untouched.
 func ApplyHerdrThemeFromConfig() {
-	applyHerdrTheme(loadHerdrThemeCustom(herdrConfigPath()))
+	name, custom := loadHerdrThemeConfig(herdrConfigPath())
+	applyHerdrTheme(resolveHerdrThemeTokens(name, custom))
 }

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -202,6 +202,7 @@ const defaultHerdrTheme = "catppuccin"
 var herdrThemeAliases = map[string]string{
 	"catppuccin":       "catppuccin",
 	"catppuccin-mocha": "catppuccin",
+	"catppuccin-latte": "catppuccin-latte",
 	"latte":            "catppuccin-latte",
 	"light":            "catppuccin-latte",
 	"terminal":         "terminal",
@@ -291,7 +292,7 @@ func resolveHerdrThemeTokens(name string, custom map[string]string) map[string]s
 		}
 	}
 	for token, value := range custom {
-		if value == "" {
+		if !validHexColor(value) {
 			continue
 		}
 		tokens[token] = value

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -1,0 +1,142 @@
+package picker
+
+import (
+	"image/color"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"charm.land/lipgloss/v2"
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// herdrTokenRoles maps Herdr [theme.custom] token names to the picker color
+// roles they feed. Tokens that are absent or invalid leave the built-in
+// default in place.
+var herdrTokenRoles = map[string]*color.Color{
+	"text":     &textColor,
+	"subtext0": &mutedColor,
+	"green":    &greenColor,
+	"yellow":   &amberColor,
+	"red":      &redColor,
+	"accent":   &skyColor,
+	"mauve":    &violetColor,
+	"overlay1": &ghostColor,
+}
+
+var hexColorPattern = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
+
+type herdrThemeConfig struct {
+	Theme struct {
+		Custom map[string]string `toml:"custom"`
+	} `toml:"theme"`
+}
+
+// herdrConfigPath mirrors Herdr's own lookup order for its config file.
+func herdrConfigPath() string {
+	if path := os.Getenv("HERDR_CONFIG_PATH"); path != "" {
+		return path
+	}
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if configDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		configDir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configDir, "herdr", "config.toml")
+}
+
+// loadHerdrThemeCustom reads the [theme.custom] token table from a Herdr
+// config file. A missing file, missing table, or unparsable file yields nil.
+func loadHerdrThemeCustom(path string) map[string]string {
+	if path == "" {
+		return nil
+	}
+	//nolint:gosec // the config path is user-selected by design.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var parsed herdrThemeConfig
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		return nil
+	}
+	return parsed.Theme.Custom
+}
+
+// validHexColor reports whether value is a #RGB or #RRGGBB hex color.
+func validHexColor(value string) bool {
+	return hexColorPattern.MatchString(value)
+}
+
+// rebuildPickerStyles recreates every style that captured a color variable at
+// package initialization time.
+func rebuildPickerStyles() {
+	titleStyle = lipgloss.NewStyle().
+		Foreground(violetColor).
+		Bold(true)
+
+	countStyle = lipgloss.NewStyle().
+		Foreground(mutedColor)
+
+	sectionStyle = lipgloss.NewStyle().
+		Foreground(violetColor).
+		Bold(true)
+
+	ruleStyle = lipgloss.NewStyle().
+		Foreground(mutedColor)
+
+	rowLabelStyle = lipgloss.NewStyle().
+		Foreground(textColor)
+
+	selectedLabelStyle = rowLabelStyle.Bold(true)
+
+	matchStyle = lipgloss.NewStyle().
+		Foreground(violetColor).
+		Bold(true)
+
+	selectionRailStyle = lipgloss.NewStyle().
+		Foreground(skyColor).
+		Bold(true)
+
+	smearTrailStyle = lipgloss.NewStyle().
+		Foreground(violetColor)
+
+	pathStyle = lipgloss.NewStyle().
+		Foreground(mutedColor)
+
+	emptyStyle = lipgloss.NewStyle().
+		Foreground(amberColor)
+
+	moreStyle = lipgloss.NewStyle().
+		Foreground(mutedColor)
+
+	helpStyle = lipgloss.NewStyle().
+		Foreground(mutedColor)
+}
+
+// applyHerdrTheme overrides the picker palette from Herdr [theme.custom]
+// tokens and refreshes the dependent styles. Unknown or invalid tokens are
+// ignored, so partial tables only affect the roles they define.
+func applyHerdrTheme(custom map[string]string) {
+	if len(custom) == 0 {
+		return
+	}
+	for token, value := range custom {
+		target, ok := herdrTokenRoles[token]
+		if !ok || !validHexColor(value) {
+			continue
+		}
+		*target = lipgloss.Color(value)
+	}
+	rebuildPickerStyles()
+}
+
+// ApplyHerdrThemeFromConfig loads Herdr's own config file and applies its
+// [theme.custom] tokens to the picker palette. A missing or malformed file
+// leaves the built-in palette untouched.
+func ApplyHerdrThemeFromConfig() {
+	applyHerdrTheme(loadHerdrThemeCustom(herdrConfigPath()))
+}

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -1,0 +1,192 @@
+package picker
+
+import (
+	"image/color"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestValidHexColor(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "six digit hex", value: "#7FA563", want: true},
+		{name: "three digit hex", value: "#abc", want: true},
+		{name: "uppercase hex", value: "#D8647E", want: true},
+		{name: "missing hash", value: "7FA563", want: false},
+		{name: "too short", value: "#ab", want: false},
+		{name: "too long", value: "#aabbcce", want: false},
+		{name: "named color", value: "red", want: false},
+		{name: "empty", value: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validHexColor(tt.value); got != tt.want {
+				t.Errorf("validHexColor(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHerdrConfigPath(t *testing.T) {
+	t.Run("HERDR_CONFIG_PATH wins", func(t *testing.T) {
+		t.Setenv("HERDR_CONFIG_PATH", "/custom/herdr.toml")
+		t.Setenv("XDG_CONFIG_HOME", "/xdg")
+		if got := herdrConfigPath(); got != "/custom/herdr.toml" {
+			t.Errorf("herdrConfigPath() = %q, want /custom/herdr.toml", got)
+		}
+	})
+
+	t.Run("XDG_CONFIG_HOME fallback", func(t *testing.T) {
+		t.Setenv("HERDR_CONFIG_PATH", "")
+		t.Setenv("XDG_CONFIG_HOME", "/xdg")
+		want := filepath.Join("/xdg", "herdr", "config.toml")
+		if got := herdrConfigPath(); got != want {
+			t.Errorf("herdrConfigPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("home config fallback", func(t *testing.T) {
+		t.Setenv("HERDR_CONFIG_PATH", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+		got := herdrConfigPath()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("no home directory: %v", err)
+		}
+		want := filepath.Join(home, ".config", "herdr", "config.toml")
+		if got != want {
+			t.Errorf("herdrConfigPath() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestLoadHerdrThemeCustom(t *testing.T) {
+	t.Run("reads custom tokens and ignores unrelated tables", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.toml")
+		content := `
+[theme]
+name = "catppuccin"
+
+[theme.custom]
+text = "#cdcdcd"
+
+[[keys.command]]
+key = "prefix+t"
+type = "plugin_action"
+command = "fullerzz.sesh.open-picker"
+`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		custom := loadHerdrThemeCustom(path)
+		want := map[string]string{"text": "#cdcdcd"}
+		if !reflect.DeepEqual(custom, want) {
+			t.Errorf("loadHerdrThemeCustom() = %v, want %v", custom, want)
+		}
+	})
+
+	t.Run("missing file yields nil", func(t *testing.T) {
+		if got := loadHerdrThemeCustom(filepath.Join(t.TempDir(), "absent.toml")); got != nil {
+			t.Errorf("loadHerdrThemeCustom() = %v, want nil", got)
+		}
+	})
+
+	t.Run("invalid TOML yields nil", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.WriteFile(path, []byte("[theme"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if got := loadHerdrThemeCustom(path); got != nil {
+			t.Errorf("loadHerdrThemeCustom() = %v, want nil", got)
+		}
+	})
+}
+
+func TestApplyHerdrTheme(t *testing.T) {
+	saved := []struct {
+		target *color.Color
+		value  color.Color
+	}{
+		{&textColor, textColor},
+		{&mutedColor, mutedColor},
+		{&greenColor, greenColor},
+		{&amberColor, amberColor},
+		{&redColor, redColor},
+		{&skyColor, skyColor},
+		{&violetColor, violetColor},
+		{&ghostColor, ghostColor},
+	}
+	t.Cleanup(func() {
+		for _, s := range saved {
+			*s.target = s.value
+		}
+		rebuildPickerStyles()
+	})
+
+	t.Run("overrides valid tokens and skips the rest", func(t *testing.T) {
+		applyHerdrTheme(map[string]string{
+			"text":   "#112233",
+			"accent": "#445566",
+			"red":    "not-a-color",
+			"bogus":  "#abcdef",
+		})
+
+		if !reflect.DeepEqual(textColor, lipgloss.Color("#112233")) {
+			t.Errorf("textColor = %v, want #112233", textColor)
+		}
+		if !reflect.DeepEqual(skyColor, lipgloss.Color("#445566")) {
+			t.Errorf("skyColor = %v, want #445566", skyColor)
+		}
+		if redColor != saved[4].value {
+			t.Errorf("redColor = %v, want untouched default %v", redColor, saved[4].value)
+		}
+		if violetColor != saved[6].value {
+			t.Errorf("violetColor = %v, want untouched default %v", violetColor, saved[6].value)
+		}
+
+		if got := rowLabelStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#112233")) {
+			t.Errorf("rowLabelStyle foreground = %v, want #112233", got)
+		}
+		if got := selectedLabelStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#112233")) {
+			t.Errorf("selectedLabelStyle foreground = %v, want #112233", got)
+		}
+		if got := selectionRailStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#445566")) {
+			t.Errorf("selectionRailStyle foreground = %v, want #445566", got)
+		}
+	})
+
+	t.Run("empty table is a no-op", func(t *testing.T) {
+		before := textColor
+		applyHerdrTheme(map[string]string{})
+		if !reflect.DeepEqual(textColor, before) {
+			t.Errorf("textColor = %v, want unchanged %v", textColor, before)
+		}
+	})
+}
+
+func TestRebuildPickerStylesTracksColorVars(t *testing.T) {
+	original := violetColor
+	t.Cleanup(func() {
+		violetColor = original
+		rebuildPickerStyles()
+	})
+
+	violetColor = lipgloss.Color("#010203")
+	rebuildPickerStyles()
+
+	if got := titleStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#010203")) {
+		t.Errorf("titleStyle foreground = %v, want #010203", got)
+	}
+	if got := smearTrailStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#010203")) {
+		t.Errorf("smearTrailStyle foreground = %v, want #010203", got)
+	}
+}

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -225,6 +225,23 @@ func TestResolveHerdrThemeTokens(t *testing.T) {
 			},
 		},
 		{
+			name:    "canonical light name resolves its own palette",
+			rawName: "catppuccin-latte",
+			contains: map[string]string{
+				"accent": "#1e66f5",
+				"text":   "#4c4f69",
+			},
+		},
+		{
+			name:    "invalid custom tokens fall back to the base palette",
+			rawName: "nord",
+			custom:  map[string]string{"accent": "#112233", "yellow": "bogus"},
+			contains: map[string]string{
+				"accent": "#112233",
+				"yellow": "#ebcb8b",
+			},
+		},
+		{
 			name:        "terminal theme has no hex base",
 			rawName:     "terminal",
 			custom:      map[string]string{"green": "#446688"},
@@ -258,6 +275,9 @@ func TestHerdrThemePalettesAreComplete(t *testing.T) {
 		for token, value := range palette {
 			if !validHexColor(value) {
 				t.Errorf("palette %q token %q = %q, want #RRGGBB hex", name, token, value)
+			}
+			if _, ok := herdrTokenRoles[token]; !ok {
+				t.Errorf("palette %q token %q is not a picker role", name, token)
 			}
 		}
 	}

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -68,8 +68,8 @@ func TestHerdrConfigPath(t *testing.T) {
 	})
 }
 
-func TestLoadHerdrThemeCustom(t *testing.T) {
-	t.Run("reads custom tokens and ignores unrelated tables", func(t *testing.T) {
+func TestLoadHerdrThemeConfig(t *testing.T) {
+	t.Run("reads name and custom tokens, ignores unrelated tables", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.toml")
 		content := `
 [theme]
@@ -87,26 +87,31 @@ command = "fullerzz.sesh.open-picker"
 			t.Fatalf("write config: %v", err)
 		}
 
-		custom := loadHerdrThemeCustom(path)
+		name, custom := loadHerdrThemeConfig(path)
+		if name != "catppuccin" {
+			t.Errorf("loadHerdrThemeConfig() name = %q, want %q", name, "catppuccin")
+		}
 		want := map[string]string{"text": "#cdcdcd"}
 		if !reflect.DeepEqual(custom, want) {
-			t.Errorf("loadHerdrThemeCustom() = %v, want %v", custom, want)
+			t.Errorf("loadHerdrThemeConfig() custom = %v, want %v", custom, want)
 		}
 	})
 
-	t.Run("missing file yields nil", func(t *testing.T) {
-		if got := loadHerdrThemeCustom(filepath.Join(t.TempDir(), "absent.toml")); got != nil {
-			t.Errorf("loadHerdrThemeCustom() = %v, want nil", got)
+	t.Run("missing file yields empty results", func(t *testing.T) {
+		name, custom := loadHerdrThemeConfig(filepath.Join(t.TempDir(), "absent.toml"))
+		if name != "" || custom != nil {
+			t.Errorf("loadHerdrThemeConfig() = (%q, %v), want empty results", name, custom)
 		}
 	})
 
-	t.Run("invalid TOML yields nil", func(t *testing.T) {
+	t.Run("invalid TOML yields empty results", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.toml")
 		if err := os.WriteFile(path, []byte("[theme"), 0o600); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
-		if got := loadHerdrThemeCustom(path); got != nil {
-			t.Errorf("loadHerdrThemeCustom() = %v, want nil", got)
+		name, custom := loadHerdrThemeConfig(path)
+		if name != "" || custom != nil {
+			t.Errorf("loadHerdrThemeConfig() = (%q, %v), want empty results", name, custom)
 		}
 	})
 }
@@ -171,6 +176,115 @@ func TestApplyHerdrTheme(t *testing.T) {
 			t.Errorf("textColor = %v, want unchanged %v", textColor, before)
 		}
 	})
+}
+
+func TestResolveHerdrThemeTokens(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawName     string
+		custom      map[string]string
+		contains    map[string]string
+		notContains []string
+	}{
+		{
+			name:    "named theme resolves its palette",
+			rawName: "dracula",
+			contains: map[string]string{
+				"accent": "#bd93f9",
+				"red":    "#ff5555",
+				"text":   "#f8f8f2",
+			},
+		},
+		{
+			name:    "aliases, casing, and spacing normalize like Herdr",
+			rawName: "Tokyo Night",
+			contains: map[string]string{
+				"accent": "#7aa2f7",
+				"mauve":  "#bb9af7",
+			},
+		},
+		{
+			name:    "unknown names fall back to the default theme",
+			rawName: "not-a-theme",
+			contains: map[string]string{
+				"accent": "#89b4fa",
+			},
+		},
+		{
+			name:     "unset name resolves to the default theme",
+			contains: map[string]string{"text": "#cdd6f4"},
+		},
+		{
+			name:    "custom tokens override the base palette",
+			rawName: "nord",
+			custom:  map[string]string{"accent": "#112233", "bogus-token": "#abcdef"},
+			contains: map[string]string{
+				"accent":      "#112233",
+				"text":        "#eceff4",
+				"bogus-token": "#abcdef",
+			},
+		},
+		{
+			name:        "terminal theme has no hex base",
+			rawName:     "terminal",
+			custom:      map[string]string{"green": "#446688"},
+			contains:    map[string]string{"green": "#446688"},
+			notContains: []string{"accent", "text"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHerdrThemeTokens(tt.rawName, tt.custom)
+			for token, want := range tt.contains {
+				if got[token] != want {
+					t.Errorf("token %q = %q, want %q", token, got[token], want)
+				}
+			}
+			for _, token := range tt.notContains {
+				if value, ok := got[token]; ok {
+					t.Errorf("token %q = %q, want absent", token, value)
+				}
+			}
+		})
+	}
+}
+
+func TestHerdrThemePalettesAreComplete(t *testing.T) {
+	for name, palette := range herdrThemePalettes {
+		if len(palette) != len(herdrTokenRoles) {
+			t.Errorf("palette %q has %d tokens, want %d", name, len(palette), len(herdrTokenRoles))
+		}
+		for token, value := range palette {
+			if !validHexColor(value) {
+				t.Errorf("palette %q token %q = %q, want #RRGGBB hex", name, token, value)
+			}
+		}
+	}
+}
+
+func TestApplyHerdrThemeFromConfigResolvesNamedTheme(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := "[theme]\nname = \"dracula\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("HERDR_CONFIG_PATH", path)
+
+	savedSky, savedText := skyColor, textColor
+	t.Cleanup(func() {
+		skyColor, textColor = savedSky, savedText
+		rebuildPickerStyles()
+	})
+
+	ApplyHerdrThemeFromConfig()
+
+	if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
+		t.Errorf("skyColor = %v, want #bd93f9", skyColor)
+	}
+	if !reflect.DeepEqual(textColor, lipgloss.Color("#f8f8f2")) {
+		t.Errorf("textColor = %v, want #f8f8f2", textColor)
+	}
 }
 
 func TestRebuildPickerStylesTracksColorVars(t *testing.T) {


### PR DESCRIPTION
## Native picker now follows Herdr's active theme

Previously the native picker rendered with a hardcoded palette (Tokyo Night-ish) regardless of the theme configured in Herdr, so it visibly clashed with the rest of the UI. This PR makes the picker inherit Herdr's own colors:

1. `[theme] name` resolves against all built-in Herdr themes (palettes mirrored from `src/app/state.rs`, including light variants and common aliases like `catppuccin-mocha` / `tokyonight`)
2. `[theme.custom]` tokens override the base per token, so personal palettes (e.g. a tuned Vague setup) flow into the picker unchanged

### Why the palettes are embedded in this plugin

Herdr does not expose its resolved theme colors anywhere an external process can read:

- the socket API has no field returning palette data
- no resolved-theme file is written to disk
- `config.toml` only stores the name string plus optional custom overrides

A separate plugin process therefore has exactly one way to know that dracula's accent is `#bd93f9`: ship a copy of the palette table. Alternatives considered:

| Alternative | Why rejected |
| --- | --- |
| Query the running server | No API endpoint exposes theme/palette data |
| Parse Herdr's config only | Covers `[theme.custom]` users but leaves every stock-theme user (arguably the majority) with a mismatched picker |
| Shell out / parse Herdr internals at runtime | Fragile and inappropriate |

The tables are transcribed from Herdr 0.8.2's `src/app/state.rs` `Palette` constructors, restricted to the eight tokens the picker consumes. A unit test asserts every table stays complete and well-formed.

Embedding duplicates upstream state and may not be desirable long term. If Herdr grows a way to export resolved colors (an `api` field or a runtime file would both work), these tables can be deleted in favor of querying it. Until then, matching today's themes seems worth the duplication, but reducing scope is completely fine if fewer embedded themes are preferred.

### Behavior notes

- Unknown/unset `name` falls back to catppuccin, mirroring Herdr's own diagnostics behavior. One consequence worth flagging: a user with no `[theme]` section at all now gets a catppuccin-tinted picker instead of the previous static palette. Easy to flip to untouched defaults if preferred.
- The ANSI-based `terminal` theme has no fixed hex values, so nothing is inherited there; explicit `[theme.custom]` overrides still apply.
- Invalid or missing custom tokens fall back per role, so partial overrides only affect the roles they define.

### Validation

- `just check`: golangci-lint lint + fmt-check, race-enabled test suite via gotestsum (295 tests), release-ref integrity script
- `just build`, then `./bin/herdr-sesh --version` and `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- Manually verified against live Herdr sessions with `name = "catppuccin"` plus full `[theme.custom]`, and with named-only configs


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

