### PR TITLE
chore(changelog): include GitHub contributors

### DIFF
--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -146,10 +146,7 @@ done
 just_bin=$(mise which just)
 git_cliff_bin=$(mise which git-cliff)
 
-"$git_cliff_bin" --context --offline >"$tmp/changelog-context.json"
-sed 's/"github":{"contributors":\[\]}/"github":{"contributors":[{"username":"first-timer","pr_title":"First contribution","pr_number":79,"pr_labels":[],"is_first_time":true},{"username":"direct-contributor","pr_title":null,"pr_number":null,"pr_labels":[],"is_first_time":true}]}/g' \
-  "$tmp/changelog-context.json" >"$tmp/changelog-context-with-contributors.json"
-"$git_cliff_bin" --from-context "$tmp/changelog-context-with-contributors.json" \
+"$git_cliff_bin" --from-context "$repo_root/.github/scripts/testdata/changelog-context.json" \
   --output "$tmp/rendered-changelog.md"
 if grep -Eq '.## v[0-9]' "$tmp/rendered-changelog.md"; then
   echo 'first-time contributor entries must preserve the next release heading newline' >&2
@@ -157,6 +154,16 @@ if grep -Eq '.## v[0-9]' "$tmp/rendered-changelog.md"; then
 fi
 if ! grep -Fxq '* @direct-contributor made their first contribution' "$tmp/rendered-changelog.md"; then
   echo 'first-time contributor entries without a pull request must omit the PR suffix' >&2
+  exit 1
+fi
+if ! grep -Fq 'by @orhun in [#389](https://github.com/fullerzz/herdr-plugin-sesh/pull/389)' \
+  "$tmp/rendered-changelog.md"; then
+  echo 'commit pull request metadata must link to the pull request' >&2
+  exit 1
+fi
+if ! grep -Fq '@first-timer made their first contribution in [#79](https://github.com/fullerzz/herdr-plugin-sesh/pull/79)' \
+  "$tmp/rendered-changelog.md"; then
+  echo 'first-time contributor metadata must link to the pull request' >&2
   exit 1
 fi
 

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -141,6 +141,21 @@ done
 
 just_bin=$(mise which just)
 git_cliff_bin=$(mise which git-cliff)
+
+"$git_cliff_bin" --context --offline >"$tmp/changelog-context.json"
+sed 's/"github":{"contributors":\[\]}/"github":{"contributors":[{"username":"first-timer","pr_title":"First contribution","pr_number":79,"pr_labels":[],"is_first_time":true},{"username":"direct-contributor","pr_title":null,"pr_number":null,"pr_labels":[],"is_first_time":true}]}/g' \
+  "$tmp/changelog-context.json" >"$tmp/changelog-context-with-contributors.json"
+"$git_cliff_bin" --from-context "$tmp/changelog-context-with-contributors.json" \
+  --output "$tmp/rendered-changelog.md"
+if grep -Eq '.## v[0-9]' "$tmp/rendered-changelog.md"; then
+  echo 'first-time contributor entries must preserve the next release heading newline' >&2
+  exit 1
+fi
+if ! grep -Fxq '* @direct-contributor made their first contribution' "$tmp/rendered-changelog.md"; then
+  echo 'first-time contributor entries without a pull request must omit the PR suffix' >&2
+  exit 1
+fi
+
 release_tools="$tmp/release-tools"
 mkdir -p "$release_tools"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$release_tools/just"
@@ -156,6 +171,22 @@ printf '%s\n' \
   'exec "$RELEASE_TEST_GIT_CLIFF" "$@"' \
   >"$release_tools/mise"
 chmod +x "$release_tools/just" "$release_tools/mise"
+
+if preview_error=$(
+  cd "$repo_root"
+  env -u GITHUB_TOKEN \
+    GIT_CLIFF_OFFLINE=true \
+    PATH="$release_tools:$PATH" \
+    RELEASE_TEST_GIT_CLIFF="$git_cliff_bin" \
+    "$just_bin" preview-changelog 2>&1
+); then
+  echo 'changelog preview must require an authenticated GitHub metadata request' >&2
+  exit 1
+fi
+case "$preview_error" in
+  *'GITHUB_TOKEN is required for GitHub changelog metadata'*) ;;
+  *) echo "missing changelog preview token failed unclearly: $preview_error" >&2; exit 1 ;;
+esac
 
 setup_release_repo() {
   release_repo=$1
@@ -180,11 +211,32 @@ run_release_recipe() {
   release_repo=$1
   (
     cd "$release_repo"
-    PATH="$release_tools:$PATH" \
+    GITHUB_TOKEN=test-token \
+      GIT_CLIFF_OFFLINE=true \
+      PATH="$release_tools:$PATH" \
       RELEASE_TEST_GIT_CLIFF="$git_cliff_bin" \
       "$just_bin" --yes release v1.2.3
   )
 }
+
+missing_token_repo="$tmp/release-missing-token"
+missing_token_remote="$tmp/release-missing-token.git"
+setup_release_repo "$missing_token_repo" "$missing_token_remote"
+if missing_token_error=$(
+  cd "$missing_token_repo"
+  env -u GITHUB_TOKEN \
+    GIT_CLIFF_OFFLINE=true \
+    PATH="$release_tools:$PATH" \
+    RELEASE_TEST_GIT_CLIFF="$git_cliff_bin" \
+    "$just_bin" --yes release v1.2.3 2>&1
+); then
+  echo 'release must require an authenticated GitHub metadata request' >&2
+  exit 1
+fi
+case "$missing_token_error" in
+  *'GITHUB_TOKEN is required for GitHub changelog metadata'*) ;;
+  *) echo "missing release token failed unclearly: $missing_token_error" >&2; exit 1 ;;
+esac
 
 success_repo="$tmp/release-success"
 success_remote="$tmp/release-success.git"

--- a/.github/scripts/test-release-ref.sh
+++ b/.github/scripts/test-release-ref.sh
@@ -56,6 +56,10 @@ if ! grep -Fq 'if [ "$manifest_version" != "$version" ]; then' "$changelog_workf
   echo 'changelog workflow must reject tags that do not match the manifest version' >&2
   exit 1
 fi
+if ! grep -Fq '  pull-requests: read' "$changelog_workflow"; then
+  echo 'changelog workflow must allow git-cliff to read pull request metadata' >&2
+  exit 1
+fi
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT

--- a/.github/scripts/testdata/changelog-context.json
+++ b/.github/scripts/testdata/changelog-context.json
@@ -1,0 +1,148 @@
+[
+  {
+    "version": "v2.0.0",
+    "message": null,
+    "commits": [
+      {
+        "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "message": "add merge_commit flag to the context",
+        "body": null,
+        "footers": [],
+        "group": "<!-- 0 -->🚀 Features",
+        "breaking_description": null,
+        "breaking": false,
+        "scope": "commit",
+        "links": [],
+        "author": {
+          "name": "Test Author",
+          "email": "author@example.com",
+          "timestamp": 1767225600
+        },
+        "committer": {
+          "name": "Test Committer",
+          "email": "committer@example.com",
+          "timestamp": 1767225600
+        },
+        "conventional": true,
+        "merge_commit": false,
+        "statistics": {
+          "files_changed": 1,
+          "additions": 1,
+          "deletions": 0
+        },
+        "extra": null,
+        "github": {
+          "username": null,
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": false
+        },
+        "gitlab": {
+          "username": null,
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": false
+        },
+        "gitea": {
+          "username": null,
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": false
+        },
+        "bitbucket": {
+          "username": null,
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": false
+        },
+        "azure_devops": {
+          "username": null,
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": false
+        },
+        "raw_message": "feat(commit): add merge_commit flag to the context",
+        "remote": {
+          "username": "orhun",
+          "pr_title": "feat(commit): add merge_commit flag to the context",
+          "pr_number": 389,
+          "pr_labels": [],
+          "is_first_time": false
+        }
+      }
+    ],
+    "commit_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "timestamp": 1767225600,
+    "previous": null,
+    "repository": null,
+    "commit_range": null,
+    "submodule_commits": {},
+    "statistics": null,
+    "extra": null,
+    "bump_type": null,
+    "github": {
+      "contributors": [
+        {
+          "username": "first-timer",
+          "pr_title": "First contribution",
+          "pr_number": 79,
+          "pr_labels": [],
+          "is_first_time": true
+        },
+        {
+          "username": "direct-contributor",
+          "pr_title": null,
+          "pr_number": null,
+          "pr_labels": [],
+          "is_first_time": true
+        }
+      ]
+    },
+    "gitlab": {
+      "contributors": []
+    },
+    "gitea": {
+      "contributors": []
+    },
+    "bitbucket": {
+      "contributors": []
+    },
+    "azure_devops": {
+      "contributors": []
+    }
+  },
+  {
+    "version": "v1.0.0",
+    "message": null,
+    "commits": [],
+    "commit_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "timestamp": 1767225600,
+    "previous": null,
+    "repository": null,
+    "commit_range": null,
+    "submodule_commits": {},
+    "statistics": null,
+    "extra": null,
+    "bump_type": null,
+    "github": {
+      "contributors": []
+    },
+    "gitlab": {
+      "contributors": []
+    },
+    "gitea": {
+      "contributors": []
+    },
+    "bitbucket": {
+      "contributors": []
+    },
+    "azure_devops": {
+      "contributors": []
+    }
+  }
+]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   update-changelog:

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,14 +16,14 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 {% for commit in commits %}
-- {% if commit.breaking %}[BREAKING] {% endif %}{% if commit.remote.pr_title %}{{ commit.remote.pr_title | split(pat="\n") | first | trim }}{% else %}{% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}{% endif %}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %} ([{{ commit.id | truncate(length=7, end="") }}](<REPO>/commit/{{ commit.id }}))
+- {% if commit.breaking %}[BREAKING] {% endif %}{% if commit.remote.pr_title %}{{ commit.remote.pr_title | split(pat="\n") | first | trim }}{% else %}{% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}{% endif %}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](<REPO>/pull/{{ commit.remote.pr_number }}){% endif %} ([{{ commit.id | truncate(length=7, end="") }}](<REPO>/commit/{{ commit.id }}))
 {% endfor %}
 
 {% endfor %}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
 ### New Contributors
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * @{{ contributor.username }} made their first contribution{% if contributor.pr_number %} in #{{ contributor.pr_number }}{% endif %}
+  * @{{ contributor.username }} made their first contribution{% if contributor.pr_number %} in [#{{ contributor.pr_number }}](<REPO>/pull/{{ contributor.pr_number }}){% endif %}
 {% endfor %}
 {% endif %}
 """

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,10 @@
 # git-cliff configuration
 # https://git-cliff.org/docs/configuration
 
+[remote.github]
+owner = "fullerzz"
+repo = "herdr-plugin-sesh"
+
 [changelog]
 body = """
 {% if version %}\
@@ -12,10 +16,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 {% for commit in commits %}
-- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{% if commit.breaking %}[BREAKING] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](<REPO>/commit/{{ commit.id }}))
+- {% if commit.breaking %}[BREAKING] {% endif %}{% if commit.remote.pr_title %}{{ commit.remote.pr_title | split(pat="\n") | first | trim }}{% else %}{% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}{% endif %}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %} ([{{ commit.id | truncate(length=7, end="") }}](<REPO>/commit/{{ commit.id }}))
 {% endfor %}
 
 {% endfor %}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+### New Contributors
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  * @{{ contributor.username }} made their first contribution{% if contributor.pr_number %} in #{{ contributor.pr_number }}{% endif %}
+{% endfor %}
+{% endif %}
 """
 trim = true
 render_always = true

--- a/justfile
+++ b/justfile
@@ -49,6 +49,11 @@ preview-changelog $version='':
     #!/usr/bin/env bash
     set -euo pipefail
 
+    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+        echo "GITHUB_TOKEN is required for GitHub changelog metadata" >&2
+        exit 1
+    fi
+
     if [[ -n "$version" ]]; then
         mise exec -- git-cliff --tag "$version"
     else
@@ -77,6 +82,10 @@ release $tag:
     fi
     if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
         echo "Tag already exists: $tag" >&2
+        exit 1
+    fi
+    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+        echo "GITHUB_TOKEN is required for GitHub changelog metadata" >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- enrich changelog entries with GitHub author and pull request metadata
- list first-time contributors while preserving release heading boundaries and handling direct commits
- require authenticated metadata fetches for local changelog previews and releases
- add release-harness coverage for rendering and token preflights

## Validation
- GOLANGCI_LINT_CACHE=/private/tmp/herdr-plugin-sesh-golangci-lint-cache just check
- just build
- ./bin/herdr-sesh --version
- ./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

