### PR TITLE
feat(picker): prioritize workspace name matches

### DIFF
--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -31,11 +31,11 @@ func (m *Model) Filter(q string) {
 	homeQuery := strings.EqualFold(q, "home")
 	for _, s := range m.All {
 		nameMatch := Match(s.Name, q, m.SeparatorAware)
-		pathMatch := Match(s.Path, q, m.SeparatorAware)
+		pathMatch := Match(s.Path, q, m.SeparatorAware) || homeQuery && isHomePath(s.Path)
 		if !nameMatch && !pathMatch {
 			continue
 		}
-		if homeQuery && isHomeSession(s) {
+		if homeQuery && isHomePath(s.Path) {
 			homeMatches = append(homeMatches, s)
 		} else if nameMatch {
 			m.Filtered = append(m.Filtered, s)
@@ -79,7 +79,6 @@ func (m *Model) Current() (model.Session, bool) {
 	return m.Filtered[m.Selected], true
 }
 func Match(s, q string, sep bool) bool {
-	raw := s
 	s = strings.ToLower(s)
 	q = strings.ToLower(q)
 	if sep {
@@ -87,10 +86,7 @@ func Match(s, q string, sep bool) bool {
 		s = repl.Replace(s)
 		q = repl.Replace(q)
 	}
-	if strings.Contains(s, q) {
-		return true
-	}
-	return q == "home" && isHomePath(raw)
+	return strings.Contains(s, q)
 }
 func isHomePath(p string) bool {
 	if p == "" {

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -27,16 +27,23 @@ func (m *Model) Filter(q string) {
 	m.Query = q
 	m.Filtered = m.Filtered[:0]
 	var homeMatches []model.Session
+	var pathMatches []model.Session
 	homeQuery := strings.EqualFold(q, "home")
 	for _, s := range m.All {
-		if Match(s.Name, q, m.SeparatorAware) || Match(s.Path, q, m.SeparatorAware) {
-			if homeQuery && isHomeSession(s) {
-				homeMatches = append(homeMatches, s)
-				continue
-			}
+		nameMatch := Match(s.Name, q, m.SeparatorAware)
+		pathMatch := Match(s.Path, q, m.SeparatorAware)
+		if !nameMatch && !pathMatch {
+			continue
+		}
+		if homeQuery && isHomeSession(s) {
+			homeMatches = append(homeMatches, s)
+		} else if nameMatch {
 			m.Filtered = append(m.Filtered, s)
+		} else {
+			pathMatches = append(pathMatches, s)
 		}
 	}
+	m.Filtered = append(m.Filtered, pathMatches...)
 	if len(homeMatches) > 0 {
 		m.Filtered = append(homeMatches, m.Filtered...)
 	}

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -52,6 +52,24 @@ func TestFilterRanksNameMatchesBeforePathMatches(t *testing.T) {
 		}
 	}
 }
+func TestFilterKeepsNameMatchAheadOfPathOnlyWorktreeParent(t *testing.T) {
+	m := New([]model.Session{
+		{Source: "herdr", Name: "backend", Path: "/work/api", WorkspaceID: "w-parent"},
+		{Source: "herdr", Name: "api-fix", Path: "/work/api-fix", WorkspaceID: "w-child", Worktree: model.WorktreeRelation{Linked: true, ParentWorkspaceID: "w-parent"}},
+	})
+
+	m.Filter("api")
+
+	want := []string{"api-fix", "backend"}
+	if len(m.Filtered) != len(want) {
+		t.Fatalf("filtered=%#v", m.Filtered)
+	}
+	for i, name := range want {
+		if m.Filtered[i].Name != name {
+			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
+		}
+	}
+}
 func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
 	t.Setenv("HOME", "/Users/zach")
 	m := New([]model.Session{

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -31,6 +31,27 @@ func TestFilterResetsSelectionWhenQueryChanges(t *testing.T) {
 		t.Fatalf("cur=%#v ok=%v", cur, ok)
 	}
 }
+func TestFilterRanksNameMatchesBeforePathMatches(t *testing.T) {
+	m := New([]model.Session{
+		{Source: "zoxide", Path: "/work/api-unnamed"},
+		{Source: "config", Name: "api-service", Path: "/work/service"},
+		{Source: "herdr", Name: "api-both", Path: "/work/api-both"},
+		{Source: "herdr", Name: "worker", Path: "/work/api-worker"},
+		{Source: "config", Name: "api-web", Path: "/work/web"},
+	})
+
+	m.Filter("api")
+
+	want := []string{"api-service", "api-both", "api-web", "", "worker"}
+	if len(m.Filtered) != len(want) {
+		t.Fatalf("filtered=%#v", m.Filtered)
+	}
+	for i, name := range want {
+		if m.Filtered[i].Name != name {
+			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
+		}
+	}
+}
 func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
 	t.Setenv("HOME", "/Users/zach")
 	m := New([]model.Session{

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -64,6 +64,26 @@ func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
 		t.Fatalf("cur=%#v ok=%v", cur, ok)
 	}
 }
+func TestFilterRanksActualHomePathBeforeMisleadingHomeName(t *testing.T) {
+	t.Setenv("HOME", "/Users/zachfuller")
+	m := New([]model.Session{
+		{Name: "~", Path: "/tmp/home-archive"},
+		{Name: "home-manager", Path: "/tmp/manager"},
+		{Name: "~", Path: "/Users/zachfuller"},
+	})
+
+	m.Filter("home")
+
+	want := []string{"/Users/zachfuller", "/tmp/manager", "/tmp/home-archive"}
+	if len(m.Filtered) != len(want) {
+		t.Fatalf("filtered=%#v", m.Filtered)
+	}
+	for i, path := range want {
+		if m.Filtered[i].Path != path {
+			t.Fatalf("filtered[%d].Path=%q, want %q", i, m.Filtered[i].Path, path)
+		}
+	}
+}
 func TestSeparatorAwareMatch(t *testing.T) {
 	if !Match("my-api.service", "api service", true) {
 		t.Fatal("expected separator aware match")


### PR DESCRIPTION
## Summary

- rank native-picker workspace-name matches ahead of path-only matches
- preserve the configured workspace order within each match group
- keep the actual home-directory session first for the special `home` query
- add regression coverage for all match groups, stable ordering, unnamed sessions, empty queries, and misleading home-like names

## Related issue

Closes #102

## Validation

- [x] `just check`
- [x] `just build`
- [ ] `just build-docs` (not applicable; no documentation changes)
- [x] `./bin/herdr-sesh --version`
- [x] `./bin/herdr-sesh list --json --config testdata/sesh.toml`

## User-facing changes

Native-picker searches now show real workspace-name matches before sessions that match only through their paths. FZF behavior is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

