### PR TITLE
feat(picker): allow disabling native preview

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,7 @@ the state directory.
 | Field | Runtime effect |
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
+| `show_preview` | Shows the preview panel in the native picker. The default is `true`; set it to `false` to give the workspace list the full available width and height without running preview commands. This does not change fzf preview behavior. |
 | `herdr_theme_inherit` | Inherits colors from Herdr's active theme. The default is `true`; set it to `false` to keep the native picker's built-in colors. |
 | `replace_worktree_icon` | Replaces the Herdr sheep icon with `↳` for linked worktree rows. The default is `true`. Set it to `false` to keep the sheep icon (or plain `[herdr]` when icons are hidden); the purple type color and tree branches remain. |
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
@@ -194,6 +195,7 @@ path_components = 1
 
 [picker]
 show_icons = true
+show_preview = true
 herdr_theme_inherit = true
 replace_worktree_icon = true
 prompt = "Sesh> "

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -210,6 +210,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		HideLastWorkspace:              !cfg.TUI.ShowLastWorkspace,
 		HideLastWorkspacePath:          !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:                 cfg.SeparatorAware,
+		HidePreview:                    !cfg.TUI.ShowPreview,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -596,6 +596,17 @@ func TestPickerOptionsPropagateWorktreeIconReplacement(t *testing.T) {
 	}
 }
 
+func TestPickerOptionsPropagatePreviewVisibility(t *testing.T) {
+	cfg := config.Default()
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.HidePreview {
+		t.Fatal("default config hid native picker preview")
+	}
+	cfg.TUI.ShowPreview = false
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.HidePreview {
+		t.Fatal("show_preview=false was not propagated")
+	}
+}
+
 func TestPickerJSONCommand(t *testing.T) {
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,9 @@ type SessionConfig struct {
 }
 
 type TUIConfig struct {
-	ShowIcons             bool   `toml:"show_icons"`
+	ShowIcons bool `toml:"show_icons"`
+	// ShowPreview is native-only; the legacy Sesh schema has no equivalent setting.
+	ShowPreview           bool   `toml:"-"`
 	HerdrThemeInherit     bool   `toml:"herdr_theme_inherit"`
 	ReplaceWorktreeIcon   bool   `toml:"replace_worktree_icon"`
 	ShowLastWorkspace     bool   `toml:"show_last_workspace"`
@@ -64,6 +66,7 @@ func Default() Config {
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
+			ShowPreview:           true,
 			HerdrThemeInherit:     true,
 			ReplaceWorktreeIcon:   true,
 			ShowLastWorkspace:     true,

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -42,6 +42,7 @@ type nativePicker struct {
 	// No omitempty: migration must keep an explicitly configured false, and
 	// an always-present value keeps icon behavior self-documenting.
 	ShowIcons             bool   `toml:"show_icons"`
+	ShowPreview           *bool  `toml:"show_preview,omitempty"`
 	HerdrThemeInherit     *bool  `toml:"herdr_theme_inherit,omitempty"`
 	ReplaceWorktreeIcon   *bool  `toml:"replace_worktree_icon,omitempty"`
 	ShowLastWorkspace     *bool  `toml:"show_last_workspace,omitempty"`
@@ -197,6 +198,9 @@ func (n nativeConfig) apply(cfg *Config) {
 	}
 	cfg.SeparatorAware = n.Picker.SeparatorAware
 	cfg.TUI.ShowIcons = n.Picker.ShowIcons
+	if n.Picker.ShowPreview != nil {
+		cfg.TUI.ShowPreview = *n.Picker.ShowPreview
+	}
 	if n.Picker.HerdrThemeInherit != nil {
 		cfg.TUI.HerdrThemeInherit = *n.Picker.HerdrThemeInherit
 	}

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -34,6 +34,7 @@ path_components = 2
 
 [picker]
 show_icons = true
+show_preview = false
 herdr_theme_inherit = true
 show_last_workspace = true
 show_last_workspace_path = true
@@ -137,6 +138,28 @@ replace_worktree_icon = false
 	}
 	if cfg.TUI.ReplaceWorktreeIcon {
 		t.Fatal("replace_worktree_icon=true, want false")
+	}
+}
+
+func TestNativePickerCanDisablePreview(t *testing.T) {
+	cfg, err := loadNative(t, `version = 1
+
+[picker]
+show_preview = false
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.ShowPreview {
+		t.Fatal("show_preview=true, want false")
+	}
+
+	defaults, err := loadNative(t, "version = 1\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !defaults.TUI.ShowPreview {
+		t.Fatal("show_preview=false by default, want true")
 	}
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -133,6 +133,7 @@ type Options struct {
 	HideLastWorkspace              bool
 	HideLastWorkspacePath          bool
 	SeparatorAware                 bool
+	HidePreview                    bool
 	DefaultPreviewCommand          string
 	FZFCommand                     string
 	RefreshAgentStatuses           func() (map[string]string, error)
@@ -199,6 +200,7 @@ type teaModel struct {
 	previewKey string
 
 	defaultPreviewCommand   string
+	hidePreview             bool
 	showIcons               bool
 	replaceWorktreeIcon     bool
 	hideLastWorkspace       bool
@@ -286,6 +288,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		input:                 input,
 		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
+		hidePreview:           opts.HidePreview,
 		showIcons:             opts.ShowIcons,
 		replaceWorktreeIcon:   !opts.DisableWorktreeIconReplacement,
 		hideLastWorkspace:     opts.HideLastWorkspace,
@@ -303,7 +306,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
-	if current, ok := list.Current(); ok {
+	if current, ok := list.Current(); ok && !m.hidePreview {
 		m.previewKey = sessionmodel.Key(current)
 		m.preview = "Loading preview..."
 	}
@@ -659,7 +662,10 @@ func (m teaModel) View() tea.View {
 	input.SetWidth(maxInt(8, width-lipgloss.Width(input.Prompt)-1))
 	lines = append(lines, fitLine(input.View(), width), horizontalRule(width))
 
-	if previewWidth > 0 {
+	if m.hidePreview {
+		lines = append(lines, sectionStyle.Render("WORKSPACES"))
+		lines = append(lines, strings.Split(strings.TrimSuffix(m.listView(width, m.listOnlyBodyLines()), "\n"), "\n")...)
+	} else if previewWidth > 0 {
 		previewLines := m.previewBodyLines()
 		list := sectionStyle.Render("WORKSPACES") + "\n" + m.listView(listWidth, previewLines)
 		preview := m.previewView(previewWidth, previewLines)
@@ -677,6 +683,12 @@ func (m teaModel) View() tea.View {
 	footer := helpStyle.Render(fmt.Sprintf("enter select · ctrl+j/k · ctrl+r %s · ctrl+x close · esc exit", sortMode))
 	if m.closeError != "" {
 		footer = emptyStyle.Render(m.closeError)
+	} else if m.hidePreview && m.closingWorkspaceID != "" {
+		status := "Closing workspace..."
+		if m.quitAfterWorkspaceClose {
+			status = "Cancelling workspace close..."
+		}
+		footer = emptyStyle.Render(status)
 	}
 	lines = append(lines,
 		horizontalRule(width),
@@ -847,6 +859,13 @@ func (m teaModel) previewBodyLines() int {
 	return lines
 }
 
+func (m teaModel) listOnlyBodyLines() int {
+	if m.height == 0 {
+		return defaultVisibleRows
+	}
+	return maxInt(1, m.height-pickerChromeRows-previewTitleRows)
+}
+
 func (m teaModel) stackedBodyLines() (int, int) {
 	if m.height == 0 {
 		return defaultVisibleRows, compactPreviewBody
@@ -970,6 +989,11 @@ func (m teaModel) previewTitle() string {
 }
 
 func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
+	if m.hidePreview {
+		m.previewKey = ""
+		m.preview = ""
+		return m, nil
+	}
 	current, ok := m.list.Current()
 	if !ok {
 		m.previewKey = ""
@@ -1021,7 +1045,9 @@ func (m teaModel) smearToInput() (teaModel, tea.Cmd) {
 
 func (m teaModel) focusSmearDistance() int {
 	visibleRows := m.previewBodyLines()
-	if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
+	if m.hidePreview {
+		visibleRows = m.listOnlyBodyLines()
+	} else if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
 		visibleRows, _ = m.stackedBodyLines()
 	}
 	start, _, moreAbove, _ := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -3,7 +3,9 @@ package picker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1392,6 +1394,52 @@ func TestTeaModelPreviewUsesConfiguredCommand(t *testing.T) {
 	}
 }
 
+func TestTeaModelHidePreviewDoesNotRunInitialPreview(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "preview-ran")
+	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}}, Options{
+		HidePreview:           true,
+		DefaultPreviewCommand: fmt.Sprintf("touch %q", marker),
+	})
+
+	executeTeaCommand(m.Init())
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("preview command ran while hidden: %v", err)
+	}
+}
+
+func TestTeaModelHidePreviewDoesNotRefreshAfterSelection(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "1")
+	marker := filepath.Join(t.TempDir(), "preview-ran")
+	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}, {Name: "web", Path: "/tmp/web"}}, Options{
+		HidePreview:           true,
+		DefaultPreviewCommand: fmt.Sprintf("touch %q", marker),
+	})
+	m.listFocused = true
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	executeTeaCommand(cmd)
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("preview command refreshed while hidden: %v", err)
+	}
+}
+
+func executeTeaCommand(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return
+	}
+	for _, child := range batch {
+		if child != nil {
+			_ = child()
+		}
+	}
+}
+
 func TestTeaModelRefreshesPreviewWhenSelectionChanges(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}, {Name: "web", Path: "/tmp/web"}}, Options{})
 	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
@@ -1546,6 +1594,81 @@ func TestTeaModelStacksPreviewAtNarrowWidth(t *testing.T) {
 	if strings.Contains(view, "│") {
 		t.Fatalf("narrow view should not contain a vertical pane divider:\n%s", view)
 	}
+}
+
+func TestTeaModelHidePreviewUsesAllAvailableSpace(t *testing.T) {
+	items := make([]model.Session, 18)
+	for i := range items {
+		items[i] = model.Session{
+			Name: fmt.Sprintf("workspace-%02d", i),
+			Path: "/tmp/path-that-only-fits-after-preview-space-is-reclaimed",
+		}
+	}
+
+	for _, width := range []int{70, 120} {
+		t.Run(fmt.Sprintf("width_%d", width), func(t *testing.T) {
+			m := newTeaModel(items, Options{HidePreview: true})
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: width, Height: 28})
+			m = updated.(teaModel)
+			view := ansi.Strip(m.View().Content)
+
+			if strings.Contains(view, "PREVIEW") || strings.Contains(view, "│") {
+				t.Fatalf("hidden preview still rendered at width %d:\n%s", width, view)
+			}
+			if got := lipgloss.Height(view); got != 28 {
+				t.Fatalf("view height=%d, want 28:\n%s", got, view)
+			}
+			if got := maxLineWidth(view); got != width {
+				t.Fatalf("view width=%d, want %d:\n%s", got, width, view)
+			}
+			if width == 70 && !strings.Contains(view, "workspace-17") {
+				t.Fatalf("narrow list did not reclaim preview rows:\n%s", view)
+			}
+			if width == 120 && !strings.Contains(view, items[0].Path) {
+				t.Fatalf("wide list did not give reclaimed width to the path column:\n%s", view)
+			}
+		})
+	}
+}
+
+func TestTeaModelHidePreviewFitsShortNarrowTerminal(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}}, Options{HidePreview: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 70, Height: 14})
+	m = updated.(teaModel)
+	view := ansi.Strip(m.View().Content)
+
+	if got := lipgloss.Height(view); got != 14 {
+		t.Fatalf("view height=%d, want 14:\n%s", got, view)
+	}
+}
+
+func TestTeaModelHidePreviewShowsWorkspaceCloseProgressInFooter(t *testing.T) {
+	m := newTeaModel([]model.Session{{Source: "herdr", Name: "api", WorkspaceID: "w1"}}, Options{
+		HidePreview:    true,
+		CloseWorkspace: func(context.Context, string) error { return nil },
+	})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
+	m = updated.(teaModel)
+	m, _ = m.closeSelectedWorkspace()
+	t.Cleanup(func() {
+		if m.cancelWorkspaceClose != nil {
+			m.cancelWorkspaceClose()
+		}
+	})
+
+	if footer := renderedFooter(m); !strings.Contains(footer, "Closing workspace...") {
+		t.Fatalf("closing footer=%q", footer)
+	}
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = updated.(teaModel)
+	if footer := renderedFooter(m); !strings.Contains(footer, "Cancelling workspace close...") {
+		t.Fatalf("cancelling footer=%q", footer)
+	}
+}
+
+func renderedFooter(m teaModel) string {
+	lines := strings.Split(strings.TrimSuffix(ansi.Strip(m.View().Content), "\n"), "\n")
+	return lines[len(lines)-1]
 }
 
 func TestTeaModelSplitsPreviewAtTerminalThreshold(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a default-on native picker show_preview setting
- skip preview commands and give the workspace list the reclaimed width and height when disabled
- preserve close progress in the footer and document the new option

Closes #84

## Validation
- go test ./internal/config ./internal/app ./internal/picker
- GOLANGCI_LINT_CACHE=/private/tmp/codex-herdr-sesh-golangci-84 just check
- just build
- ./bin/herdr-sesh --version
- ./bin/herdr-sesh list --json --config testdata/sesh.toml
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

