### PR TITLE
docs: document agent workspace sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ tabs.
 - Focus an existing workspace or create one from a configured session or
   directory.
 - Apply startup commands, previews, and named Herdr tabs to new workspaces.
-- Filter, sort, deduplicate, and optionally cache session results.
+- Filter, deduplicate, and optionally cache session results, with native
+  [workspace, recent, and agent-priority sorting](docs/config.md#picker).
 - Jump directly to the previously focused workspace.
 - Clone a Git repository and connect to it in one command.
 - Use the built-in picker by default or opt into the experimental fzf picker.

--- a/docs/config.md
+++ b/docs/config.md
@@ -60,7 +60,7 @@ replace_worktree_icon = true
 prompt = "Sesh> "
 placeholder = "Search workspaces"
 separator_aware = true
-workspace_sort = "recent"
+workspace_sort = "agent"
 show_last_workspace = true
 show_last_workspace_path = false
 
@@ -145,7 +145,7 @@ can leave the source untouched.
     | `tui.show_last_workspace_path` | `picker.show_last_workspace_path` |
     | `tui.prompt` | `picker.prompt` |
     | `tui.placeholder` | `picker.placeholder` |
-    | `tui.default_sort` | `picker.workspace_sort` |
+    | `tui.default_sort` | `picker.workspace_sort` (`workspace`, `recent`, or `agent`) |
     | `default_session.startup_command` | `workspace_defaults.startup` |
     | `default_session.preview_command` | `workspace_defaults.preview` |
     | `session[]` | `workspace[]` |
@@ -200,7 +200,7 @@ equivalent; native decoding rejects them like any other unknown key.
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |
 | `placeholder` | Replaces the picker placeholder. An empty value uses `Filter workspaces`. |
 | `separator_aware` | Makes native and fzf picker searches treat `-`, `_`, `/`, and `.` as spaces. |
-| `workspace_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default) or `recent` (most recently visited first). Press ++ctrl+r++ to switch modes while the picker is open. |
+| `workspace_sort` | Sets the native picker's initial Herdr workspace order to `workspace` (Herdr's order, the default), `recent` (most recently visited first), or `agent` (agent-status priority). Press ++ctrl+r++ to cycle `workspace` → `recent` → `agent` while the picker is open. This setting does not affect fzf or JSON output. |
 | `show_last_workspace` | Shows the workspace targeted by `herdr-sesh last` in the picker footer. The default is `true`; set it to `false` to disable the feature. |
 | `show_last_workspace_path` | Shows the Herdr workspace working directory beside the last workspace name. The default is `true`; set it to `false` to show only the workspace name. |
 
@@ -218,6 +218,15 @@ instantaneous without drawing any preset's trail.
 Open Herdr workspaces show the agent state reported by Herdr: an animated amber
 Jump spinner (`⢄⢂⢁⡁⡈⡐⡠`) while working, red `◉` when blocked, green `✓` when idle,
 and teal `●` when done. Workspaces with an unknown state have no indicator.
+Herdr calls an actively running agent `working`.
+
+The native picker's `agent` sort mode orders recognized states as blocked →
+done → working → idle, followed by workspaces with no agent or an unknown
+state. Ties retain Herdr's original workspace order, including unrecognized
+future states. Live status refreshes update this order without changing the
+selected workspace. Sorting only rearranges Herdr rows within their configured
+source-order slots; it does not move them ahead of `config`, `zoxide`, or `dir`
+rows when `list.source_order` puts those sources first.
 
 ### Picker colors
 
@@ -261,8 +270,10 @@ overrides.
 
 The native picker marks a linked Git worktree workspace with a purple
 `↳ herdr` type label, replacing the normal Herdr sheep icon, and groups it
-immediately beneath its open parent workspace in both workspace and recent sort
-modes, matching Herdr's sidebar. With icons disabled, the label is `[↳ herdr]`.
+immediately beneath its open parent workspace in workspace, recent, and agent
+sort modes, matching Herdr's sidebar. In agent mode, the highest-priority status
+on any family member ranks the whole family; the parent remains first and its
+children follow in agent-priority order. With icons disabled, the label is `[↳ herdr]`.
 When the parent is visible, `├─` and `└─` branches reinforce the family in the
 workspace-name column. Wide layouts show the worktree path in the secondary
 column when space permits; narrow layouts retain the purple type label. This is


### PR DESCRIPTION
## Summary

Document the native picker's agent-priority workspace sorting.

- Add `agent` to the configuration example and `workspace_sort` reference.
- Document the `workspace → recent → agent` cycle.
- Explain blocked → done → working → idle priority and clarify that Herdr calls a running agent `working`.
- Describe stable ties, live refresh behavior, source-order boundaries, and linked-worktree family promotion.
- Clarify that agent sorting does not affect fzf or JSON output.

This is **3 of 3** in stack #97 and depends on #95.

## Related issue

N/A

## Validation

- [x] `just build-docs`
- [x] `just check` on the completed stack
- [x] `just build` on the completed stack

## User-facing changes

Updates `README.md` and `docs/config.md`; no additional runtime changes are introduced in this layer.
