### PR TITLE
fix(picker): allow disabling Herdr theme inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ tabs.
 
 - Search active Herdr workspaces, Sesh-style TOML sessions, and zoxide history
   from a native terminal picker.
+- Match the native picker to Herdr's active theme by default, with a
+  configuration toggle to retain the picker's built-in colors.
 - Focus an existing workspace or create one from a configured session or
   directory.
 - Apply startup commands, previews, and named Herdr tabs to new workspaces.

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,7 @@ the state directory.
 | Field | Runtime effect |
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
+| `herdr_theme_inherit` | Inherits colors from Herdr's active theme. The default is `true`; set it to `false` to keep the native picker's built-in colors. |
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 | `separator_aware` | Makes native and fzf picker searches treat `-`, `_`, `/`, and `.` as spaces. |
@@ -82,9 +83,17 @@ and teal `●` when done. Workspaces with an unknown state have no indicator.
 
 ## Picker colors
 
-The native picker inherits colors from Herdr's own theme so it matches the
-running Herdr UI. It reads the same config file Herdr uses
-(`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr/config.toml`, then
+By default, the native picker inherits colors from Herdr's own theme so it
+matches the running Herdr UI. Disable inheritance to keep the picker's built-in
+colors:
+
+```toml
+[picker]
+herdr_theme_inherit = false
+```
+
+When enabled, it reads the same config file Herdr uses (`HERDR_CONFIG_PATH`,
+then `$XDG_CONFIG_HOME/herdr/config.toml`, then
 `~/.config/herdr/config.toml`) and resolves `[theme] name` against Herdr's
 built-in themes:
 
@@ -171,6 +180,7 @@ path_components = 1
 
 [picker]
 show_icons = true
+herdr_theme_inherit = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
 separator_aware = true
@@ -244,6 +254,7 @@ meaning under the renamed table.
 | `dir_length` | `naming.path_components` |
 | `separator_aware` | `picker.separator_aware` |
 | `tui.show_icons` | `picker.show_icons` |
+| `tui.herdr_theme_inherit` | `picker.herdr_theme_inherit` |
 | `tui.show_last_workspace` | `picker.show_last_workspace` |
 | `tui.show_last_workspace_path` | `picker.show_last_workspace_path` |
 | `tui.prompt` | `picker.prompt` |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -232,8 +232,6 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		return err
 	}
 	useFZF := *fzfPicker || strings.EqualFold(os.Getenv("HERDR_SESH_PICKER"), "fzf")
-	// Inherit Herdr's theme so both pickers render with its colors.
-	pickerpkg.ApplyHerdrThemeFromConfig()
 	var sessions, herdrWorkspaces []model.Session
 	if useFZF || *jsonOut {
 		sessions, err = a.collectAllowUnavailableHerdr(ctx, cfg, "")
@@ -257,6 +255,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		Prompt:                cfg.TUI.Prompt,
 		Placeholder:           cfg.TUI.Placeholder,
 		ShowIcons:             cfg.TUI.ShowIcons,
+		HerdrThemeInherit:     cfg.TUI.HerdrThemeInherit,
 		HideLastWorkspace:     !cfg.TUI.ShowLastWorkspace,
 		HideLastWorkspacePath: !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:        cfg.SeparatorAware,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type SessionConfig struct {
 
 type TUIConfig struct {
 	ShowIcons             bool   `toml:"show_icons"`
+	HerdrThemeInherit     bool   `toml:"herdr_theme_inherit"`
 	ShowLastWorkspace     bool   `toml:"show_last_workspace"`
 	ShowLastWorkspacePath bool   `toml:"show_last_workspace_path"`
 	Prompt                string `toml:"prompt"`
@@ -62,6 +63,7 @@ func Default() Config {
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
+			HerdrThemeInherit:     true,
 			ShowLastWorkspace:     true,
 			ShowLastWorkspacePath: true,
 		},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -190,6 +190,7 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 			Prompt                *string `toml:"prompt"`
 			Placeholder           *string `toml:"placeholder"`
 			ShowIcons             *bool   `toml:"show_icons"`
+			HerdrThemeInherit     *bool   `toml:"herdr_theme_inherit"`
 			ShowLastWorkspace     *bool   `toml:"show_last_workspace"`
 			ShowLastWorkspacePath *bool   `toml:"show_last_workspace_path"`
 			DefaultSort           *string `toml:"default_sort"`
@@ -224,6 +225,7 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 		probe.TUI.Prompt != nil,
 		probe.TUI.Placeholder != nil,
 		probe.TUI.ShowIcons != nil,
+		probe.TUI.HerdrThemeInherit != nil,
 		probe.TUI.ShowLastWorkspace != nil,
 		probe.TUI.ShowLastWorkspacePath != nil,
 		probe.TUI.DefaultSort != nil,
@@ -231,7 +233,7 @@ func loadInto(dst *Config, path string, seen map[string]bool, strict bool) error
 	return nil
 }
 
-func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, showLastWorkspaceSet, showLastWorkspacePathSet, defaultSortSet bool) {
+func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet, showIconsSet, herdrThemeInheritSet, showLastWorkspaceSet, showLastWorkspacePathSet, defaultSortSet bool) {
 	if src.Cache {
 		dst.Cache = true
 	}
@@ -252,6 +254,9 @@ func merge(dst *Config, src Config, previewCommandSet, promptSet, placeholderSet
 	}
 	if showIconsSet {
 		dst.TUI.ShowIcons = src.TUI.ShowIcons
+	}
+	if herdrThemeInheritSet {
+		dst.TUI.HerdrThemeInherit = src.TUI.HerdrThemeInherit
 	}
 	if showLastWorkspaceSet {
 		dst.TUI.ShowLastWorkspace = src.TUI.ShowLastWorkspace

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -200,6 +200,20 @@ func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
 	}
 }
 
+func TestLoadExplicitFalseHerdrThemeInheritOverridesImportedValue(t *testing.T) {
+	d := t.TempDir()
+	mustWrite(t, filepath.Join(d, "extra.toml"), "[tui]\nherdr_theme_inherit = true\n")
+	p := filepath.Join(d, "sesh.toml")
+	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nherdr_theme_inherit = false\n")
+	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.HerdrThemeInherit {
+		t.Fatal("herdr_theme_inherit = true, want false")
+	}
+}
+
 func TestLoadExplicitFalseShowLastWorkspacePathOverridesImportedValue(t *testing.T) {
 	d := t.TempDir()
 	mustWrite(t, filepath.Join(d, "extra.toml"), "[tui]\nshow_last_workspace_path = true\n")
@@ -225,6 +239,12 @@ func TestLoadExplicitFalseShowLastWorkspaceOverridesImportedValue(t *testing.T) 
 	}
 	if cfg.TUI.ShowLastWorkspace {
 		t.Fatal("show_last_workspace = true, want false")
+	}
+}
+
+func TestDefaultInheritsHerdrTheme(t *testing.T) {
+	if !Default().TUI.HerdrThemeInherit {
+		t.Fatal("herdr_theme_inherit default = false, want true")
 	}
 }
 

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -190,6 +190,7 @@ func writePrivateFileAtomic(path string, data []byte) error {
 func marshalNative(cfg Config) ([]byte, error) {
 	defaults := Default()
 	dirLength := cfg.DirLength
+	herdrThemeInherit := cfg.TUI.HerdrThemeInherit
 	showLastWorkspace := cfg.TUI.ShowLastWorkspace
 	showLastWorkspacePath := cfg.TUI.ShowLastWorkspacePath
 	n := nativeConfig{
@@ -202,6 +203,7 @@ func marshalNative(cfg Config) ([]byte, error) {
 		Naming: nativeNaming{PathComponents: &dirLength},
 		Picker: nativePicker{
 			ShowIcons:             cfg.TUI.ShowIcons,
+			HerdrThemeInherit:     &herdrThemeInherit,
 			ShowLastWorkspace:     &showLastWorkspace,
 			ShowLastWorkspacePath: &showLastWorkspacePath,
 			Prompt:                cfg.TUI.Prompt,

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -216,6 +216,16 @@ func TestMigrateEmitsShowIconsExplicitly(t *testing.T) {
 	})
 }
 
+func TestMigratePreservesDisabledHerdrThemeInheritance(t *testing.T) {
+	text, cfg := migrateAndRead(t, "[tui]\nherdr_theme_inherit = false\n")
+	if !strings.Contains(text, "herdr_theme_inherit = false") {
+		t.Fatalf("disabled Herdr theme inheritance dropped from output:\n%s", text)
+	}
+	if cfg.TUI.HerdrThemeInherit {
+		t.Fatal("migrated herdr_theme_inherit = true, want false")
+	}
+}
+
 func TestMigratePreservesLastWorkspacePickerSettings(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[tui]\nshow_last_workspace = false\nshow_last_workspace_path = false\n")
 	if !strings.Contains(text, "show_last_workspace = false") || !strings.Contains(text, "show_last_workspace_path = false") {

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -42,6 +42,7 @@ type nativePicker struct {
 	// No omitempty: migration must keep an explicitly configured false, and
 	// an always-present value keeps icon behavior self-documenting.
 	ShowIcons             bool   `toml:"show_icons"`
+	HerdrThemeInherit     *bool  `toml:"herdr_theme_inherit,omitempty"`
 	ShowLastWorkspace     *bool  `toml:"show_last_workspace,omitempty"`
 	ShowLastWorkspacePath *bool  `toml:"show_last_workspace_path,omitempty"`
 	Prompt                string `toml:"prompt,omitempty"`
@@ -195,6 +196,9 @@ func (n nativeConfig) apply(cfg *Config) {
 	}
 	cfg.SeparatorAware = n.Picker.SeparatorAware
 	cfg.TUI.ShowIcons = n.Picker.ShowIcons
+	if n.Picker.HerdrThemeInherit != nil {
+		cfg.TUI.HerdrThemeInherit = *n.Picker.HerdrThemeInherit
+	}
 	if n.Picker.ShowLastWorkspace != nil {
 		cfg.TUI.ShowLastWorkspace = *n.Picker.ShowLastWorkspace
 	}

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -34,6 +34,7 @@ path_components = 2
 
 [picker]
 show_icons = true
+herdr_theme_inherit = true
 show_last_workspace = true
 show_last_workspace_path = true
 prompt = "P> "
@@ -75,7 +76,7 @@ tabs = ["git"]
 		SeparatorAware: true,
 		SortOrder:      []string{"config", "herdr"},
 		Blacklist:      []string{"^scratch$"},
-		TUI:            TUIConfig{ShowIcons: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
+		TUI:            TUIConfig{ShowIcons: true, HerdrThemeInherit: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
 		DefaultSessionConfig: DefaultSessionConfig{
 			StartupCommand: "make dev",
 			PreviewCommand: "ls {}",
@@ -106,8 +107,22 @@ func TestNativeMinimalFileKeepsDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := Default()
-	if cfg.DirLength != d.DirLength || cfg.TUI.DefaultSort != d.TUI.DefaultSort || !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath || cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
+	if cfg.DirLength != d.DirLength || cfg.TUI.DefaultSort != d.TUI.DefaultSort || !cfg.TUI.HerdrThemeInherit || !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath || cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
 		t.Fatalf("defaults lost: %#v", cfg)
+	}
+}
+
+func TestNativePickerCanDisableHerdrThemeInheritance(t *testing.T) {
+	cfg, err := loadNative(t, `version = 1
+
+[picker]
+herdr_theme_inherit = false
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.HerdrThemeInherit {
+		t.Fatal("herdr_theme_inherit = true, want false")
 	}
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -112,6 +112,7 @@ type Options struct {
 	Prompt                string
 	Placeholder           string
 	ShowIcons             bool
+	HerdrThemeInherit     bool
 	HideLastWorkspace     bool
 	HideLastWorkspacePath bool
 	SeparatorAware        bool
@@ -140,6 +141,7 @@ type ReloadResult struct {
 }
 
 func Run(items []sessionmodel.Session, opts Options) (sessionmodel.Session, bool, error) {
+	configureHerdrTheme(opts.HerdrThemeInherit)
 	var popts []tea.ProgramOption
 	if opts.Output != nil {
 		popts = append(popts, tea.WithOutput(opts.Output))

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -47,19 +47,28 @@ const (
 	herdrSourceIcon    = "\U000f0cc6"
 	zoxideSourceIcon   = "\uf114"
 	configSourceIcon   = "\ue615"
+
+	defaultSkyColor    = "#7DCFFF"
+	defaultVioletColor = "#BB9AF7"
+	defaultGreenColor  = "#9ECE6A"
+	defaultAmberColor  = "#E0AF68"
+	defaultRedColor    = "#F7768E"
+	defaultTextColor   = "#C0CAF5"
+	defaultMutedColor  = "#565F89"
+	defaultGhostColor  = "#737AA2"
 )
 
 var (
 	agentStatusSpinner = spinner.Jump
 
-	skyColor    = lipgloss.Color("#7DCFFF")
-	violetColor = lipgloss.Color("#BB9AF7")
-	greenColor  = lipgloss.Color("#9ECE6A")
-	amberColor  = lipgloss.Color("#E0AF68")
-	redColor    = lipgloss.Color("#F7768E")
-	textColor   = lipgloss.Color("#C0CAF5")
-	mutedColor  = lipgloss.Color("#565F89")
-	ghostColor  = lipgloss.Color("#737AA2")
+	skyColor    = lipgloss.Color(defaultSkyColor)
+	violetColor = lipgloss.Color(defaultVioletColor)
+	greenColor  = lipgloss.Color(defaultGreenColor)
+	amberColor  = lipgloss.Color(defaultAmberColor)
+	redColor    = lipgloss.Color(defaultRedColor)
+	textColor   = lipgloss.Color(defaultTextColor)
+	mutedColor  = lipgloss.Color(defaultMutedColor)
+	ghostColor  = lipgloss.Color(defaultGhostColor)
 
 	titleStyle = lipgloss.NewStyle().
 			Foreground(violetColor).

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -364,7 +364,10 @@ func applyHerdrTheme(tokens map[string]string) {
 	rebuildPickerStyles()
 }
 
-func ApplyHerdrThemeFromConfig() {
+func configureHerdrTheme(inherit bool) {
+	if !inherit {
+		return
+	}
 	name, custom := loadHerdrThemeConfig(herdrConfigPath())
 	applyHerdrTheme(resolveHerdrThemeTokens(name, custom))
 }

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -364,7 +364,20 @@ func applyHerdrTheme(tokens map[string]string) {
 	rebuildPickerStyles()
 }
 
+func resetPickerTheme() {
+	skyColor = lipgloss.Color(defaultSkyColor)
+	violetColor = lipgloss.Color(defaultVioletColor)
+	greenColor = lipgloss.Color(defaultGreenColor)
+	amberColor = lipgloss.Color(defaultAmberColor)
+	redColor = lipgloss.Color(defaultRedColor)
+	textColor = lipgloss.Color(defaultTextColor)
+	mutedColor = lipgloss.Color(defaultMutedColor)
+	ghostColor = lipgloss.Color(defaultGhostColor)
+	rebuildPickerStyles()
+}
+
 func configureHerdrTheme(inherit bool) {
+	resetPickerTheme()
 	if !inherit {
 		return
 	}

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -283,7 +283,7 @@ func TestHerdrThemePalettesAreComplete(t *testing.T) {
 	}
 }
 
-func TestConfigureHerdrThemeRespectsInheritanceSetting(t *testing.T) {
+func TestConfigureHerdrThemeResetsColorsBetweenRuns(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	content := "[theme]\nname = \"dracula\"\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -291,36 +291,69 @@ func TestConfigureHerdrThemeRespectsInheritanceSetting(t *testing.T) {
 	}
 	t.Setenv("HERDR_CONFIG_PATH", path)
 
-	t.Run("disabled keeps picker colors", func(t *testing.T) {
-		savedSky, savedText := skyColor, textColor
-		t.Cleanup(func() {
-			skyColor, textColor = savedSky, savedText
-			rebuildPickerStyles()
-		})
-
-		configureHerdrTheme(false)
-
-		if !reflect.DeepEqual(skyColor, savedSky) || !reflect.DeepEqual(textColor, savedText) {
-			t.Fatalf("colors changed while inheritance was disabled: sky=%v text=%v", skyColor, textColor)
+	saved := []struct {
+		target *color.Color
+		value  color.Color
+	}{
+		{&textColor, textColor},
+		{&mutedColor, mutedColor},
+		{&greenColor, greenColor},
+		{&amberColor, amberColor},
+		{&redColor, redColor},
+		{&skyColor, skyColor},
+		{&violetColor, violetColor},
+		{&ghostColor, ghostColor},
+	}
+	t.Cleanup(func() {
+		for _, s := range saved {
+			*s.target = s.value
 		}
+		rebuildPickerStyles()
 	})
 
-	t.Run("enabled resolves named theme", func(t *testing.T) {
-		savedSky, savedText := skyColor, textColor
-		t.Cleanup(func() {
-			skyColor, textColor = savedSky, savedText
-			rebuildPickerStyles()
-		})
+	configureHerdrTheme(true)
+	if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
+		t.Fatalf("enabled run did not apply Dracula accent: %v", skyColor)
+	}
 
-		configureHerdrTheme(true)
+	configureHerdrTheme(false)
 
-		if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
-			t.Errorf("skyColor = %v, want #bd93f9", skyColor)
+	colors := []struct {
+		name string
+		got  color.Color
+		want color.Color
+	}{
+		{name: "text", got: textColor, want: lipgloss.Color("#C0CAF5")},
+		{name: "muted", got: mutedColor, want: lipgloss.Color("#565F89")},
+		{name: "green", got: greenColor, want: lipgloss.Color("#9ECE6A")},
+		{name: "amber", got: amberColor, want: lipgloss.Color("#E0AF68")},
+		{name: "red", got: redColor, want: lipgloss.Color("#F7768E")},
+		{name: "sky", got: skyColor, want: lipgloss.Color("#7DCFFF")},
+		{name: "violet", got: violetColor, want: lipgloss.Color("#BB9AF7")},
+		{name: "ghost", got: ghostColor, want: lipgloss.Color("#737AA2")},
+	}
+	for _, c := range colors {
+		if !reflect.DeepEqual(c.got, c.want) {
+			t.Errorf("%s color after disabled run = %v, want %v", c.name, c.got, c.want)
 		}
-		if !reflect.DeepEqual(textColor, lipgloss.Color("#f8f8f2")) {
-			t.Errorf("textColor = %v, want #f8f8f2", textColor)
+	}
+
+	styles := []struct {
+		name string
+		got  color.Color
+		want color.Color
+	}{
+		{name: "title", got: titleStyle.GetForeground(), want: lipgloss.Color("#BB9AF7")},
+		{name: "count", got: countStyle.GetForeground(), want: lipgloss.Color("#565F89")},
+		{name: "row label", got: rowLabelStyle.GetForeground(), want: lipgloss.Color("#C0CAF5")},
+		{name: "selection rail", got: selectionRailStyle.GetForeground(), want: lipgloss.Color("#7DCFFF")},
+		{name: "empty", got: emptyStyle.GetForeground(), want: lipgloss.Color("#E0AF68")},
+	}
+	for _, s := range styles {
+		if !reflect.DeepEqual(s.got, s.want) {
+			t.Errorf("%s style after disabled run = %v, want %v", s.name, s.got, s.want)
 		}
-	})
+	}
 }
 
 func TestRebuildPickerStylesTracksColorVars(t *testing.T) {

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -283,7 +283,7 @@ func TestHerdrThemePalettesAreComplete(t *testing.T) {
 	}
 }
 
-func TestApplyHerdrThemeFromConfigResolvesNamedTheme(t *testing.T) {
+func TestConfigureHerdrThemeRespectsInheritanceSetting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	content := "[theme]\nname = \"dracula\"\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -291,20 +291,36 @@ func TestApplyHerdrThemeFromConfigResolvesNamedTheme(t *testing.T) {
 	}
 	t.Setenv("HERDR_CONFIG_PATH", path)
 
-	savedSky, savedText := skyColor, textColor
-	t.Cleanup(func() {
-		skyColor, textColor = savedSky, savedText
-		rebuildPickerStyles()
+	t.Run("disabled keeps picker colors", func(t *testing.T) {
+		savedSky, savedText := skyColor, textColor
+		t.Cleanup(func() {
+			skyColor, textColor = savedSky, savedText
+			rebuildPickerStyles()
+		})
+
+		configureHerdrTheme(false)
+
+		if !reflect.DeepEqual(skyColor, savedSky) || !reflect.DeepEqual(textColor, savedText) {
+			t.Fatalf("colors changed while inheritance was disabled: sky=%v text=%v", skyColor, textColor)
+		}
 	})
 
-	ApplyHerdrThemeFromConfig()
+	t.Run("enabled resolves named theme", func(t *testing.T) {
+		savedSky, savedText := skyColor, textColor
+		t.Cleanup(func() {
+			skyColor, textColor = savedSky, savedText
+			rebuildPickerStyles()
+		})
 
-	if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
-		t.Errorf("skyColor = %v, want #bd93f9", skyColor)
-	}
-	if !reflect.DeepEqual(textColor, lipgloss.Color("#f8f8f2")) {
-		t.Errorf("textColor = %v, want #f8f8f2", textColor)
-	}
+		configureHerdrTheme(true)
+
+		if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
+			t.Errorf("skyColor = %v, want #bd93f9", skyColor)
+		}
+		if !reflect.DeepEqual(textColor, lipgloss.Color("#f8f8f2")) {
+			t.Errorf("textColor = %v, want #f8f8f2", textColor)
+		}
+	})
 }
 
 func TestRebuildPickerStylesTracksColorVars(t *testing.T) {

--- a/testdata/herdr-sesh.toml
+++ b/testdata/herdr-sesh.toml
@@ -10,6 +10,7 @@ path_components = 1
 
 [picker]
 show_icons = true
+herdr_theme_inherit = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
 separator_aware = true


### PR DESCRIPTION
## Summary

- add a default-on `picker.herdr_theme_inherit` configuration toggle
- keep the native picker's built-in colors when inheritance is disabled
- preserve explicit legacy values during loading and migration
- document the setting and update the native config fixture

## Validation

- `just check`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

