### PR TITLE
feat(picker): configure home match prioritization

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -55,6 +55,7 @@ path_components = 1
 [picker]
 show_icons = true
 show_preview = true
+prioritize_home = false
 herdr_theme_inherit = true
 replace_worktree_icon = true
 prompt = "Sesh> "
@@ -195,6 +196,7 @@ equivalent; native decoding rejects them like any other unknown key.
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
 | `show_preview` | Shows the preview panel in the native picker. The default is `true`; set it to `false` to give the workspace list the full available width and height without running preview commands. This does not change fzf preview behavior. |
+| `prioritize_home` | Controls exact case-insensitive `home` searches in the native picker. The default is `true`, which promotes the actual home-directory session ahead of real-name and ordinary path matches. Set it to `false` to keep real-name matches first, then path matches in their existing order; the actual home-directory session remains searchable through the exact `home` alias. |
 | `herdr_theme_inherit` | Inherits colors from Herdr's active theme. The default is `true`; set it to `false` to keep the native picker's built-in colors. |
 | `replace_worktree_icon` | Replaces the Herdr sheep icon with `↳` for linked worktree rows. The default is `true`. Set it to `false` to keep the sheep icon (or plain `[herdr]` when icons are hidden); the purple type color and tree branches remain. |
 | `prompt` | Replaces the picker prompt. An empty value uses `Sesh> `. |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -210,7 +210,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		HideLastWorkspace:              !cfg.TUI.ShowLastWorkspace,
 		HideLastWorkspacePath:          !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:                 cfg.SeparatorAware,
-		PrioritizeHome:                 cfg.TUI.PrioritizeHome,
+		DisableHomePrioritization:      !cfg.TUI.PrioritizeHome,
 		HidePreview:                    !cfg.TUI.ShowPreview,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
 		WorkspaceSort:                  cfg.TUI.DefaultSort,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -210,6 +210,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		HideLastWorkspace:              !cfg.TUI.ShowLastWorkspace,
 		HideLastWorkspacePath:          !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:                 cfg.SeparatorAware,
+		PrioritizeHome:                 cfg.TUI.PrioritizeHome,
 		HidePreview:                    !cfg.TUI.ShowPreview,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
 		WorkspaceSort:                  cfg.TUI.DefaultSort,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -618,6 +618,17 @@ func TestPickerOptionsPropagatePreviewVisibility(t *testing.T) {
 	}
 }
 
+func TestPickerOptionsPropagateHomePrioritization(t *testing.T) {
+	cfg := config.Default()
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.PrioritizeHome {
+		t.Fatal("default config disabled home prioritization")
+	}
+	cfg.TUI.PrioritizeHome = false
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.PrioritizeHome {
+		t.Fatal("prioritize_home=false was not propagated")
+	}
+}
+
 func TestPickerJSONCommand(t *testing.T) {
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -620,11 +620,11 @@ func TestPickerOptionsPropagatePreviewVisibility(t *testing.T) {
 
 func TestPickerOptionsPropagateHomePrioritization(t *testing.T) {
 	cfg := config.Default()
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.PrioritizeHome {
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.DisableHomePrioritization {
 		t.Fatal("default config disabled home prioritization")
 	}
 	cfg.TUI.PrioritizeHome = false
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.PrioritizeHome {
+	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.DisableHomePrioritization {
 		t.Fatal("prioritize_home=false was not propagated")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type TUIConfig struct {
 	ShowIcons bool `toml:"show_icons"`
 	// ShowPreview is native-only; the legacy Sesh schema has no equivalent setting.
 	ShowPreview           bool   `toml:"-"`
+	PrioritizeHome        bool   `toml:"-"`
 	HerdrThemeInherit     bool   `toml:"herdr_theme_inherit"`
 	ReplaceWorktreeIcon   bool   `toml:"replace_worktree_icon"`
 	ShowLastWorkspace     bool   `toml:"show_last_workspace"`
@@ -67,6 +68,7 @@ func Default() Config {
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
 			ShowPreview:           true,
+			PrioritizeHome:        true,
 			HerdrThemeInherit:     true,
 			ReplaceWorktreeIcon:   true,
 			ShowLastWorkspace:     true,

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -43,6 +43,7 @@ type nativePicker struct {
 	// an always-present value keeps icon behavior self-documenting.
 	ShowIcons             bool   `toml:"show_icons"`
 	ShowPreview           *bool  `toml:"show_preview,omitempty"`
+	PrioritizeHome        *bool  `toml:"prioritize_home,omitempty"`
 	HerdrThemeInherit     *bool  `toml:"herdr_theme_inherit,omitempty"`
 	ReplaceWorktreeIcon   *bool  `toml:"replace_worktree_icon,omitempty"`
 	ShowLastWorkspace     *bool  `toml:"show_last_workspace,omitempty"`
@@ -200,6 +201,9 @@ func (n nativeConfig) apply(cfg *Config) {
 	cfg.TUI.ShowIcons = n.Picker.ShowIcons
 	if n.Picker.ShowPreview != nil {
 		cfg.TUI.ShowPreview = *n.Picker.ShowPreview
+	}
+	if n.Picker.PrioritizeHome != nil {
+		cfg.TUI.PrioritizeHome = *n.Picker.PrioritizeHome
 	}
 	if n.Picker.HerdrThemeInherit != nil {
 		cfg.TUI.HerdrThemeInherit = *n.Picker.HerdrThemeInherit

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -35,6 +35,7 @@ path_components = 2
 [picker]
 show_icons = true
 show_preview = false
+prioritize_home = false
 herdr_theme_inherit = true
 show_last_workspace = true
 show_last_workspace_path = true
@@ -77,7 +78,7 @@ tabs = ["git"]
 		SeparatorAware: true,
 		SortOrder:      []string{"config", "herdr"},
 		Blacklist:      []string{"^scratch$"},
-		TUI:            TUIConfig{ShowIcons: true, HerdrThemeInherit: true, ReplaceWorktreeIcon: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
+		TUI:            TUIConfig{ShowIcons: true, PrioritizeHome: false, HerdrThemeInherit: true, ReplaceWorktreeIcon: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
 		DefaultSessionConfig: DefaultSessionConfig{
 			StartupCommand: "make dev",
 			PreviewCommand: "ls {}",
@@ -108,8 +109,18 @@ func TestNativeMinimalFileKeepsDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := Default()
-	if cfg.DirLength != d.DirLength || cfg.TUI.DefaultSort != d.TUI.DefaultSort || !cfg.TUI.HerdrThemeInherit || !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath || !cfg.TUI.ReplaceWorktreeIcon || cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
+	if cfg.DirLength != d.DirLength || cfg.TUI.DefaultSort != d.TUI.DefaultSort || !cfg.TUI.PrioritizeHome || !cfg.TUI.HerdrThemeInherit || !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath || !cfg.TUI.ReplaceWorktreeIcon || cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
 		t.Fatalf("defaults lost: %#v", cfg)
+	}
+}
+
+func TestNativePickerCanDisableHomePrioritization(t *testing.T) {
+	cfg, err := loadNative(t, "version = 1\n[picker]\nprioritize_home = false\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.PrioritizeHome {
+		t.Fatal("prioritize_home=true, want false")
 	}
 }
 

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -14,12 +14,14 @@ type Model struct {
 	Query          string
 	Selected       int
 	SeparatorAware bool
+	PrioritizeHome bool
 }
 
 func New(items []model.Session) Model {
 	return Model{
-		All:      append([]model.Session(nil), items...),
-		Filtered: append([]model.Session(nil), items...),
+		All:            append([]model.Session(nil), items...),
+		Filtered:       append([]model.Session(nil), items...),
+		PrioritizeHome: true,
 	}
 }
 func (m *Model) Filter(q string) {
@@ -35,7 +37,7 @@ func (m *Model) Filter(q string) {
 		if !nameMatch && !pathMatch {
 			continue
 		}
-		if homeQuery && isHomePath(s.Path) {
+		if homeQuery && m.PrioritizeHome && isHomePath(s.Path) {
 			homeMatches = append(homeMatches, s)
 		} else if nameMatch {
 			m.Filtered = append(m.Filtered, s)

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -37,9 +37,15 @@ func (m *Model) Filter(q string) {
 		if !nameMatch && !pathMatch {
 			continue
 		}
-		if homeQuery && m.PrioritizeHome && isHomePath(s.Path) {
-			homeMatches = append(homeMatches, s)
-		} else if nameMatch {
+		if homeQuery && isHomePath(s.Path) {
+			if m.PrioritizeHome {
+				homeMatches = append(homeMatches, s)
+			} else {
+				pathMatches = append(pathMatches, s)
+			}
+			continue
+		}
+		if nameMatch {
 			m.Filtered = append(m.Filtered, s)
 		} else {
 			pathMatches = append(pathMatches, s)

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -9,19 +9,18 @@ import (
 )
 
 type Model struct {
-	All            []model.Session
-	Filtered       []model.Session
-	Query          string
-	Selected       int
-	SeparatorAware bool
-	PrioritizeHome bool
+	All                       []model.Session
+	Filtered                  []model.Session
+	Query                     string
+	Selected                  int
+	SeparatorAware            bool
+	DisableHomePrioritization bool
 }
 
 func New(items []model.Session) Model {
 	return Model{
-		All:            append([]model.Session(nil), items...),
-		Filtered:       append([]model.Session(nil), items...),
-		PrioritizeHome: true,
+		All:      append([]model.Session(nil), items...),
+		Filtered: append([]model.Session(nil), items...),
 	}
 }
 func (m *Model) Filter(q string) {
@@ -38,7 +37,7 @@ func (m *Model) Filter(q string) {
 			continue
 		}
 		if homeQuery && isHomePath(s.Path) {
-			if m.PrioritizeHome {
+			if !m.DisableHomePrioritization {
 				homeMatches = append(homeMatches, s)
 			} else {
 				pathMatches = append(pathMatches, s)

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -109,14 +109,14 @@ func TestFilterCanDisableHomePrioritization(t *testing.T) {
 		{Name: "path-before", Path: "/tmp/home-path"},
 		{Name: "home-tools", Path: "/tmp/tools"},
 		{Name: "home-manager", Path: "/tmp/manager"},
-		{Name: "~", Path: "/Users/zach"},
+		{Name: "home-root", Path: "/Users/zach"},
 		{Name: "path-after", Path: "/tmp/home-after"},
 	})
 	m.PrioritizeHome = false
 
 	m.Filter("HOME")
 
-	want := []string{"home-tools", "home-manager", "path-before", "~", "path-after"}
+	want := []string{"home-tools", "home-manager", "path-before", "home-root", "path-after"}
 	if len(m.Filtered) != len(want) {
 		t.Fatalf("filtered=%#v", m.Filtered)
 	}

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -82,6 +82,22 @@ func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
 		t.Fatalf("cur=%#v ok=%v", cur, ok)
 	}
 }
+
+func TestZeroValueModelPrioritizesHome(t *testing.T) {
+	t.Setenv("HOME", "/Users/zach")
+	m := Model{All: []model.Session{
+		{Name: "home-manager", Path: "/tmp/home-manager"},
+		{Name: "~", Path: "/Users/zach"},
+	}}
+
+	m.Filter("home")
+
+	cur, ok := m.Current()
+	if !ok || cur.Name != "~" {
+		t.Fatalf("cur=%#v ok=%v", cur, ok)
+	}
+}
+
 func TestFilterRanksActualHomePathBeforeMisleadingHomeName(t *testing.T) {
 	t.Setenv("HOME", "/Users/zachfuller")
 	m := New([]model.Session{
@@ -112,7 +128,7 @@ func TestFilterCanDisableHomePrioritization(t *testing.T) {
 		{Name: "home-root", Path: "/Users/zach"},
 		{Name: "path-after", Path: "/tmp/home-after"},
 	})
-	m.PrioritizeHome = false
+	m.DisableHomePrioritization = true
 
 	m.Filter("HOME")
 

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -102,6 +102,30 @@ func TestFilterRanksActualHomePathBeforeMisleadingHomeName(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterCanDisableHomePrioritization(t *testing.T) {
+	t.Setenv("HOME", "/Users/zach")
+	m := New([]model.Session{
+		{Name: "path-before", Path: "/tmp/home-path"},
+		{Name: "home-tools", Path: "/tmp/tools"},
+		{Name: "home-manager", Path: "/tmp/manager"},
+		{Name: "~", Path: "/Users/zach"},
+		{Name: "path-after", Path: "/tmp/home-after"},
+	})
+	m.PrioritizeHome = false
+
+	m.Filter("HOME")
+
+	want := []string{"home-tools", "home-manager", "path-before", "~", "path-after"}
+	if len(m.Filtered) != len(want) {
+		t.Fatalf("filtered=%#v", m.Filtered)
+	}
+	for i, name := range want {
+		if m.Filtered[i].Name != name {
+			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
+		}
+	}
+}
 func TestSeparatorAwareMatch(t *testing.T) {
 	if !Match("my-api.service", "api service", true) {
 		t.Fatal("expected separator aware match")

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -137,7 +137,7 @@ type Options struct {
 	HideLastWorkspace              bool
 	HideLastWorkspacePath          bool
 	SeparatorAware                 bool
-	PrioritizeHome                 bool
+	DisableHomePrioritization      bool
 	HidePreview                    bool
 	DefaultPreviewCommand          string
 	FZFCommand                     string
@@ -278,7 +278,9 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	sortHerdrWorkspaces(items, initialOrder)
 	list := New(items)
 	list.SeparatorAware = opts.SeparatorAware
-	list.PrioritizeHome = opts.PrioritizeHome
+	if opts.DisableHomePrioritization {
+		list.PrioritizeHome = false
+	}
 	prompt := opts.Prompt
 	if prompt == "" {
 		prompt = defaultPrompt

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -278,9 +278,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	sortHerdrWorkspaces(items, initialOrder)
 	list := New(items)
 	list.SeparatorAware = opts.SeparatorAware
-	if opts.DisableHomePrioritization {
-		list.PrioritizeHome = false
-	}
+	list.DisableHomePrioritization = opts.DisableHomePrioritization
 	prompt := opts.Prompt
 	if prompt == "" {
 		prompt = defaultPrompt

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -137,6 +137,7 @@ type Options struct {
 	HideLastWorkspace              bool
 	HideLastWorkspacePath          bool
 	SeparatorAware                 bool
+	PrioritizeHome                 bool
 	HidePreview                    bool
 	DefaultPreviewCommand          string
 	FZFCommand                     string
@@ -277,6 +278,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	sortHerdrWorkspaces(items, initialOrder)
 	list := New(items)
 	list.SeparatorAware = opts.SeparatorAware
+	list.PrioritizeHome = opts.PrioritizeHome
 	prompt := opts.Prompt
 	if prompt == "" {
 		prompt = defaultPrompt

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -28,6 +28,24 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestTeaModelHomePrioritizationOption(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want bool
+	}{
+		{name: "zero options keep prioritization enabled", want: true},
+		{name: "explicit disable turns prioritization off", opts: Options{DisableHomePrioritization: true}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTeaModel(nil, tc.opts)
+			if m.list.PrioritizeHome != tc.want {
+				t.Fatalf("PrioritizeHome=%t, want %t", m.list.PrioritizeHome, tc.want)
+			}
+		})
+	}
+}
+
 func TestTeaModelFiltersMovesAndChooses(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Name: "api-service", Path: "/tmp/api"},

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -30,17 +30,17 @@ func TestMain(m *testing.M) {
 
 func TestTeaModelHomePrioritizationOption(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		opts Options
-		want bool
+		name         string
+		opts         Options
+		wantDisabled bool
 	}{
-		{name: "zero options keep prioritization enabled", want: true},
-		{name: "explicit disable turns prioritization off", opts: Options{DisableHomePrioritization: true}, want: false},
+		{name: "zero options keep prioritization enabled"},
+		{name: "explicit disable turns prioritization off", opts: Options{DisableHomePrioritization: true}, wantDisabled: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTeaModel(nil, tc.opts)
-			if m.list.PrioritizeHome != tc.want {
-				t.Fatalf("PrioritizeHome=%t, want %t", m.list.PrioritizeHome, tc.want)
+			if m.list.DisableHomePrioritization != tc.wantDisabled {
+				t.Fatalf("DisableHomePrioritization=%t, want %t", m.list.DisableHomePrioritization, tc.wantDisabled)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add native `[picker].prioritize_home` configuration with a backward-compatible `true` default
- keep the exact `home` alias while allowing real workspace-name matches to rank first when prioritization is disabled
- preserve stable bucket order and zero-value picker API behavior, with focused config, app, and picker regressions
- document the new setting and disabled behavior

Closes #105

## Validation

- `go test` focused RED/GREEN regressions for native config, app option wiring, picker filtering, and zero-value picker options
- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-issue-105-final-lint-cache just check` (389 tests)
- `just build-docs`
- `git diff --check 65cbdbd..HEAD`

## Review

- task-scoped spec and quality review completed
- disabled actual-home name-match edge case fixed and re-reviewed
- whole-branch review completed; zero-value `picker.Options` compatibility fixed and re-reviewed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

