### PR TITLE
perf(picker): cancel superseded previews

### DIFF
--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -196,8 +196,12 @@ type teaModel struct {
 	reduceMotion        bool
 	smear               smearPreset
 
-	preview    string
-	previewKey string
+	preview              string
+	previewKey           string
+	previewParentContext context.Context
+	previewContext       context.Context
+	cancelPreview        context.CancelFunc
+	previewRequestID     uint64
 
 	defaultPreviewCommand   string
 	hidePreview             bool
@@ -222,8 +226,9 @@ type teaModel struct {
 }
 
 type previewMsg struct {
-	key  string
-	text string
+	key       string
+	requestID uint64
+	text      string
 }
 
 type statusRefreshTickMsg struct{}
@@ -303,12 +308,12 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		closeWorkspace:        opts.CloseWorkspace,
 		reloadPicker:          opts.ReloadPicker,
 		workspaceCloseContext: closeContext,
+		previewParentContext:  closeContext,
 		reduceMotion:          reduceMotion == "1" || strings.EqualFold(reduceMotion, "true"),
 		smear:                 newSmearPreset(os.Getenv("HERDR_SESH_SMEAR_PRESET")),
 	}
 	if current, ok := list.Current(); ok && !m.hidePreview {
-		m.previewKey = sessionmodel.Key(current)
-		m.preview = "Loading preview..."
+		m, _ = m.startPreview(current)
 	}
 	return m
 }
@@ -316,7 +321,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 func (m teaModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{m.input.Focus()}
 	if current, ok := m.list.Current(); ok && m.previewKey != "" {
-		cmds = append(cmds, previewCommand(m.previewKey, current, m.defaultPreviewCommand))
+		cmds = append(cmds, previewCommand(m.previewContext, m.previewKey, m.previewRequestID, current, m.defaultPreviewCommand))
 	}
 	if m.refreshAgentStatuses != nil {
 		cmds = append(cmds, scheduleStatusRefresh(), m.agentSpinner.Tick)
@@ -436,7 +441,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.smearTick()
 	}
 	if preview, ok := msg.(previewMsg); ok {
-		if preview.key == m.previewKey {
+		if preview.requestID == m.previewRequestID && preview.key == m.previewKey {
 			m.preview = preview.text
 		}
 		return m, nil
@@ -521,6 +526,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.preview = "Cancelling workspace close..."
 			return m, nil
 		}
+		m = m.cancelActivePreview()
 		return m, tea.Quit
 	case "enter":
 		if m.closingWorkspaceID != "" {
@@ -530,6 +536,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.choice = choice
 			m.chosen = true
 		}
+		m = m.cancelActivePreview()
 		return m, tea.Quit
 	case "up", "ctrl+p", "ctrl+k":
 		if !m.listFocused {
@@ -579,6 +586,7 @@ func (m teaModel) closeSelectedWorkspace() (teaModel, tea.Cmd) {
 	}
 	m.closingWorkspaceID = current.WorkspaceID
 	m.closeError = ""
+	m = m.cancelActivePreview()
 	m.previewKey = ""
 	m.preview = "Closing workspace..."
 	closeCtx, cancel := context.WithCancel(m.workspaceCloseContext)
@@ -990,12 +998,14 @@ func (m teaModel) previewTitle() string {
 
 func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
 	if m.hidePreview {
+		m = m.cancelActivePreview()
 		m.previewKey = ""
 		m.preview = ""
 		return m, nil
 	}
 	current, ok := m.list.Current()
 	if !ok {
+		m = m.cancelActivePreview()
 		m.previewKey = ""
 		m.preview = "No preview available"
 		return m, nil
@@ -1004,9 +1014,27 @@ func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
 	if key == m.previewKey {
 		return m, nil
 	}
-	m.previewKey = key
+	return m.startPreview(current)
+}
+
+func (m teaModel) cancelActivePreview() teaModel {
+	if m.cancelPreview != nil {
+		m.cancelPreview()
+		m.cancelPreview = nil
+	}
+	m.previewRequestID++
+	return m
+}
+
+//nolint:contextcheck // Bubble Tea persists the caller context on the model between messages.
+func (m teaModel) startPreview(s sessionmodel.Session) (teaModel, tea.Cmd) {
+	m = m.cancelActivePreview()
+	ctx, cancel := context.WithCancel(m.previewParentContext)
+	m.previewContext = ctx
+	m.cancelPreview = cancel
+	m.previewKey = sessionmodel.Key(s)
 	m.preview = "Loading preview..."
-	return m, previewCommand(key, current, m.defaultPreviewCommand)
+	return m, previewCommand(ctx, m.previewKey, m.previewRequestID, s, m.defaultPreviewCommand)
 }
 
 func (m teaModel) focusList() (teaModel, tea.Cmd) {
@@ -1185,9 +1213,9 @@ func overlayCell(line string, column int, cell string, width int) string {
 	return fitLine(ansi.Cut(line, 0, column)+cell+ansi.Cut(line, column+1, width), width)
 }
 
-func previewCommand(key string, s sessionmodel.Session, defaultPreviewCommand string) tea.Cmd {
+func previewCommand(ctx context.Context, key string, requestID uint64, s sessionmodel.Session, defaultPreviewCommand string) tea.Cmd {
 	return func() tea.Msg {
-		text, err := renderPreview(context.Background(), s, defaultPreviewCommand)
+		text, err := renderPreview(ctx, s, defaultPreviewCommand)
 		if err != nil {
 			text = err.Error()
 		}
@@ -1195,7 +1223,7 @@ func previewCommand(key string, s sessionmodel.Session, defaultPreviewCommand st
 		if text == "" {
 			text = "No preview available"
 		}
-		return previewMsg{key: key, text: text}
+		return previewMsg{key: key, requestID: requestID, text: text}
 	}
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -454,6 +454,7 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.cancelWorkspaceClose = nil
 		if m.quitAfterWorkspaceClose {
 			m.quitAfterWorkspaceClose = false
+			m = m.cancelActivePreview()
 			return m, tea.Quit
 		}
 		if closed.closeErr != nil {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -1589,6 +1589,70 @@ func TestTeaModelCancelsPreviewOnQuitOrNoPreview(t *testing.T) {
 	}
 }
 
+func TestTeaModelCancelsRestartedPreviewWhenQuittingPendingClose(t *testing.T) {
+	t.Setenv("HERDR_SESH_REDUCE_MOTION", "1")
+	closeStarted := make(chan struct{})
+	previewStarted := make(chan struct{})
+	previewCanceled := make(chan struct{})
+	oldPreview := renderPreview
+	renderPreview = func(ctx context.Context, _ model.Session, _ string) (string, error) {
+		close(previewStarted)
+		<-ctx.Done()
+		close(previewCanceled)
+		return "", ctx.Err()
+	}
+	t.Cleanup(func() { renderPreview = oldPreview })
+
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "api", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "web", WorkspaceID: "w2"},
+	}, Options{
+		Context: context.Background(),
+		CloseWorkspace: func(ctx context.Context, _ string) error {
+			close(closeStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	m.listFocused = true
+	updated, closeCmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	closeResult := make(chan tea.Msg, 1)
+	go func() { closeResult <- closeCmd() }()
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("workspace close did not start")
+	}
+
+	updated, moveCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(teaModel)
+	go executeTeaCommand(moveCmd)
+	select {
+	case <-previewStarted:
+	case <-time.After(time.Second):
+		t.Fatal("navigation did not restart preview during close")
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = updated.(teaModel)
+	updated, quitCmd := m.Update(<-closeResult)
+	m = updated.(teaModel)
+	if quitCmd == nil {
+		t.Fatal("pending close did not quit after cancellation")
+	}
+	if quitMsg := quitCmd(); quitMsg == nil {
+		t.Fatal("quit command returned nil")
+	} else if _, ok := quitMsg.(tea.QuitMsg); !ok {
+		t.Fatalf("quit command returned %T", quitMsg)
+	}
+	select {
+	case <-previewCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("restarted preview did not observe cancellation before quit")
+	}
+}
+
 func TestTeaModelRefreshesAgentStatuses(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Source: "herdr", Name: "api", WorkspaceID: "w1", AgentStatus: "working"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"charm.land/bubbles/v2/cursor"
@@ -882,7 +883,7 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 30})
 	m = updated.(teaModel)
-	updated, _ = m.Update(previewCommand(m.previewKey, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)())
+	updated, _ = m.Update(previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)())
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
 	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "LAST WORKSPACE · workspace-api  /tmp/workspace-api", "WORKSPACES", "PREVIEW · workspace-api · working", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
@@ -1387,7 +1388,7 @@ func TestPreviewTitleShowsWorktreeParentBeforeAgentStatus(t *testing.T) {
 
 func TestTeaModelPreviewUsesConfiguredCommand(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}}, Options{DefaultPreviewCommand: "printf preview:%s {}"})
-	msg := previewCommand(m.previewKey, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)()
+	msg := previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)()
 	preview := msg.(previewMsg)
 	if got := strings.TrimSpace(preview.text); got != "preview:/tmp/api" {
 		t.Fatalf("preview=%q", preview.text)
@@ -1452,6 +1453,139 @@ func TestTeaModelRefreshesPreviewWhenSelectionChanges(t *testing.T) {
 	current, ok := m.list.Current()
 	if !ok || current.Name != "web" || m.previewKey != model.Key(current) {
 		t.Fatalf("current=%#v ok=%v previewKey=%q", current, ok, m.previewKey)
+	}
+}
+
+func TestTeaModelCancelsSupersededPreview(t *testing.T) {
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	oldPreview := renderPreview
+	renderPreview = func(ctx context.Context, s model.Session, _ string) (string, error) {
+		switch s.Name {
+		case "api":
+			close(firstStarted)
+			<-ctx.Done()
+			close(firstCanceled)
+			return "", ctx.Err()
+		case "web":
+			close(secondStarted)
+			<-releaseSecond
+			return "web preview", nil
+		default:
+			t.Fatalf("unexpected preview for %q", s.Name)
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { renderPreview = oldPreview })
+
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{Context: context.Background()})
+	m.previewKey = ""
+	m, firstCmd := m.refreshPreview()
+	firstResult := make(chan tea.Msg, 1)
+	go func() { firstResult <- firstCmd() }()
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first preview did not start")
+	}
+
+	m.list.Move(1)
+	m, secondCmd := m.refreshPreview()
+	secondResult := make(chan tea.Msg, 1)
+	go func() { secondResult <- secondCmd() }()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("replacement preview did not start")
+	}
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("superseded preview did not observe cancellation")
+	}
+
+	close(releaseSecond)
+	updated, _ := m.Update(<-secondResult)
+	m = updated.(teaModel)
+	if m.preview != "web preview" {
+		t.Fatalf("preview=%q, want replacement result", m.preview)
+	}
+	<-firstResult
+}
+
+func TestTeaModelRejectsObsoleteSameKeyPreview(t *testing.T) {
+	oldPreview := renderPreview
+	renderPreview = func(_ context.Context, s model.Session, _ string) (string, error) {
+		return s.Name + " preview", nil
+	}
+	t.Cleanup(func() { renderPreview = oldPreview })
+
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+	m.previewKey = ""
+	m, firstCmd := m.refreshPreview()
+	m.list.Move(1)
+	m, _ = m.refreshPreview()
+	m.list.Move(-1)
+	m, _ = m.refreshPreview()
+
+	updated, _ := m.Update(firstCmd())
+	m = updated.(teaModel)
+	if m.preview != "Loading preview..." {
+		t.Fatalf("preview=%q, want active request loading text", m.preview)
+	}
+}
+
+func TestTeaModelCancelsPreviewOnQuitOrNoPreview(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		advance func(teaModel) (teaModel, tea.Cmd)
+	}{
+		{
+			name: "quit",
+			advance: func(m teaModel) (teaModel, tea.Cmd) {
+				updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+				return updated.(teaModel), cmd
+			},
+		},
+		{
+			name: "no preview",
+			advance: func(m teaModel) (teaModel, tea.Cmd) {
+				m = m.filter("missing")
+				return m.refreshPreview()
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			started := make(chan struct{})
+			canceled := make(chan struct{})
+			oldPreview := renderPreview
+			renderPreview = func(ctx context.Context, _ model.Session, _ string) (string, error) {
+				close(started)
+				<-ctx.Done()
+				close(canceled)
+				return "", ctx.Err()
+			}
+			t.Cleanup(func() { renderPreview = oldPreview })
+
+			m := newTeaModel([]model.Session{{Name: "api"}}, Options{Context: context.Background()})
+			m.previewKey = ""
+			m, previewCmd := m.refreshPreview()
+			go previewCmd()
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("preview did not start")
+			}
+
+			_, _ = tt.advance(m)
+			select {
+			case <-canceled:
+			case <-time.After(time.Second):
+				t.Fatal("preview did not observe cancellation")
+			}
+		})
 	}
 }
 

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -1461,6 +1461,7 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 	firstCanceled := make(chan struct{})
 	secondStarted := make(chan struct{})
 	releaseSecond := make(chan struct{})
+	previewErr := make(chan error, 1)
 	oldPreview := renderPreview
 	renderPreview = func(ctx context.Context, s model.Session, _ string) (string, error) {
 		switch s.Name {
@@ -1474,8 +1475,9 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 			<-releaseSecond
 			return "web preview", nil
 		default:
-			t.Fatalf("unexpected preview for %q", s.Name)
-			return "", nil
+			err := fmt.Errorf("unexpected preview for %q", s.Name)
+			previewErr <- err
+			return "", err
 		}
 	}
 	t.Cleanup(func() { renderPreview = oldPreview })
@@ -1487,6 +1489,8 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 	go func() { firstResult <- firstCmd() }()
 	select {
 	case <-firstStarted:
+	case err := <-previewErr:
+		t.Fatal(err)
 	case <-time.After(time.Second):
 		t.Fatal("first preview did not start")
 	}
@@ -1497,6 +1501,8 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 	go func() { secondResult <- secondCmd() }()
 	select {
 	case <-secondStarted:
+	case err := <-previewErr:
+		t.Fatal(err)
 	case <-time.After(time.Second):
 		t.Fatal("replacement preview did not start")
 	}

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -3,12 +3,14 @@ package preview
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
@@ -41,10 +43,26 @@ func runShell(ctx context.Context, command string) (string, error) {
 	defer cancel()
 	//nolint:gosec // preview commands are user-configured shell snippets by design.
 	c := exec.CommandContext(ctx, "sh", "-lc", command)
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	killProcessGroup := func() error {
+		if c.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	c.Cancel = killProcessGroup
+	c.WaitDelay = 250 * time.Millisecond
 	var out, errb bytes.Buffer
 	c.Stdout = &out
 	c.Stderr = &errb
 	err := c.Run()
+	if errors.Is(err, exec.ErrWaitDelay) {
+		_ = killProcessGroup()
+	}
 	if err != nil {
 		return out.String() + errb.String(), err
 	}

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -41,30 +41,39 @@ func Render(ctx context.Context, s model.Session, fallbackCommand string) (strin
 func runShell(ctx context.Context, command string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	//nolint:gosec // preview commands are user-configured shell snippets by design.
-	c := exec.CommandContext(ctx, "sh", "-lc", command)
-	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	sentinel := exec.Command("sh", "-c", `kill -s STOP "$$"`)
+	sentinel.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := sentinel.Start(); err != nil {
+		return "", err
+	}
+	processGroupID := sentinel.Process.Pid
 	killProcessGroup := func() error {
-		if c.Process == nil {
-			return os.ErrProcessDone
-		}
-		err := syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+		err := syscall.Kill(-processGroupID, syscall.SIGKILL)
 		if errors.Is(err, syscall.ESRCH) {
 			return os.ErrProcessDone
 		}
 		return err
 	}
+	//nolint:gosec // preview commands are user-configured shell snippets by design.
+	c := exec.CommandContext(ctx, "sh", "-lc", command)
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: processGroupID}
 	c.Cancel = killProcessGroup
 	c.WaitDelay = 250 * time.Millisecond
 	var out, errb bytes.Buffer
 	c.Stdout = &out
 	c.Stderr = &errb
 	err := c.Run()
-	if errors.Is(err, exec.ErrWaitDelay) {
-		_ = killProcessGroup()
+	killErr := killProcessGroup()
+	if killErr != nil {
+		_ = sentinel.Process.Kill()
 	}
+	_ = sentinel.Wait()
+	output := out.String() + errb.String()
 	if err != nil {
-		return out.String() + errb.String(), err
+		return output, err
+	}
+	if killErr != nil {
+		return output, killErr
 	}
 	return out.String(), nil
 }

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
@@ -17,6 +18,110 @@ func TestRenderUsesPreviewCommand(t *testing.T) {
 	}
 	if strings.TrimSpace(out) != "/tmp/has space" {
 		t.Fatalf("got %q", out)
+	}
+}
+
+func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	release := filepath.Join(dir, "release")
+	survived := filepath.Join(dir, "survived")
+	t.Setenv("READY_FILE", ready)
+	t.Setenv("RELEASE_FILE", release)
+	t.Setenv("SURVIVED_FILE", survived)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_, _ = runShell(ctx, `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' &`)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("descendant process did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	returned := false
+	select {
+	case <-done:
+		returned = true
+	case <-time.After(time.Second):
+		t.Error("runShell remained blocked after its shell exited")
+	}
+	cancel()
+	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if !returned {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("runShell did not return after descendant cleanup")
+		}
+	}
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(survived); err == nil {
+			t.Fatal("descendant process survived shell exit and cancellation")
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRunShellCancellationKillsDescendantProcess(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	release := filepath.Join(dir, "release")
+	survived := filepath.Join(dir, "survived")
+	t.Setenv("READY_FILE", ready)
+	t.Setenv("RELEASE_FILE", release)
+	t.Setenv("SURVIVED_FILE", survived)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_, _ = runShell(ctx, `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' & wait`)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("descendant process did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runShell remained blocked after cancellation")
+	}
+	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(survived); err == nil {
+			t.Fatal("descendant process survived cancellation")
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -2,7 +2,9 @@ package preview
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,10 +34,10 @@ func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
-		_, _ = runShell(ctx, `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' &`)
-		close(done)
+		_, err := runShell(ctx, `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' &`)
+		done <- err
 	}()
 
 	deadline := time.Now().Add(time.Second)
@@ -50,8 +52,9 @@ func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
 	}
 
 	returned := false
+	var runErr error
 	select {
-	case <-done:
+	case runErr = <-done:
 		returned = true
 	case <-time.After(time.Second):
 		t.Error("runShell remained blocked after its shell exited")
@@ -62,15 +65,49 @@ func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
 	}
 	if !returned {
 		select {
-		case <-done:
+		case runErr = <-done:
 		case <-time.After(time.Second):
 			t.Fatal("runShell did not return after descendant cleanup")
 		}
+	}
+	if !errors.Is(runErr, exec.ErrWaitDelay) {
+		t.Errorf("runShell error = %v, want %v", runErr, exec.ErrWaitDelay)
 	}
 	deadline = time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(survived); err == nil {
 			t.Fatal("descendant process survived shell exit and cancellation")
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRunShellCleansUpRedirectedDescendantAfterShellExit(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	release := filepath.Join(dir, "release")
+	survived := filepath.Join(dir, "survived")
+	t.Setenv("READY_FILE", ready)
+	t.Setenv("RELEASE_FILE", release)
+	t.Setenv("SURVIVED_FILE", survived)
+	t.Cleanup(func() { _ = os.WriteFile(release, []byte("release"), 0600) })
+
+	_, err := runShell(context.Background(), `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' >/dev/null 2>&1 & while [ ! -e "$READY_FILE" ]; do sleep 0.01; done`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(ready); err != nil {
+		t.Fatalf("descendant process did not start: %v", err)
+	}
+	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(survived); err == nil {
+			t.Fatal("redirected descendant survived shell exit")
 		} else if !os.IsNotExist(err) {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Summary

- cancel superseded native preview work on navigation and all quit, no-preview, and close paths
- pin configured previews to a sentinel-led Unix process group so successful shells, pipelines, and background children are terminated after output collection
- preserve native cancellation, exit-status, and inherited-pipe timeout errors while cleaning up the full process group
- reject stale A-to-B-to-A results with request IDs plus session keys
- cover the pending-workspace-close quit path found during review

## Benchmark results

Measured on Apple M4 Pro with the benchmark suite merged in #92. Values are medians from three runs of:

```text
go test -run=^$ -bench=BenchmarkPreviewNavigationBurst -count=3 ./internal/picker
```

| Metric | `main` (`8c7d3e7`) | This branch | Change |
| --- | ---: | ---: | ---: |
| Burst latency | 9,679,944 ns/op | 1,326,642 ns/op | **-86.3%** |
| Stale previews canceled | 0/op | 7/op | 7 of 8 requests canceled |
| Previews completed | 8/op | 1/op | Only the active request completes |
| Allocations | 207 allocs/op | 282 allocs/op | +75 allocs/op |

The benchmark models eight rapid navigation requests with a context-aware 1 ms preview workload. Cancellation bookkeeping adds small allocation overhead, but prevents seven stale preview workloads from completing.

## Validation

- `go test -run=^$ -bench=BenchmarkPreviewNavigationBurst -count=3 ./internal/picker`
- `go test -race ./internal/preview -run 'TestRunShell|TestRenderUsesPreviewCommand' -count=10`
- `go test ./internal/preview -run 'TestRunShell|TestRenderUsesPreviewCommand' -count=20`
- `env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o /private/tmp/herdr-sesh-preview-linux-pr90.test ./internal/preview`
- `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-pr90-lint-cache just check` (355 race-enabled tests)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
