### PR TITLE
fix(picker): normalize separators in the query, not just the candidate

### DIFF
--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -78,6 +78,7 @@ func Match(s, q string, sep bool) bool {
 	if sep {
 		repl := strings.NewReplacer("-", " ", "_", " ", "/", " ", ".", " ")
 		s = repl.Replace(s)
+		q = repl.Replace(q)
 	}
 	if strings.Contains(s, q) {
 		return true

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -48,3 +48,51 @@ func TestSeparatorAwareMatch(t *testing.T) {
 		t.Fatal("expected separator aware match")
 	}
 }
+
+func TestSeparatorAwareMatchNormalizesQuerySeparators(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		hay   string
+		query string
+	}{
+		{"query keeps the candidate's separator", "my-api.service", "api-service"},
+		{"query separator differs from the candidate's", "my-api.service", "api/service"},
+		{"query separator matches a path boundary", "/work/api-service", "work/api"},
+		{"underscore query against a dashed candidate", "my-api-service", "api_service"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !Match(tc.hay, tc.query, true) {
+				t.Fatalf("Match(%q, %q, true) = false, want true", tc.hay, tc.query)
+			}
+		})
+	}
+}
+
+// Normalizing the query is strictly additive: the candidate never retains any
+// of the four separators, so a query containing one could not match before.
+func TestSeparatorAwareMatchIsAdditive(t *testing.T) {
+	for _, tc := range []struct {
+		hay   string
+		query string
+		want  bool
+	}{
+		{"my-api.service", "api", true},
+		{"my-api.service", "nope", false},
+		{"my-api.service", "api service", true},
+		{"my-api.service", "service api", false},
+		{"my-api.service", "", true},
+	} {
+		if got := Match(tc.hay, tc.query, true); got != tc.want {
+			t.Fatalf("Match(%q, %q, true) = %v, want %v", tc.hay, tc.query, got, tc.want)
+		}
+	}
+}
+
+func TestSeparatorUnawareMatchLeavesQueryLiteral(t *testing.T) {
+	if !Match("my-api.service", "api.service", false) {
+		t.Fatal("expected literal match when separator awareness is off")
+	}
+	if Match("my-api.service", "api service", false) {
+		t.Fatal("did not expect separator normalization when it is off")
+	}
+}


### PR DESCRIPTION
## Problem

With `separator_aware = true`, `Match` normalizes `-`, `_`, `/` and `.` to spaces in the **candidate** but leaves the **query** untouched (`internal/picker/model.go:78-81`). Since the normalized candidate then contains none of those four characters, any query containing one can never match:

```go
Match("my-api.service", "api-service", true)  // false
Match("my-api.service", "api service", true)  // true
```

In practice, typing a hyphen while filtering silently returns zero results. Since project names are commonly hyphenated, the natural query is the one that fails — you have to learn to substitute a space for every separator.

## Fix

Apply the same replacer to the query. One line.

## Why this is safe

**Strictly additive — no query that matches today can stop matching.** After normalization the candidate retains none of the four separators, so:

- a query *containing* a separator matched nothing before, and
- a query *without* one is returned unchanged by the replacer.

So the only behavior that changes is queries that previously matched nothing.

## Consistency with the fzf picker

The fzf path already supports both forms: `fzfInput` appends a normalized search field *alongside* the original, so `api-service` and `api service` both match there (`internal/picker/fzf_test.go:35-43` asserts the normalized field is added, not substituted). This change brings the native picker in line with it, and with the documented behavior — `docs/config.md` describes `separator_aware` as making "searches treat `-`, `_`, `/`, and `.` as spaces", which reads as applying to the search, not to one side of it. No docs change needed.

The existing `TestSeparatorAwareMatch` (space query against a separated candidate) still passes unchanged.

## Tests

Added to `internal/picker/model_test.go`:

- `TestSeparatorAwareMatchNormalizesQuerySeparators` — query keeping the candidate's separator, a cross-separator query (`api/service` vs `my-api.service`), a path-boundary query, and an underscore query against a dashed candidate. **All four fail without the one-line change.**
- `TestSeparatorAwareMatchIsAdditive` — pins the additive property, including the empty query and a wrong-order query that must stay unmatched.
- `TestSeparatorUnawareMatchLeavesQueryLiteral` — pins that `separator_aware = false` keeps the query literal, so the flag still has an off state.

## Validation

```
mise exec -- just check   # lint, fmt-check, 380 tests with -race, test-release-ref — all pass
mise exec -- just build
```

## Note on overlap

#103 touches `Match` and `model_test.go` as well (it moves the `home` special case out into `Filter`). It leaves the `s = repl.Replace(s)` line intact, so it does not fix or conflict with this semantically — but whichever lands second will need a trivial textual rebase. Happy to rebase this on top of #103 if you would rather take that one first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

