### PR TITLE
perf(sources): skip unnecessary pane discovery

### DIFF
--- a/internal/sources/herdr_workspaces.go
+++ b/internal/sources/herdr_workspaces.go
@@ -19,9 +19,15 @@ func (s HerdrWorkspaces) List(ctx context.Context) (model.Sessions, error) {
 	if err != nil {
 		return out, err
 	}
-	panes, err := s.Client.PaneList(ctx, "")
-	if err != nil {
-		panes = nil
+	var panes []herdr.Pane
+	for _, workspace := range ws {
+		if workspace.ForegroundCWD == "" && workspace.CWD == "" {
+			panes, err = s.Client.PaneList(ctx, "")
+			if err != nil {
+				panes = nil
+			}
+			break
+		}
 	}
 	parentsByRepo := worktreeParentsByRepo(ws)
 	for _, w := range ws {

--- a/internal/sources/herdr_workspaces_test.go
+++ b/internal/sources/herdr_workspaces_test.go
@@ -7,6 +7,36 @@ import (
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 )
 
+type countingHerdrClient struct {
+	*herdr.FakeClient
+
+	paneListCalls int
+}
+
+func (c *countingHerdrClient) PaneList(ctx context.Context, workspaceID string) ([]herdr.Pane, error) {
+	c.paneListCalls++
+	return c.FakeClient.PaneList(ctx, workspaceID)
+}
+
+func TestHerdrWorkspacesSkipsPaneListWhenWorkspaceHasPath(t *testing.T) {
+	client := &countingHerdrClient{FakeClient: &herdr.FakeClient{Workspaces: []herdr.Workspace{
+		{ID: "w-foreground", Label: "foreground", ForegroundCWD: "/tmp/foreground"},
+		{ID: "w-cwd", Label: "cwd", CWD: "/tmp/cwd"},
+	}}}
+
+	got, err := (HerdrWorkspaces{Client: client}).List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.paneListCalls != 0 {
+		t.Fatalf("PaneList calls=%d, want 0", client.paneListCalls)
+	}
+	paths := got.Ordered()
+	if len(paths) != 2 || paths[0].Path != "/tmp/foreground" || paths[1].Path != "/tmp/cwd" {
+		t.Fatalf("sessions=%#v", paths)
+	}
+}
+
 func TestHerdrWorkspacesRelatesLinkedWorktreeToUniqueParent(t *testing.T) {
 	repo := "/repos/project/.git"
 	src := HerdrWorkspaces{Client: &herdr.FakeClient{Workspaces: []herdr.Workspace{


### PR DESCRIPTION
## Summary

- skip `herdr pane list` when `workspace list` already supplies every workspace path
- preserve pane-derived and linked-worktree fallbacks for pathless workspaces

## Benchmark results

Measured on Apple M4 Pro with the benchmark suite merged in #92. Values are medians from three runs of:

```text
go test -run=^$ -bench=BenchmarkHerdrWorkspacesList -count=3 ./internal/sources
```

| Scenario | `main` (`8c7d3e7`) | This branch | Change |
| --- | ---: | ---: | ---: |
| Complete paths, in-memory | 226,962 ns/op, 2 commands | 134,597 ns/op, 1 command | **-40.7%** |
| Complete paths, process boundary | 7,613,533 ns/op, 2 commands | 3,945,840 ns/op, 1 command | **-48.2%** |
| Pane fallback, in-memory | 229,661 ns/op, 2 commands | 229,842 ns/op, 2 commands | Within noise |
| Pane fallback, process boundary | 7,784,544 ns/op, 2 commands | 7,666,351 ns/op, 2 commands | Within noise |

For the optimized complete-path case, allocations also fall from 1,864 to 1,345 per operation. The process-boundary benchmark uses the suite's controlled helper subprocess; it isolates the saved command boundary rather than claiming an absolute latency for a live Herdr installation.

## Validation

- `go test -run=^$ -bench=BenchmarkHerdrWorkspacesList -count=3 ./internal/sources`
- `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-lint-lazy just check` (346 race-enabled tests)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
