### PR TITLE
feat(config): support agent workspace sort

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -212,6 +212,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		SeparatorAware:                 cfg.SeparatorAware,
 		HidePreview:                    !cfg.TUI.ShowPreview,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
+		WorkspaceSort:                  cfg.TUI.DefaultSort,
 	}
 }
 
@@ -280,7 +281,6 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			a.warnf("ignoring workspace history: %v", historyErr)
 		}
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
-		pickOpts.RecentWorkspaceSort = cfg.TUI.DefaultSort == "recent"
 		if cfg.TUI.ShowLastWorkspace {
 			pickOpts.HerdrWorkspaces = herdrWorkspaces
 			lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), currentWorkspaceID)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -585,6 +585,17 @@ func TestListCacheDistinguishesRelativeConfigsAcrossWorkingDirectories(t *testin
 	}
 }
 
+func TestPickerOptionsPropagateWorkspaceSort(t *testing.T) {
+	cfg := config.Default()
+	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort; got != "workspace" {
+		t.Fatalf("default workspace sort = %q, want workspace", got)
+	}
+	cfg.TUI.DefaultSort = "agent"
+	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort; got != "agent" {
+		t.Fatalf("workspace sort = %q, want agent", got)
+	}
+}
+
 func TestPickerOptionsPropagateWorktreeIconReplacement(t *testing.T) {
 	cfg := config.Default()
 	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.DisableWorktreeIconReplacement {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -84,8 +84,8 @@ func decodeLegacy(cfg *Config, path string, strict bool) error {
 		return err
 	}
 	attachDefaults(cfg)
-	if cfg.TUI.DefaultSort != "workspace" && cfg.TUI.DefaultSort != "recent" {
-		return fmt.Errorf("load %s: tui.default_sort must be \"workspace\" or \"recent\"", path)
+	if cfg.TUI.DefaultSort != "workspace" && cfg.TUI.DefaultSort != "recent" && cfg.TUI.DefaultSort != "agent" {
+		return fmt.Errorf("load %s: tui.default_sort must be \"workspace\", \"recent\", or \"agent\"", path)
 	}
 	return nil
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -276,22 +276,32 @@ func TestDefaultReplacesWorktreeIcon(t *testing.T) {
 }
 
 func TestLoadTUIDefaultSort(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "sesh.toml")
-	mustWrite(t, p, "[tui]\ndefault_sort = \"recent\"\n")
-	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.DefaultSort != "recent" {
-		t.Fatalf("default sort = %q", cfg.TUI.DefaultSort)
+	for _, sortMode := range []string{"recent", "agent"} {
+		t.Run(sortMode, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "sesh.toml")
+			mustWrite(t, p, "[tui]\ndefault_sort = \""+sortMode+"\"\n")
+			cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.TUI.DefaultSort != sortMode {
+				t.Fatalf("default sort = %q, want %q", cfg.TUI.DefaultSort, sortMode)
+			}
+		})
 	}
 }
 
 func TestLoadRejectsInvalidTUIDefaultSort(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "sesh.toml")
 	mustWrite(t, p, "[tui]\ndefault_sort = \"newest\"\n")
-	if _, _, err := Load(LoadOptions{Warn: io.Discard, Path: p}); err == nil {
+	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+	if err == nil {
 		t.Fatal("expected invalid default sort error")
+	}
+	for _, want := range []string{"tui.default_sort", "workspace", "recent", "agent"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
 	}
 }
 

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -178,6 +178,16 @@ func migrateAndRead(t *testing.T, legacyBody string) (string, Config) {
 	return string(data), cfg
 }
 
+func TestMigratePreservesAgentWorkspaceSort(t *testing.T) {
+	text, cfg := migrateAndRead(t, "[tui]\ndefault_sort = \"agent\"\n")
+	if !strings.Contains(text, "workspace_sort") {
+		t.Fatalf("agent workspace sort missing from migrated config:\n%s", text)
+	}
+	if cfg.TUI.DefaultSort != "agent" {
+		t.Fatalf("workspace sort = %q, want agent", cfg.TUI.DefaultSort)
+	}
+}
+
 func TestMigrateEmitsShowIconsExplicitly(t *testing.T) {
 	t.Run("explicit true survives", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "[tui]\nshow_icons = true\n")

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -122,8 +122,8 @@ func (n nativeConfig) validate(path string) error {
 	if n.Naming.PathComponents != nil && *n.Naming.PathComponents < 1 {
 		return fail("naming.path_components", "must be at least 1")
 	}
-	if s := n.Picker.WorkspaceSort; s != "" && s != "workspace" && s != "recent" {
-		return fail("picker.workspace_sort", "must be \"workspace\" or \"recent\", got %q", s)
+	if s := n.Picker.WorkspaceSort; s != "" && s != "workspace" && s != "recent" && s != "agent" {
+		return fail("picker.workspace_sort", "must be \"workspace\" or \"recent\" or \"agent\", got %q", s)
 	}
 	seenSources := map[string]bool{}
 	for _, s := range n.List.SourceOrder {

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -113,6 +113,16 @@ func TestNativeMinimalFileKeepsDefaults(t *testing.T) {
 	}
 }
 
+func TestNativePickerAcceptsAgentWorkspaceSort(t *testing.T) {
+	cfg, err := loadNative(t, "version = 1\n[picker]\nworkspace_sort = \"agent\"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.DefaultSort != "agent" {
+		t.Fatalf("workspace sort = %q, want agent", cfg.TUI.DefaultSort)
+	}
+}
+
 func TestNativePickerCanDisableHerdrThemeInheritance(t *testing.T) {
 	cfg, err := loadNative(t, `version = 1
 
@@ -199,7 +209,7 @@ func TestNativeFailures(t *testing.T) {
 		"unknown nested field": {"version = 1\n[picker]\ntheme = \"dark\"\n", "theme"},
 		"legacy key rejected":  {"version = 1\nstrict_mode = true\n", "strict_mode"},
 		"import rejected":      {"version = 1\nimport = [\"x.toml\"]\n", "import"},
-		"bad sort":             {"version = 1\n[picker]\nworkspace_sort = \"newest\"\n", "workspace_sort"},
+		"bad sort":             {"version = 1\n[picker]\nworkspace_sort = \"newest\"\n", "picker.workspace_sort: must be \"workspace\" or \"recent\" or \"agent\""},
 		"bad path components":  {"version = 1\n[naming]\npath_components = 0\n", "path_components"},
 		"unknown source":       {"version = 1\n[list]\nsource_order = [\"tmux\"]\n", "source_order"},
 		"duplicate source":     {"version = 1\n[list]\nsource_order = [\"dir\", \"dir\"]\n", "source_order"},

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -149,7 +149,6 @@ type Options struct {
 	// metadata" while an empty slice means "no workspaces".
 	ReloadPicker         func(context.Context) (ReloadResult, error)
 	RecentWorkspaceIDs   []string
-	RecentWorkspaceSort  bool
 	WorkspaceSort        string
 	LastWorkspaceID      string
 	LastWorkspaceUnknown bool
@@ -268,9 +267,6 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	workspaceOrder := herdrWorkspaceIDs(items)
 	items = append([]sessionmodel.Session(nil), items...)
 	workspaceSort := normalizeWorkspaceSort(opts.WorkspaceSort)
-	if opts.WorkspaceSort == "" && opts.RecentWorkspaceSort {
-		workspaceSort = workspaceSortRecent
-	}
 	initialOrder := workspaceOrder
 	switch workspaceSort {
 	case workspaceSortRecent:


### PR DESCRIPTION
## Summary

Wire the native picker's agent sort mode through configuration and application startup.

- Accept `agent` for native `picker.workspace_sort`.
- Accept `agent` for deprecated legacy `tui.default_sort` while preserving migration compatibility.
- Carry the configured mode into picker options without changing the default `workspace` behavior.
- Keep recent-workspace history available so users can cycle into `recent` from any configured initial mode.
- Add native, legacy, migration, and app propagation tests.

This is **2 of 3** in stack #97. It depends on #94 and is followed by documentation in #96.

## Related issue

N/A

## Validation

- [x] `just fmt-check`
- [x] `go test ./...` on `agent-sort/config`
- [x] `just check` on the completed stack
- [x] `just build` on the completed stack
- [x] CLI version and fixture-backed JSON smoke checks

## User-facing changes

Users can set the initial native picker mode with:

```toml
[picker]
workspace_sort = "agent"
```

The legacy `tui.default_sort = "agent"` value also migrates to the native setting.
