### PR TITLE
feat: track external workspace history

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Sesh concepts map onto Herdr as follows:
 
 ## Requirements
 
-- [Herdr](https://herdr.dev/docs/installation/) 0.8.0 or newer
+- [Herdr](https://herdr.dev/docs/installation/) 0.8.2 or newer
 - Linux or macOS
 - Git and Go 1.26.4 or newer for Herdr's source-based plugin installation
 - Optional: `zoxide` for directory history and `eza` for the default preview

--- a/docs/development/workspace-history.md
+++ b/docs/development/workspace-history.md
@@ -1,0 +1,220 @@
+---
+icon: lucide/history
+tags:
+  - Development
+  - Architecture
+  - Herdr
+  - Workspace history
+---
+
+# Workspace history tracking
+
+The `last-workspace-tracking` implementation keeps `herdr-sesh last` and the
+picker's previous-workspace marker accurate when focus changes outside the
+plugin. Herdr lifecycle hooks elect one long-lived subscriber per socket, and
+that subscriber serializes focus and close events into plugin-owned
+history.[^watcher-source]
+
+!!! warning "Runtime protocol 21 is the compatibility boundary"
+
+    The manifest requires Herdr 0.8.2 or newer, but the watcher also checks the
+    server's protocol at runtime. Protocol 21 starts lifecycle subscriptions at
+    the current event sequence.[^protocol-source] Older protocols can replay
+    retained events without exposing a replay boundary, so the watcher fails
+    instead of risking stale workspace order.
+
+## Why a resident subscriber exists
+
+Herdr launches startup and event hooks as separate processes. Those processes
+can overlap, so letting every `workspace.focused` hook write history would make
+the final file order depend on process scheduling instead of focus order.
+
+The plugin manifest routes three lifecycle triggers to the same hidden command:
+
+| Trigger | Hook behavior | Subscriber behavior |
+| --- | --- | --- |
+| Startup | Does not mutate history; attempts watcher election. | Establishes the event stream and records the session snapshot. |
+| `workspace.focused` | Does not mutate history; attempts watcher election. | Records the focused workspace in stream order. |
+| `workspace.closed` | Removes the ID from `data.workspace_id` once, then attempts watcher election. | Removes the same ID if the stream also reports it; removal is idempotent. |
+
+`TryHistoryWatcherLock` uses a socket-derived `flock` file named
+`history-watch-<sha256(socket)>.lock`. The winner holds the lock while
+`WatchWorkspaceEvents` runs; other hook processes exit. A later lifecycle hook
+can elect a replacement if the subscriber stops.
+
+The following diagram maps the production control flow in `internal/app` while
+keeping the hook and subscriber responsibilities separate.
+
+```mermaid
+flowchart TD
+    Hook["startup / focused / closed hook"] --> Apply["applyHistoryHook"]
+    Apply -->|startup or focused| NoWrite["No focus-history write"]
+    Apply -->|closed| RemoveOnce["Remove payload workspace once"]
+    NoWrite --> Elect{"TryHistoryWatcherLock"}
+    RemoveOnce --> Elect
+    Elect -->|not acquired| Exit["Exit hook process"]
+    Elect -->|acquired| Watch["WatchWorkspaceEvents"]
+    Watch -->|workspace_focused| Record["Record"]
+    Watch -->|workspace_closed| Remove["RemoveWorkspace"]
+    Record --> Retry["Retry only ErrHistoryLockTimeout in place"]
+    Remove --> Retry
+```
+
+## Subscriber bootstrap and event ordering
+
+Each connection attempt follows this order:
+
+1. Call `ping` and reject servers below protocol 21.
+2. Open the event connection and subscribe to `workspace.focused` and
+   `workspace.closed`.
+3. Start decoding live events as soon as the subscription acknowledgement
+   arrives.
+4. Use a second socket connection to request
+   `session.snapshot`.[^snapshot-source]
+5. Record `focused_workspace_id`, then consume already-buffered and future live
+   events in decoder order.
+
+Starting the decoder before the snapshot request closes the bootstrap window:
+an event that arrives while `session.snapshot` is in flight waits in the
+channel and is applied after the snapshot. The buffer holds 1,024 events. If
+the stream ends, buffered events are drained before the watcher reconnects
+after 100 ms.
+
+Subscription request names use dotted event types. Incoming event envelopes
+use `workspace_focused` and `workspace_closed`; malformed, unrelated, and
+ID-less envelopes are ignored.
+
+```mermaid
+sequenceDiagram
+    participant W as Watcher
+    participant E as Event connection
+    participant S as Snapshot connection
+    participant H as History
+    W->>E: ping
+    E-->>W: protocol
+    W->>E: events.subscribe
+    E-->>W: subscription_started
+    Note over W,E: Decoder starts buffering live events
+    W->>S: session.snapshot
+    S-->>W: focused_workspace_id
+    W->>H: Record snapshot focus
+    loop Ordered live stream
+        E-->>W: workspace event
+        W->>H: Record or RemoveWorkspace
+    end
+    E--xW: unexpected EOF
+    W->>H: Drain buffered events
+    W->>E: Reconnect after 100 ms
+```
+
+Regression tests define three boundaries for this flow: reject retained-replay
+protocols, preserve an event from the snapshot window, and reconnect after
+unexpected EOF.
+
+## Session-scoped persistence
+
+`SessionHistoryDir` cleans and hashes `HERDR_SOCKET_PATH` with SHA-256. Each
+Herdr session therefore writes to an independent path:
+
+```text
+${HERDR_PLUGIN_STATE_DIR}/history/<sha256-clean-socket-path>/history.json
+```
+
+Existing unscoped `history.json` belongs to the default Herdr session. It is
+copied into that session's scoped directory on first use while holding the
+legacy history lock. Named sessions never inherit the old file.
+
+History mutation has a separate stable lock, `history.lock`. Writers attempt
+`LOCK_EX | LOCK_NB` every 10 ms for up to 250 ms. A timeout returns the typed
+`ErrHistoryLockTimeout` error.[^flock-source]
+
+- short-lived close hooks make one bounded mutation attempt;
+- the resident subscriber retries only this typed timeout in place, preserving
+  event order;
+- other errors stop the watcher instead of spinning.
+
+`Record`, `RecordSwitch`, `RemoveWorkspace`, migration, and direct saves all
+share the same lock boundary. JSON writes go to a temporary file, set mode
+`0600`, and atomically rename over `history.json`; state directories use
+`0700`.[^persistence-source]
+
+```mermaid
+flowchart TD
+    Producers["Subscriber / CLI / close hook"] --> Mutation["Record / RecordSwitch / RemoveWorkspace"]
+    Mutation --> Lock["Acquire history.lock<br/>250 ms maximum"]
+    Lock --> Load["Load history<br/>recover malformed JSON for writes"]
+    Load --> Normalize["Newest first / deduplicate / cap at 50"]
+    Normalize --> Temp["Write temporary file<br/>mode 0600"]
+    Temp --> Rename["Atomic rename to history.json"]
+```
+
+The history list is newest first, deduplicated, and capped at 50 workspace IDs.
+`Record` ignores an already-current head. Explicit CLI and picker transitions
+use `RecordSwitch(from, to)` so both sides of the switch survive even before a
+Herdr event is observed.[^record-switch-source] Closed workspaces are pruned,
+and malformed JSON is recovered only at a locked write boundary.
+
+`Last` returns the second entry because the head is the focused workspace.
+Code that already knows the current workspace can use `Previous` to select the
+first non-current entry.
+
+## Failure model
+
+??? info "Deliberate constraints"
+
+    - The subscriber uses one resident plugin command slot per Herdr socket.
+    - Herdr does not supervise the command; the next lifecycle hook performs
+      replacement election after a crash.
+    - File locking depends on `flock`. Unsupported filesystems fail explicitly.
+    - The JSON format and 50-entry cap remain intentionally small; there is no
+      database or background compaction layer.
+
+The close-hook payload is authoritative. `HERDR_WORKSPACE_ID` is contextual and
+is not used to decide which workspace closed; a missing or malformed
+`HERDR_PLUGIN_EVENT_JSON.data.workspace_id` fails safely.
+
+## Verify a change
+
+Run the focused race-enabled suite first, then the repository and docs gates:
+
+```bash
+go test -race -count=1 ./internal/state ./internal/herdr ./internal/app
+just check
+just build-docs
+```
+
+The most useful implementation entry points are:
+
+| Area | File |
+| --- | --- |
+| Hook routing and watcher ownership | `herdr-plugin.toml`, `internal/app/app.go` |
+| Herdr protocol and subscription loop | `internal/herdr/events.go` |
+| Session paths, locks, and history semantics | `internal/state/history.go` |
+| Atomic writes | `internal/state/json.go` |
+| Concurrency and protocol regressions | `internal/app/app_test.go`, `internal/herdr/events_test.go`, `internal/state/history_test.go` |
+
+[Watcher orchestration](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/app/app.go){ .md-button }
+[Event subscriber](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go){ .md-button }
+[History state](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/state/history.go){ .md-button }
+
+[^watcher-source]: See the lifecycle declarations in
+    [`herdr-plugin.toml`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/herdr-plugin.toml)
+    and watcher election in
+    [`internal/app/app.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/app/app.go).
+[^protocol-source]: The runtime gate and protocol rationale live in
+    [`internal/herdr/events.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go)
+    and its
+    [protocol regression tests](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events_test.go).
+[^snapshot-source]: See `loadSessionSnapshot` and the buffered decoder in
+    [`internal/herdr/events.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go).
+[^flock-source]: [`syscall.Flock`](https://pkg.go.dev/syscall#Flock) provides the
+    process-level advisory lock used by `withHistoryLock` and
+    `TryHistoryWatcherLock`.
+[^persistence-source]: The lock and state rules are in
+    [`internal/state/history.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/state/history.go);
+    atomic replacement is in
+    [`internal/state/json.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/state/json.go).
+[^record-switch-source]: See `RecordSwitch` in
+    [`internal/state/history.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/state/history.go)
+    and its focused tests in
+    [`internal/state/history_test.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/state/history_test.go).

--- a/docs/development/workspace-history.md
+++ b/docs/development/workspace-history.md
@@ -15,13 +15,15 @@ plugin. Herdr lifecycle hooks elect one long-lived subscriber per socket, and
 that subscriber serializes focus and close events into plugin-owned
 history.[^watcher-source]
 
-!!! warning "Runtime protocol 21 is the compatibility boundary"
+!!! info "Protocol 20 replay is reconciled before history is published"
 
-    The manifest requires Herdr 0.8.2 or newer, but the watcher also checks the
-    server's protocol at runtime. Protocol 21 starts lifecycle subscriptions at
-    the current event sequence.[^protocol-source] Older protocols can replay
-    retained events without exposing a replay boundary, so the watcher fails
-    instead of risking stale workspace order.
+    The manifest requires Herdr 0.8.2 or newer, whose stable socket protocol is
+    20. Protocol 20 replays retained lifecycle events to a new subscriber, so
+    the watcher buffers the complete replay before publishing any history and
+    then reconciles it with a fresh session snapshot. Protocol 21 and newer
+    start lifecycle subscriptions at the current event sequence and skip that
+    replay step; see the [subscriber implementation](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go)
+    and [protocol regression tests](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events_test.go).
 
 ## Why a resident subscriber exists
 
@@ -64,24 +66,28 @@ flowchart TD
 
 Each connection attempt follows this order:
 
-1. Call `ping` and reject servers below protocol 21.
+1. Call `ping` and reject servers below protocol 20.
 2. Open the event connection and subscribe to `workspace.focused` and
    `workspace.closed`.
-3. Start decoding live events as soon as the subscription acknowledgement
-   arrives.
-4. Use a second socket connection to request
+3. Start decoding events as soon as the subscription acknowledgement arrives.
+4. On protocol 20, buffer retained events until the stream is quiet. There is
+   no fixed cutoff: publishing a partial replay could temporarily move a stale
+   workspace ahead of the current one.
+5. Use a second socket connection to request
    `session.snapshot`.[^snapshot-source]
-5. Record `focused_workspace_id`, then consume already-buffered and future live
-   events in decoder order.
+6. Apply retained events, discard stale close events for workspaces present in
+   the snapshot, record `focused_workspace_id`, then consume already-buffered
+   and future live events in decoder order.
 
-Starting the decoder before the snapshot request closes the bootstrap window:
-an event that arrives while `session.snapshot` is in flight waits in the
-channel and is applied after the snapshot. The buffer holds 1,024 events. If
-the stream ends, buffered events are drained before the watcher reconnects
-after 100 ms and installs a fresh snapshot. Herdr subscriptions do not expose a
-replay cursor, so an unexpected disconnect can lose intermediate focus changes;
-the snapshot restores the current focus but cannot reconstruct that transient
-order.[^reconnect-gap]
+Starting the decoder before replay reconciliation and the snapshot request
+closes both bootstrap windows. An event that arrives while `session.snapshot`
+is in flight waits in the channel and is applied after the snapshot. The buffer
+holds 1,024 events. Protocol 21 and newer have no retained replay, so they move
+directly from decoder startup to the snapshot. If the stream ends, buffered
+events are drained before the watcher reconnects after 100 ms and installs a
+fresh snapshot. Herdr subscriptions do not expose a replay cursor, so an
+unexpected disconnect can lose intermediate focus changes; the snapshot
+restores the current focus but cannot reconstruct that transient order.[^reconnect-gap]
 
 Subscription request names use dotted event types. Incoming event envelopes
 use `workspace_focused` and `workspace_closed`; malformed, unrelated, and
@@ -98,10 +104,13 @@ sequenceDiagram
     P-->>W: protocol
     W->>E: events.subscribe
     E-->>W: subscription_started
-    Note over W,E: Decoder starts buffering live events
+    Note over W,E: Decoder starts buffering events
+    opt Protocol 20
+        W->>W: Drain complete retained replay
+    end
     W->>S: session.snapshot
-    S-->>W: focused_workspace_id
-    W->>H: Record snapshot focus
+    S-->>W: focused_workspace_id + workspace IDs
+    W->>H: Apply replay, then record snapshot focus
     loop Ordered live stream
         E-->>W: workspace event
         W->>H: Record or RemoveWorkspace
@@ -111,9 +120,9 @@ sequenceDiagram
     W->>E: Reconnect after 100 ms
 ```
 
-Regression tests define three boundaries for this flow: reject retained-replay
-protocols, preserve an event from the snapshot window, and reconnect after
-unexpected EOF.
+Regression tests define four boundaries for this flow: reconcile protocol 20
+replay before the snapshot, never publish a partial replay, preserve an event
+from the snapshot window, and reconnect after unexpected EOF.
 
 ## Session-scoped persistence
 
@@ -205,10 +214,6 @@ The most useful implementation entry points are:
     [`herdr-plugin.toml`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/herdr-plugin.toml)
     and watcher election in
     [`internal/app/app.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/app/app.go).
-[^protocol-source]: The runtime gate and protocol rationale live in
-    [`internal/herdr/events.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go)
-    and its
-    [protocol regression tests](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events_test.go).
 [^snapshot-source]: See `loadSessionSnapshot` and the buffered decoder in
     [`internal/herdr/events.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go).
 [^reconnect-gap]: Herdr documents snapshots as reconnect reconciliation, while

--- a/docs/development/workspace-history.md
+++ b/docs/development/workspace-history.md
@@ -35,27 +35,32 @@ The plugin manifest routes three lifecycle triggers to the same hidden command:
 
 | Trigger | Hook behavior | Subscriber behavior |
 | --- | --- | --- |
-| Startup | Does not mutate history; attempts watcher election. | Establishes the event stream and records the session snapshot. |
-| `workspace.focused` | Does not mutate history; attempts watcher election. | Records the focused workspace in stream order. |
-| `workspace.closed` | Removes the ID from `data.workspace_id` once, then attempts watcher election. | Removes the same ID if the stream also reports it; removal is idempotent. |
+| Startup | Attempts watcher election; does not mutate history directly. | Establishes the event stream and records the session snapshot. |
+| `workspace.focused` | Attempts watcher election; does not mutate history directly. | Records the focused workspace in stream order. |
+| `workspace.closed` | Attempts watcher election, then removes the ID from `data.workspace_id` once. | Removes the same ID if the stream also reports it; removal is idempotent. |
 
 `TryHistoryWatcherLock` uses a socket-derived `flock` file named
-`history-watch-<sha256(socket)>.lock`. The winner holds the lock while
-`WatchWorkspaceEvents` runs; other hook processes exit. A later lifecycle hook
-can elect a replacement if the subscriber stops.
+`history-watch-<sha256(socket)>.lock`. Election happens before resolving the
+session history directory, so non-winning startup and focus hooks cannot trigger
+legacy-history migration. A non-winning close hook still prunes its payload ID.
+The winner holds the lock while `WatchWorkspaceEvents` runs; a later lifecycle
+hook can elect a replacement if the subscriber stops.
 
 The following diagram maps the production control flow in `internal/app` while
 keeping the hook and subscriber responsibilities separate.
 
 ```mermaid
 flowchart TD
-    Hook["startup / focused / closed hook"] --> Apply["applyHistoryHook"]
-    Apply -->|startup or focused| NoWrite["No focus-history write"]
+    Hook["startup / focused / closed hook"] --> Elect{"TryHistoryWatcherLock"}
+    Elect -->|not acquired startup/focused| Exit["Exit hook process"]
+    Elect -->|not acquired closed| Resolve["Resolve session history"]
+    Elect -->|acquired| Resolve
+    Resolve --> Apply["applyHistoryHook"]
+    Apply -->|startup or focused| NoWrite["No direct focus-history write"]
     Apply -->|closed| RemoveOnce["Remove payload workspace once"]
-    NoWrite --> Elect{"TryHistoryWatcherLock"}
-    RemoveOnce --> Elect
-    Elect -->|not acquired| Exit["Exit hook process"]
-    Elect -->|acquired| Watch["WatchWorkspaceEvents"]
+    NoWrite -->|winner| Watch["WatchWorkspaceEvents"]
+    RemoveOnce -->|winner| Watch
+    RemoveOnce -->|non-winner| Exit
     Watch -->|workspace_focused| Record["Record"]
     Watch -->|workspace_closed| Remove["RemoveWorkspace"]
     Record --> Retry["Retry only ErrHistoryLockTimeout in place"]
@@ -66,11 +71,11 @@ flowchart TD
 
 Each connection attempt follows this order:
 
-1. Call `ping` and reject servers below protocol 20.
-2. Open the event connection and subscribe to `workspace.focused` and
+1. Open the event connection and subscribe to `workspace.focused` and
    `workspace.closed`.
-3. Start decoding events as soon as the subscription acknowledgement arrives.
-4. Use a second socket connection to request the initial
+2. Start decoding events as soon as the subscription acknowledgement arrives.
+3. Call `ping` on a second connection and reject servers below protocol 20.
+4. Use another socket connection to request the initial
    `session.snapshot`.[^snapshot-source]
 5. On protocol 20, drain each currently available event batch and request a
    fresh snapshot. Apply focus events only for workspaces that still exist,
@@ -79,15 +84,15 @@ Each connection attempt follows this order:
 6. On protocol 21 and newer, apply the already-buffered and future live events
    directly in decoder order.
 
-Starting the decoder before the initial snapshot request closes the bootstrap
-window. The protocol 20 path has no timer or fixed replay cutoff: a delayed
-retained event becomes a later batch and is re-anchored to current session
-state. The buffer holds 1,024 events. If the stream ends, queued protocol 20
-events go through the same snapshot reconciliation before the watcher
-reconnects after 100 ms. Herdr subscriptions do not expose a replay cursor, so
-events that never reached the client before an unexpected disconnect can still
-be lost; the reconnect snapshot restores current focus but cannot reconstruct
-that transient order.[^reconnect-gap]
+Starting the decoder before the protocol probe and initial snapshot request
+closes both bootstrap windows. The protocol 20 path has no timer or fixed replay
+cutoff: a delayed retained event becomes a later batch and is re-anchored to
+current session state. The buffer holds 1,024 events. If the stream ends,
+queued protocol 20 events go through the same snapshot reconciliation before
+the watcher reconnects after 100 ms. Herdr subscriptions do not expose a replay
+cursor, so events that never reached the client before an unexpected disconnect
+can still be lost; the reconnect snapshot restores current focus but cannot
+reconstruct that transient order.[^reconnect-gap]
 
 Subscription request names use dotted event types. Incoming event envelopes
 use `workspace_focused` and `workspace_closed`; malformed, unrelated, and
@@ -100,11 +105,11 @@ sequenceDiagram
     participant E as Event connection
     participant S as Snapshot connection
     participant H as History
-    W->>P: ping
-    P-->>W: protocol
     W->>E: events.subscribe
     E-->>W: subscription_started
     Note over W,E: Decoder starts buffering events
+    W->>P: ping
+    P-->>W: protocol
     W->>S: session.snapshot
     S-->>W: focused_workspace_id + workspace IDs
     W->>H: Record initial snapshot focus

--- a/docs/development/workspace-history.md
+++ b/docs/development/workspace-history.md
@@ -15,14 +15,14 @@ plugin. Herdr lifecycle hooks elect one long-lived subscriber per socket, and
 that subscriber serializes focus and close events into plugin-owned
 history.[^watcher-source]
 
-!!! info "Protocol 20 replay is reconciled before history is published"
+!!! info "Protocol 20 replay is reconciled against current session state"
 
     The manifest requires Herdr 0.8.2 or newer, whose stable socket protocol is
-    20. Protocol 20 replays retained lifecycle events to a new subscriber, so
-    the watcher buffers the complete replay before publishing any history and
-    then reconciles it with a fresh session snapshot. Protocol 21 and newer
-    start lifecycle subscriptions at the current event sequence and skip that
-    replay step; see the [subscriber implementation](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go)
+    20. Protocol 20 replays retained lifecycle events without a completion
+    marker, so the watcher reconciles every available event batch with a fresh
+    session snapshot instead of inferring a boundary from timing. Protocol 21
+    and newer start lifecycle subscriptions at the current event sequence and
+    skip that replay step; see the [subscriber implementation](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go)
     and [protocol regression tests](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events_test.go).
 
 ## Why a resident subscriber exists
@@ -70,24 +70,24 @@ Each connection attempt follows this order:
 2. Open the event connection and subscribe to `workspace.focused` and
    `workspace.closed`.
 3. Start decoding events as soon as the subscription acknowledgement arrives.
-4. On protocol 20, buffer retained events until the stream is quiet. There is
-   no fixed cutoff: publishing a partial replay could temporarily move a stale
-   workspace ahead of the current one.
-5. Use a second socket connection to request
+4. Use a second socket connection to request the initial
    `session.snapshot`.[^snapshot-source]
-6. Apply retained events, discard stale close events for workspaces present in
-   the snapshot, record `focused_workspace_id`, then consume already-buffered
-   and future live events in decoder order.
+5. On protocol 20, drain each currently available event batch and request a
+   fresh snapshot. Apply focus events only for workspaces that still exist,
+   close events only for workspaces that no longer exist, then record the
+   snapshot's authoritative `focused_workspace_id`.
+6. On protocol 21 and newer, apply the already-buffered and future live events
+   directly in decoder order.
 
-Starting the decoder before replay reconciliation and the snapshot request
-closes both bootstrap windows. An event that arrives while `session.snapshot`
-is in flight waits in the channel and is applied after the snapshot. The buffer
-holds 1,024 events. Protocol 21 and newer have no retained replay, so they move
-directly from decoder startup to the snapshot. If the stream ends, buffered
-events are drained before the watcher reconnects after 100 ms and installs a
-fresh snapshot. Herdr subscriptions do not expose a replay cursor, so an
-unexpected disconnect can lose intermediate focus changes; the snapshot
-restores the current focus but cannot reconstruct that transient order.[^reconnect-gap]
+Starting the decoder before the initial snapshot request closes the bootstrap
+window. The protocol 20 path has no timer or fixed replay cutoff: a delayed
+retained event becomes a later batch and is re-anchored to current session
+state. The buffer holds 1,024 events. If the stream ends, queued protocol 20
+events go through the same snapshot reconciliation before the watcher
+reconnects after 100 ms. Herdr subscriptions do not expose a replay cursor, so
+events that never reached the client before an unexpected disconnect can still
+be lost; the reconnect snapshot restores current focus but cannot reconstruct
+that transient order.[^reconnect-gap]
 
 Subscription request names use dotted event types. Incoming event envelopes
 use `workspace_focused` and `workspace_closed`; malformed, unrelated, and
@@ -105,24 +105,28 @@ sequenceDiagram
     W->>E: events.subscribe
     E-->>W: subscription_started
     Note over W,E: Decoder starts buffering events
-    opt Protocol 20
-        W->>W: Drain complete retained replay
-    end
     W->>S: session.snapshot
     S-->>W: focused_workspace_id + workspace IDs
-    W->>H: Apply replay, then record snapshot focus
+    W->>H: Record initial snapshot focus
+    opt Protocol 20
+        W->>W: Drain available event batch
+        W->>S: session.snapshot
+        S-->>W: Current focus + workspace IDs
+        W->>H: Reconcile batch, then record snapshot focus
+    end
     loop Ordered live stream
         E-->>W: workspace event
-        W->>H: Record or RemoveWorkspace
+        W->>H: Reconcile protocol 20 or apply protocol 21
     end
     E--xW: unexpected EOF
     W->>H: Drain buffered events
     W->>E: Reconnect after 100 ms
 ```
 
-Regression tests define four boundaries for this flow: reconcile protocol 20
-replay before the snapshot, never publish a partial replay, preserve an event
-from the snapshot window, and reconnect after unexpected EOF.
+Regression tests define four boundaries for this flow: reconcile delayed
+protocol 20 replay without a timer, preserve queued replay across stream
+failure, preserve an event from the snapshot window, and reconnect after
+unexpected EOF.
 
 ## Session-scoped persistence
 

--- a/docs/development/workspace-history.md
+++ b/docs/development/workspace-history.md
@@ -78,7 +78,10 @@ Starting the decoder before the snapshot request closes the bootstrap window:
 an event that arrives while `session.snapshot` is in flight waits in the
 channel and is applied after the snapshot. The buffer holds 1,024 events. If
 the stream ends, buffered events are drained before the watcher reconnects
-after 100 ms.
+after 100 ms and installs a fresh snapshot. Herdr subscriptions do not expose a
+replay cursor, so an unexpected disconnect can lose intermediate focus changes;
+the snapshot restores the current focus but cannot reconstruct that transient
+order.[^reconnect-gap]
 
 Subscription request names use dotted event types. Incoming event envelopes
 use `workspace_focused` and `workspace_closed`; malformed, unrelated, and
@@ -87,11 +90,12 @@ ID-less envelopes are ignored.
 ```mermaid
 sequenceDiagram
     participant W as Watcher
+    participant P as Protocol connection
     participant E as Event connection
     participant S as Snapshot connection
     participant H as History
-    W->>E: ping
-    E-->>W: protocol
+    W->>P: ping
+    P-->>W: protocol
     W->>E: events.subscribe
     E-->>W: subscription_started
     Note over W,E: Decoder starts buffering live events
@@ -121,8 +125,8 @@ ${HERDR_PLUGIN_STATE_DIR}/history/<sha256-clean-socket-path>/history.json
 ```
 
 Existing unscoped `history.json` belongs to the default Herdr session. It is
-copied into that session's scoped directory on first use while holding the
-legacy history lock. Named sessions never inherit the old file.
+copied into that session's scoped directory on first use while holding both the
+legacy and destination history locks. Named sessions never inherit the old file.
 
 History mutation has a separate stable lock, `history.lock`. Writers attempt
 `LOCK_EX | LOCK_NB` every 10 ms for up to 250 ms. A timeout returns the typed
@@ -207,6 +211,9 @@ The most useful implementation entry points are:
     [protocol regression tests](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events_test.go).
 [^snapshot-source]: See `loadSessionSnapshot` and the buffered decoder in
     [`internal/herdr/events.go`](https://github.com/fullerzz/herdr-plugin-sesh/blob/main/internal/herdr/events.go).
+[^reconnect-gap]: Herdr documents snapshots as reconnect reconciliation, while
+    lifecycle subscriptions explicitly do not replay retained events. See the
+    [Herdr socket API](https://herdr.dev/docs/socket-api/#session-snapshot).
 [^flock-source]: [`syscall.Flock`](https://pkg.go.dev/syscall#Flock) provides the
     process-level advisory lock used by `withHistoryLock` and
     `TryHistoryWatcherLock`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ herdr plugin action invoke fullerzz.sesh.open-picker
 
 ## Requirements
 
-- Herdr 0.8.0 or newer
+- Herdr 0.8.2 or newer
 - Linux or macOS
 - Git and Go 1.26.4 or newer for Herdr's source-based plugin installation
 - Optional: `zoxide` for directory history and `eza` for the default preview

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -15,6 +15,17 @@ command = [
   "./cmd/herdr-sesh",
 ]
 
+[[startup]]
+command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+
+[[events]]
+on = "workspace.focused"
+command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+
+[[events]]
+on = "workspace.closed"
+command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+
 [[actions]]
 id = "open-picker"
 title = "Open Sesh Picker"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 id = "fullerzz.sesh"
 name = "Sesh for Herdr"
 version = "0.10.1"
-min_herdr_version = "0.8.0"
+min_herdr_version = "0.8.2"
 description = "Sesh-style smart workspace/session manager for Herdr"
 platforms = ["linux", "macos"]
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -16,15 +16,15 @@ command = [
 ]
 
 [[startup]]
-command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+command = ["./bin/herdr-sesh", "plugin", "watch-history"]
 
 [[events]]
 on = "workspace.focused"
-command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+command = ["./bin/herdr-sesh", "plugin", "watch-history"]
 
 [[events]]
 on = "workspace.closed"
-command = ["./bin/herdr-sesh", "plugin", "sync-history"]
+command = ["./bin/herdr-sesh", "plugin", "watch-history"]
 
 [[actions]]
 id = "open-picker"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -577,6 +577,17 @@ func (a *App) plugin(ctx context.Context, args []string) error {
 func (a *App) watchHistory(ctx context.Context) (err error) {
 	stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
 	socketPath := os.Getenv("HERDR_SOCKET_PATH")
+	// Elect first so non-winning startup and focus hooks cannot migrate history.
+	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
+	if err != nil {
+		return err
+	}
+	if acquired {
+		defer func() { err = errors.Join(err, release()) }()
+	}
+	if !acquired && os.Getenv("HERDR_PLUGIN_EVENT") != "workspace.closed" {
+		return nil
+	}
 	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
 	if err != nil {
 		return err
@@ -584,11 +595,9 @@ func (a *App) watchHistory(ctx context.Context) (err error) {
 	if err := applyHistoryHook(historyDir); err != nil {
 		return err
 	}
-	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
-	if err != nil || !acquired {
-		return err
+	if !acquired {
+		return nil
 	}
-	defer func() { err = errors.Join(err, release()) }()
 
 	return herdr.WatchWorkspaceEvents(ctx, socketPath,
 		func(workspaceID string) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -277,14 +277,18 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		selected, ok, err = pickerpkg.RunFZF(ctx, sessions, pickOpts)
 	} else {
 		client := herdr.NewCLIClient()
-		history, historyErr := state.LoadHistory(os.Getenv("HERDR_PLUGIN_STATE_DIR"))
+		historyDir, historyDirErr := historyStateDir()
+		if historyDirErr != nil {
+			a.warnf("could not resolve workspace history: %v", historyDirErr)
+		}
+		history, historyErr := state.LoadHistory(historyDir)
 		if historyErr != nil {
 			a.warnf("ignoring workspace history: %v", historyErr)
 		}
 		pickOpts.RecentWorkspaceIDs = append([]string{currentWorkspaceID}, history.Workspaces...)
 		if cfg.TUI.ShowLastWorkspace {
 			pickOpts.HerdrWorkspaces = herdrWorkspaces
-			lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), currentWorkspaceID)
+			lastWorkspaceID, _, lastWorkspaceErr := lastWorkspace(historyDir, currentWorkspaceID)
 			if lastWorkspaceErr != nil {
 				a.warnf("could not determine last workspace: %v", lastWorkspaceErr)
 			}
@@ -301,7 +305,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 			if err := client.WorkspaceClose(closeCtx, id); err != nil {
 				return err
 			}
-			if err := state.RemoveWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), id); err != nil {
+			if err := state.RemoveWorkspace(historyDir, id); err != nil {
 				deferWarn("could not prune workspace history: %v", err)
 			}
 			return nil
@@ -356,7 +360,12 @@ func (a *App) reloadPickerState(ctx context.Context, cfg config.Config, client *
 	var lastID string
 	var lastErr error
 	if cfg.TUI.ShowLastWorkspace {
-		lastID, _, lastErr = lastWorkspace(os.Getenv("HERDR_PLUGIN_STATE_DIR"), *pickerWorkspaceID)
+		historyDir, err := historyStateDir()
+		if err != nil {
+			lastErr = err
+		} else {
+			lastID, _, lastErr = lastWorkspace(historyDir, *pickerWorkspaceID)
+		}
 	}
 	if focusErr != nil {
 		*pickerWorkspaceID = ""
@@ -492,9 +501,12 @@ func gitRoot(ctx context.Context, dir string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 func (a *App) last(ctx context.Context, _ []string) error {
-	stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
+	historyDir, err := historyStateDir()
+	if err != nil {
+		return err
+	}
 	currentWorkspaceID := os.Getenv("HERDR_WORKSPACE_ID")
-	id, ok, err := lastWorkspace(stateDir, currentWorkspaceID)
+	id, ok, err := lastWorkspace(historyDir, currentWorkspaceID)
 	if err != nil {
 		return err
 	}
@@ -504,7 +516,7 @@ func (a *App) last(ctx context.Context, _ []string) error {
 	if err := herdr.NewCLIClient().WorkspaceFocus(ctx, id); err != nil {
 		return err
 	}
-	if err := state.RecordSwitch(stateDir, currentWorkspaceID, id); err != nil {
+	if err := state.RecordSwitch(historyDir, currentWorkspaceID, id); err != nil {
 		a.warnf("could not record workspace history: %v", err)
 	}
 	return nil
@@ -518,9 +530,17 @@ func lastWorkspace(stateDir, currentWorkspaceID string) (string, bool, error) {
 }
 
 func (a *App) recordWorkspaceSwitch(fromWorkspaceID, toWorkspaceID string) {
-	if err := state.RecordSwitch(os.Getenv("HERDR_PLUGIN_STATE_DIR"), fromWorkspaceID, toWorkspaceID); err != nil {
+	historyDir, err := historyStateDir()
+	if err == nil {
+		err = state.RecordSwitch(historyDir, fromWorkspaceID, toWorkspaceID)
+	}
+	if err != nil {
 		a.warnf("could not record workspace history: %v", err)
 	}
+}
+
+func historyStateDir() (string, error) {
+	return state.SessionHistoryDir(os.Getenv("HERDR_PLUGIN_STATE_DIR"), os.Getenv("HERDR_SOCKET_PATH"))
 }
 
 func (a *App) window(ctx context.Context, args []string) error {
@@ -547,21 +567,83 @@ func (a *App) plugin(ctx context.Context, args []string) error {
 	switch args[0] {
 	case "open-picker":
 		return herdr.NewCLIClient().PluginPaneOpen(ctx, "fullerzz.sesh", "picker", "overlay")
-	case "sync-history":
-		stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
-		workspaceID := os.Getenv("HERDR_WORKSPACE_ID")
-		switch os.Getenv("HERDR_PLUGIN_EVENT") {
-		case "startup", "workspace.focused":
-			return state.Record(stateDir, workspaceID)
-		case "workspace.closed":
-			return state.RemoveWorkspace(stateDir, workspaceID)
-		default:
-			return fmt.Errorf("unknown Herdr plugin event %q", os.Getenv("HERDR_PLUGIN_EVENT"))
-		}
+	case "watch-history":
+		return a.watchHistory(ctx)
 	default:
 		return errors.New("unknown plugin command")
 	}
 }
+
+func (a *App) watchHistory(ctx context.Context) (err error) {
+	stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
+	socketPath := os.Getenv("HERDR_SOCKET_PATH")
+	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
+	if err != nil {
+		return err
+	}
+	retry := func(mutate func() error) error {
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			err := mutate()
+			if !errors.Is(err, state.ErrHistoryLockTimeout) {
+				return err
+			}
+		}
+	}
+	if err := applyHistoryHook(retry, historyDir); err != nil {
+		return err
+	}
+	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
+	if err != nil || !acquired {
+		return err
+	}
+	defer func() { err = errors.Join(err, release()) }()
+
+	return herdr.WatchWorkspaceEvents(ctx, socketPath,
+		func(workspaceID string) error {
+			return retry(func() error { return state.Record(historyDir, workspaceID) })
+		},
+		func(workspaceID string) error {
+			return retry(func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
+		},
+	)
+}
+
+func applyHistoryHook(retry func(func() error) error, historyDir string) error {
+	eventName := os.Getenv("HERDR_PLUGIN_EVENT")
+	if eventName == "" || eventName == "startup" {
+		return nil
+	}
+	workspaceID := os.Getenv("HERDR_WORKSPACE_ID")
+	if workspaceID == "" {
+		var payload struct {
+			WorkspaceID string `json:"workspace_id"`
+			Data        struct {
+				WorkspaceID string `json:"workspace_id"`
+			} `json:"data"`
+		}
+		if raw := os.Getenv("HERDR_PLUGIN_EVENT_JSON"); raw != "" {
+			if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+				return fmt.Errorf("decode HERDR_PLUGIN_EVENT_JSON: %w", err)
+			}
+			workspaceID = payload.WorkspaceID
+			if workspaceID == "" {
+				workspaceID = payload.Data.WorkspaceID
+			}
+		}
+	}
+	switch eventName {
+	case "workspace.focused":
+		return retry(func() error { return state.Record(historyDir, workspaceID) })
+	case "workspace.closed":
+		return retry(func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
+	default:
+		return fmt.Errorf("unknown Herdr plugin event %q", eventName)
+	}
+}
+
 func (a *App) config(_ context.Context, args []string) error {
 	if len(args) == 0 {
 		return errors.New("config requires path, init, validate, or migrate")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -279,7 +279,7 @@ func (a *App) picker(ctx context.Context, args []string) error {
 		client := herdr.NewCLIClient()
 		historyDir, historyDirErr := historyStateDir()
 		if historyDirErr != nil {
-			a.warnf("could not resolve workspace history: %v", historyDirErr)
+			return fmt.Errorf("resolve workspace history: %w", historyDirErr)
 		}
 		history, historyErr := state.LoadHistory(historyDir)
 		if historyErr != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -581,17 +581,6 @@ func (a *App) watchHistory(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	retry := func(mutate func() error) error {
-		for {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			err := mutate()
-			if !errors.Is(err, state.ErrHistoryLockTimeout) {
-				return err
-			}
-		}
-	}
 	if err := applyHistoryHook(historyDir); err != nil {
 		return err
 	}
@@ -603,12 +592,24 @@ func (a *App) watchHistory(ctx context.Context) (err error) {
 
 	return herdr.WatchWorkspaceEvents(ctx, socketPath,
 		func(workspaceID string) error {
-			return retry(func() error { return state.Record(historyDir, workspaceID) })
+			return retryHistoryMutation(ctx, func() error { return state.Record(historyDir, workspaceID) })
 		},
 		func(workspaceID string) error {
-			return retry(func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
+			return retryHistoryMutation(ctx, func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
 		},
 	)
+}
+
+func retryHistoryMutation(ctx context.Context, mutate func() error) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := mutate()
+		if !errors.Is(err, state.ErrHistoryLockTimeout) {
+			return err
+		}
+	}
 }
 
 func applyHistoryHook(historyDir string) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -541,10 +541,26 @@ func (a *App) window(ctx context.Context, args []string) error {
 	return err
 }
 func (a *App) plugin(ctx context.Context, args []string) error {
-	if len(args) >= 1 && args[0] == "open-picker" {
-		return herdr.NewCLIClient().PluginPaneOpen(ctx, "fullerzz.sesh", "picker", "overlay")
+	if len(args) == 0 {
+		return errors.New("unknown plugin command")
 	}
-	return errors.New("unknown plugin command")
+	switch args[0] {
+	case "open-picker":
+		return herdr.NewCLIClient().PluginPaneOpen(ctx, "fullerzz.sesh", "picker", "overlay")
+	case "sync-history":
+		stateDir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
+		workspaceID := os.Getenv("HERDR_WORKSPACE_ID")
+		switch os.Getenv("HERDR_PLUGIN_EVENT") {
+		case "startup", "workspace.focused":
+			return state.Record(stateDir, workspaceID)
+		case "workspace.closed":
+			return state.RemoveWorkspace(stateDir, workspaceID)
+		default:
+			return fmt.Errorf("unknown Herdr plugin event %q", os.Getenv("HERDR_PLUGIN_EVENT"))
+		}
+	default:
+		return errors.New("unknown plugin command")
+	}
 }
 func (a *App) config(_ context.Context, args []string) error {
 	if len(args) == 0 {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -592,7 +592,7 @@ func (a *App) watchHistory(ctx context.Context) (err error) {
 			}
 		}
 	}
-	if err := applyHistoryHook(retry, historyDir); err != nil {
+	if err := applyHistoryHook(historyDir); err != nil {
 		return err
 	}
 	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
@@ -611,34 +611,31 @@ func (a *App) watchHistory(ctx context.Context) (err error) {
 	)
 }
 
-func applyHistoryHook(retry func(func() error) error, historyDir string) error {
+func applyHistoryHook(historyDir string) error {
 	eventName := os.Getenv("HERDR_PLUGIN_EVENT")
 	if eventName == "" || eventName == "startup" {
 		return nil
 	}
-	workspaceID := os.Getenv("HERDR_WORKSPACE_ID")
-	if workspaceID == "" {
+	switch eventName {
+	case "workspace.focused":
+		return nil
+	case "workspace.closed":
 		var payload struct {
-			WorkspaceID string `json:"workspace_id"`
-			Data        struct {
+			Data struct {
 				WorkspaceID string `json:"workspace_id"`
 			} `json:"data"`
 		}
-		if raw := os.Getenv("HERDR_PLUGIN_EVENT_JSON"); raw != "" {
-			if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-				return fmt.Errorf("decode HERDR_PLUGIN_EVENT_JSON: %w", err)
-			}
-			workspaceID = payload.WorkspaceID
-			if workspaceID == "" {
-				workspaceID = payload.Data.WorkspaceID
-			}
+		raw := os.Getenv("HERDR_PLUGIN_EVENT_JSON")
+		if raw == "" {
+			return errors.New("HERDR_PLUGIN_EVENT_JSON is required for workspace.closed")
 		}
-	}
-	switch eventName {
-	case "workspace.focused":
-		return retry(func() error { return state.Record(historyDir, workspaceID) })
-	case "workspace.closed":
-		return retry(func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			return fmt.Errorf("decode HERDR_PLUGIN_EVENT_JSON: %w", err)
+		}
+		if payload.Data.WorkspaceID == "" {
+			return errors.New("workspace.closed event payload is missing data.workspace_id")
+		}
+		return state.RemoveWorkspace(historyDir, payload.Data.WorkspaceID)
 	default:
 		return fmt.Errorf("unknown Herdr plugin event %q", eventName)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -643,6 +643,24 @@ func TestPickerJSONCommand(t *testing.T) {
 	}
 }
 
+func TestNativePickerFailsWhenWorkspaceHistoryCannotResolve(t *testing.T) {
+	configureFakeSources(t, "")
+	statePath := filepath.Join(t.TempDir(), "state")
+	if err := os.WriteFile(statePath, []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", statePath)
+	t.Setenv("HERDR_SOCKET_PATH", filepath.Join(t.TempDir(), "herdr", "herdr.sock"))
+
+	err := (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(
+		context.Background(),
+		[]string{"picker", "--config", filepath.Join("..", "..", "testdata", "sesh.toml")},
+	)
+	if err == nil || !strings.Contains(err.Error(), "resolve workspace history") {
+		t.Fatalf("picker error=%v, want workspace history resolution failure", err)
+	}
+}
+
 func TestPickerJSONAppliesDefaultStartupCommand(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
 	if err := os.WriteFile(cfgPath, []byte(`[default_session]
@@ -1323,7 +1341,7 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A"}}); err != nil {
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A", "closed"}}); err != nil {
 		t.Fatal(err)
 	}
 	//nolint:gosec // Test lock path is derived from t.TempDir().
@@ -1380,17 +1398,9 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 		}
 
 		enc := json.NewEncoder(conn)
-		messages := []any{
-			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
-			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "B"}},
-			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "C"}},
-			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "D"}},
-		}
-		for _, message := range messages {
-			if err := enc.Encode(message); err != nil {
-				serverDone <- err
-				return
-			}
+		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
 		}
 
 		snapshotConn, err := listener.Accept()
@@ -1411,11 +1421,16 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 			serverDone <- fmt.Errorf("snapshot method=%q", snapshotRequest.Method)
 			return
 		}
+		if err := encodeHistoryFocusEvents(enc, "C", "D"); err != nil {
+			_ = snapshotConn.Close()
+			serverDone <- err
+			return
+		}
 		if err := json.NewEncoder(snapshotConn).Encode(map[string]any{
 			"id": "herdr-sesh-history-snapshot",
 			"result": map[string]any{
 				"type":     "session_snapshot",
-				"snapshot": map[string]any{"focused_workspace_id": "D"},
+				"snapshot": map[string]any{"focused_workspace_id": "B"},
 			},
 		}); err != nil {
 			_ = snapshotConn.Close()
@@ -1427,7 +1442,7 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 			return
 		}
 		close(snapshotSent)
-		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"type": "workspace_closed", "workspace_id": "B"}}); err != nil {
+		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"type": "workspace_closed", "workspace_id": "closed"}}); err != nil {
 			serverDone <- err
 			return
 		}
@@ -1453,7 +1468,7 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	case <-time.After(time.Second):
 		t.Fatal("watcher did not request a snapshot after lock release")
 	}
-	want := []string{"D", "C", "A"}
+	want := []string{"D", "C", "B", "A"}
 	deadline := time.Now().Add(time.Second)
 	for {
 		h, loadErr := state.LoadHistory(historyDir)
@@ -1498,6 +1513,15 @@ func serveHistoryWatcherPing(listener net.Listener) error {
 			"type": "pong", "version": "0.8.2-preview", "protocol": 21,
 		},
 	})
+}
+
+func encodeHistoryFocusEvents(enc *json.Encoder, workspaceIDs ...string) error {
+	for _, workspaceID := range workspaceIDs {
+		if err := enc.Encode(map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": workspaceID}}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -982,13 +982,17 @@ func TestPluginManifestStartsHistoryWatcherForRuntimeLifecycleEvents(t *testing.
 		t.Fatal(err)
 	}
 	var manifest struct {
-		Events []struct {
+		MinHerdrVersion string `toml:"min_herdr_version"`
+		Events          []struct {
 			On      string   `toml:"on"`
 			Command []string `toml:"command"`
 		} `toml:"events"`
 	}
 	if err := toml.Unmarshal(b, &manifest); err != nil {
 		t.Fatal(err)
+	}
+	if manifest.MinHerdrVersion != "0.8.2" {
+		t.Fatalf("min_herdr_version=%q, want 0.8.2", manifest.MinHerdrVersion)
 	}
 	wantCommand := []string{"./bin/herdr-sesh", "plugin", "watch-history"}
 	got := make(map[string][]string, len(manifest.Events))
@@ -999,6 +1003,84 @@ func TestPluginManifestStartsHistoryWatcherForRuntimeLifecycleEvents(t *testing.
 		if !reflect.DeepEqual(got[event], wantCommand) {
 			t.Errorf("%s command=%#v want %#v", event, got[event], wantCommand)
 		}
+	}
+}
+
+func TestApplyHistoryHookLeavesFocusedEventsToSubscriber(t *testing.T) {
+	historyDir := t.TempDir()
+	want := state.History{Workspaces: []string{"current", "older"}}
+	if err := state.SaveHistory(historyDir, want); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.focused")
+	t.Setenv("HERDR_WORKSPACE_ID", "late-hook")
+
+	err := applyHistoryHook(historyDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.LoadHistory(historyDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(history, want) {
+		t.Fatalf("history=%#v want %#v", history, want)
+	}
+}
+
+func TestApplyHistoryHookUsesClosedEventPayloadWorkspace(t *testing.T) {
+	historyDir := t.TempDir()
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"context", "closed", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.closed")
+	t.Setenv("HERDR_WORKSPACE_ID", "context")
+	t.Setenv("HERDR_PLUGIN_EVENT_JSON", `{"data":{"workspace_id":"closed"}}`)
+
+	if err := applyHistoryHook(historyDir); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.LoadHistory(historyDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"context", "older"}
+	if !reflect.DeepEqual(history.Workspaces, want) {
+		t.Fatalf("workspaces=%#v want %#v", history.Workspaces, want)
+	}
+}
+
+func TestPluginWatchHistoryBoundsClosedHookLockWait(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
+	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed"}}); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) })
+
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", socketPath)
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.closed")
+	t.Setenv("HERDR_PLUGIN_EVENT_JSON", `{"data":{"workspace_id":"closed"}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err = (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(ctx, []string{"plugin", "watch-history"})
+	if !errors.Is(err, state.ErrHistoryLockTimeout) {
+		t.Fatalf("watch error=%v, want history lock timeout", err)
 	}
 }
 
@@ -1027,6 +1109,10 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 	releaseServer := make(chan struct{})
 	serverDone := make(chan error, 1)
 	go func() {
+		if err := serveHistoryWatcherPing(listener); err != nil {
+			serverDone <- err
+			return
+		}
 		conn, err := listener.Accept()
 		if err != nil {
 			serverDone <- err
@@ -1068,8 +1154,7 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 			return
 		}
 		_ = snapshotConn.Close()
-		// Current Herdr does not replay the hook event. A duplicate from an
-		// older server remains harmless when it is present.
+		// A duplicate live close event remains harmless.
 		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"workspace_id": "closed"}}); err != nil {
 			serverDone <- err
 			return
@@ -1138,6 +1223,10 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	releaseServer := make(chan struct{})
 	serverDone := make(chan error, 1)
 	go func() {
+		if err := serveHistoryWatcherPing(listener); err != nil {
+			serverDone <- err
+			return
+		}
 		conn, err := listener.Accept()
 		if err != nil {
 			serverDone <- err
@@ -1255,6 +1344,10 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	snapshotSent := make(chan struct{})
 	serverDone := make(chan error, 1)
 	go func() {
+		if err := serveHistoryWatcherPing(listener); err != nil {
+			serverDone <- err
+			return
+		}
 		conn, err := listener.Accept()
 		if err != nil {
 			serverDone <- err
@@ -1349,8 +1442,8 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	watchDone := make(chan error, 1)
 	go func() { watchDone <- a.Run(ctx, []string{"plugin", "watch-history"}) }()
-	// Replayed events must wait for the history lock before the newer
-	// snapshot is installed.
+	// Snapshot initialization must wait for the history lock before buffered
+	// live events are applied.
 	time.Sleep(350 * time.Millisecond)
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
 		t.Fatal(err)
@@ -1382,6 +1475,29 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	if err := <-serverDone; err != nil {
 		t.Fatal(err)
 	}
+}
+
+func serveHistoryWatcherPing(listener net.Listener) error {
+	conn, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.NewDecoder(conn).Decode(&request); err != nil {
+		return err
+	}
+	if request.Method != "ping" {
+		return fmt.Errorf("method=%q want ping", request.Method)
+	}
+	return json.NewEncoder(conn).Encode(map[string]any{
+		"id": "herdr-sesh-history-ping",
+		"result": map[string]any{
+			"type": "pong", "version": "0.8.2-preview", "protocol": 21,
+		},
+	})
 }
 
 func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1127,10 +1127,6 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 	releaseServer := make(chan struct{})
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveHistoryWatcherPing(listener); err != nil {
-			serverDone <- err
-			return
-		}
 		conn, err := listener.Accept()
 		if err != nil {
 			serverDone <- err
@@ -1150,6 +1146,10 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 		}
 		enc := json.NewEncoder(conn)
 		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		if err := serveHistoryWatcherPing(listener); err != nil {
 			serverDone <- err
 			return
 		}
@@ -1223,6 +1223,39 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 	}
 }
 
+func TestPluginWatchHistoryNonWinningFocusDoesNotMigrateLegacyHistory(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "state")
+	socketPath := filepath.Join(root, "herdr", "herdr.sock")
+	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"legacy"}}); err != nil {
+		t.Fatal(err)
+	}
+	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("failed to hold watcher election lock")
+	}
+	t.Cleanup(func() {
+		if err := release(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", socketPath)
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.focused")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(ctx, []string{"plugin", "watch-history"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "history")); !os.IsNotExist(err) {
+		t.Fatalf("non-winning focus hook migrated legacy history: %v", err)
+	}
+}
+
 func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
@@ -1241,10 +1274,6 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	releaseServer := make(chan struct{})
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveHistoryWatcherPing(listener); err != nil {
-			serverDone <- err
-			return
-		}
 		conn, err := listener.Accept()
 		if err != nil {
 			serverDone <- err
@@ -1265,6 +1294,10 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 		if err := json.NewEncoder(conn).Encode(map[string]any{
 			"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
 		}); err != nil {
+			serverDone <- err
+			return
+		}
+		if err := serveHistoryWatcherPing(listener); err != nil {
 			serverDone <- err
 			return
 		}
@@ -1377,6 +1410,164 @@ func TestRetryHistoryMutationPreservesOrderAfterLockTimeout(t *testing.T) {
 	if want := []string{"B", "C", "D"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("mutations=%#v want %#v", got, want)
 	}
+}
+
+func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T) {
+	historyDir := filepath.Join(t.TempDir(), "history")
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A", "closed"}}); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		}
+	}()
+
+	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "herdr.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	releaseServer := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() { serverDone <- serveContendedHistoryStream(listener, releaseServer) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	lockTimedOut := make(chan struct{}, 1)
+	retry := func(mutate func() error) error {
+		return retryHistoryMutation(ctx, func() error {
+			err := mutate()
+			if errors.Is(err, state.ErrHistoryLockTimeout) {
+				select {
+				case lockTimedOut <- struct{}{}:
+				default:
+				}
+			}
+			return err
+		})
+	}
+	watchDone := make(chan error, 1)
+	go func() {
+		watchDone <- herdr.WatchWorkspaceEvents(ctx, socketPath,
+			func(workspaceID string) error {
+				return retry(func() error { return state.Record(historyDir, workspaceID) })
+			},
+			func(workspaceID string) error {
+				return retry(func() error { return state.RemoveWorkspace(historyDir, workspaceID) })
+			},
+		)
+	}()
+
+	select {
+	case <-lockTimedOut:
+	case <-ctx.Done():
+		t.Fatal("watcher did not retry the contended snapshot mutation")
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+
+	want := []string{"D", "C", "B", "A"}
+	for {
+		history, err := state.LoadHistory(historyDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reflect.DeepEqual(history.Workspaces, want) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("history=%#v want %#v", history.Workspaces, want)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	close(releaseServer)
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-watchDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v want context cancellation", err)
+	}
+}
+
+func serveContendedHistoryStream(listener net.Listener, release <-chan struct{}) error {
+	stream, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stream.Close() }()
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.NewDecoder(stream).Decode(&request); err != nil {
+		return err
+	}
+	if request.Method != "events.subscribe" {
+		return fmt.Errorf("method=%q want events.subscribe", request.Method)
+	}
+	enc := json.NewEncoder(stream)
+	if err := enc.Encode(map[string]any{
+		"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
+	}); err != nil {
+		return err
+	}
+	if err := serveHistoryWatcherPing(listener); err != nil {
+		return err
+	}
+	snapshot, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = snapshot.Close() }()
+	if err := json.NewDecoder(snapshot).Decode(&request); err != nil {
+		return err
+	}
+	if request.Method != "session.snapshot" {
+		return fmt.Errorf("method=%q want session.snapshot", request.Method)
+	}
+	for _, workspaceID := range []string{"C", "D"} {
+		if err := enc.Encode(map[string]any{
+			"event": "workspace_focused", "data": map[string]any{"workspace_id": workspaceID},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := json.NewEncoder(snapshot).Encode(map[string]any{
+		"id": "herdr-sesh-history-snapshot",
+		"result": map[string]any{
+			"type": "session_snapshot", "snapshot": map[string]any{"focused_workspace_id": "B"},
+		},
+	}); err != nil {
+		return err
+	}
+	if err := enc.Encode(map[string]any{
+		"event": "workspace_closed", "data": map[string]any{"workspace_id": "closed"},
+	}); err != nil {
+		return err
+	}
+	<-release
+	return nil
 }
 
 func serveHistoryWatcherPing(listener net.Listener) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -970,6 +970,77 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	}
 }
 
+func TestPluginSyncHistoryRoutesLifecycleEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     string
+		workspace string
+		initial   []string
+		want      []string
+	}{
+		{name: "startup records workspace", event: "startup", workspace: "startup-workspace", want: []string{"startup-workspace"}},
+		{name: "focused workspace promotes workspace", event: "workspace.focused", workspace: "focused-workspace", initial: []string{"current-workspace", "older-workspace"}, want: []string{"focused-workspace", "current-workspace", "older-workspace"}},
+		{name: "closed workspace removes workspace", event: "workspace.closed", workspace: "closed-workspace", initial: []string{"closed-workspace", "other-workspace"}, want: []string{"other-workspace"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stateDir := filepath.Join(t.TempDir(), "state")
+			if err := state.SaveHistory(stateDir, state.History{Workspaces: tt.initial}); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("HERDR_PLUGIN_EVENT", tt.event)
+			t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+			t.Setenv("HERDR_WORKSPACE_ID", tt.workspace)
+
+			a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+			if err := a.Run(context.Background(), []string{"plugin", "sync-history"}); err != nil {
+				t.Fatal(err)
+			}
+			h, err := state.LoadHistory(stateDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(h.Workspaces, tt.want) {
+				t.Fatalf("workspaces=%#v want %#v", h.Workspaces, tt.want)
+			}
+		})
+	}
+}
+
+func TestPluginSyncHistoryRejectsUnknownEvent(t *testing.T) {
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.renamed")
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := a.Run(context.Background(), []string{"plugin", "sync-history"})
+	if err == nil || !strings.Contains(err.Error(), "unknown Herdr plugin event") {
+		t.Fatalf("err=%v, want unknown event error", err)
+	}
+}
+
+func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {
+	d := t.TempDir()
+	logPath := filepath.Join(d, "herdr.log")
+	fakeHerdr := filepath.Join(d, "herdr")
+	//nolint:gosec // test creates a local executable fixture.
+	if err := os.WriteFile(fakeHerdr, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
+	t.Setenv("HERDR_FAKE_LOG", logPath)
+
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := a.Run(context.Background(), []string{"plugin", "open-picker"}); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // logPath is a test-owned temp file.
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(log)); got != "plugin pane open --plugin fullerzz.sesh --entrypoint picker --placement overlay" {
+		t.Fatalf("herdr args=%q", got)
+	}
+}
+
 func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {
 	t.Helper()
 	configureFakeSources(t, zoxideOutput)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1329,166 +1329,53 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	}
 }
 
-func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T) {
-	stateDir := filepath.Join(t.TempDir(), "state")
-	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
-	socketPath := filepath.Join(socketDir, "herdr.sock")
-	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A", "closed"}}); err != nil {
-		t.Fatal(err)
-	}
-	//nolint:gosec // Test lock path is derived from t.TempDir().
-	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = lock.Close() }()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = listener.Close() })
+func TestRetryHistoryMutationPreservesOrderAfterLockTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	firstAttempt := true
+	var got []string
 
-	snapshotSent := make(chan struct{})
-	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveHistoryWatcherPing(listener); err != nil {
-			serverDone <- err
-			return
+		for _, workspaceID := range []string{"B", "C", "D"} {
+			err := retryHistoryMutation(ctx, func() error {
+				if workspaceID == "B" && firstAttempt {
+					firstAttempt = false
+					close(blocked)
+					select {
+					case <-release:
+						return fmt.Errorf("contended: %w", state.ErrHistoryLockTimeout)
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+				got = append(got, workspaceID)
+				return nil
+			})
+			if err != nil {
+				done <- err
+				return
+			}
 		}
-		conn, err := listener.Accept()
-		if err != nil {
-			serverDone <- err
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		var request struct {
-			Method string `json:"method"`
-			Params struct {
-				Subscriptions []struct {
-					Type string `json:"type"`
-				} `json:"subscriptions"`
-			} `json:"params"`
-		}
-		if err := json.NewDecoder(conn).Decode(&request); err != nil {
-			serverDone <- err
-			return
-		}
-		if request.Method != "events.subscribe" {
-			serverDone <- fmt.Errorf("method=%q", request.Method)
-			return
-		}
-		gotSubscriptions := make([]string, 0, len(request.Params.Subscriptions))
-		for _, subscription := range request.Params.Subscriptions {
-			gotSubscriptions = append(gotSubscriptions, subscription.Type)
-		}
-		if want := []string{"workspace.focused", "workspace.closed"}; !reflect.DeepEqual(gotSubscriptions, want) {
-			serverDone <- fmt.Errorf("subscriptions=%#v want %#v", gotSubscriptions, want)
-			return
-		}
-
-		enc := json.NewEncoder(conn)
-		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
-			serverDone <- err
-			return
-		}
-
-		snapshotConn, err := listener.Accept()
-		if err != nil {
-			serverDone <- err
-			return
-		}
-		var snapshotRequest struct {
-			Method string `json:"method"`
-		}
-		if err := json.NewDecoder(snapshotConn).Decode(&snapshotRequest); err != nil {
-			_ = snapshotConn.Close()
-			serverDone <- err
-			return
-		}
-		if snapshotRequest.Method != "session.snapshot" {
-			_ = snapshotConn.Close()
-			serverDone <- fmt.Errorf("snapshot method=%q", snapshotRequest.Method)
-			return
-		}
-		if err := encodeHistoryFocusEvents(enc, "C", "D"); err != nil {
-			_ = snapshotConn.Close()
-			serverDone <- err
-			return
-		}
-		if err := json.NewEncoder(snapshotConn).Encode(map[string]any{
-			"id": "herdr-sesh-history-snapshot",
-			"result": map[string]any{
-				"type":     "session_snapshot",
-				"snapshot": map[string]any{"focused_workspace_id": "B"},
-			},
-		}); err != nil {
-			_ = snapshotConn.Close()
-			serverDone <- err
-			return
-		}
-		if err := snapshotConn.Close(); err != nil {
-			serverDone <- err
-			return
-		}
-		close(snapshotSent)
-		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"type": "workspace_closed", "workspace_id": "closed"}}); err != nil {
-			serverDone <- err
-			return
-		}
-		serverDone <- nil
+		done <- nil
 	}()
 
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
-	t.Setenv("HERDR_SOCKET_PATH", socketPath)
-	t.Setenv("HERDR_WORKSPACE_ID", "stale")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	watchDone := make(chan error, 1)
-	go func() { watchDone <- a.Run(ctx, []string{"plugin", "watch-history"}) }()
-	// Snapshot initialization must wait for the history lock before buffered
-	// live events are applied.
-	time.Sleep(350 * time.Millisecond)
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
-		t.Fatal(err)
-	}
 	select {
-	case <-snapshotSent:
-	case <-time.After(time.Second):
-		t.Fatal("watcher did not request a snapshot after lock release")
+	case <-blocked:
+	case <-ctx.Done():
+		t.Fatal("history mutation did not reach lock contention")
 	}
-	want := []string{"D", "C", "B", "A"}
-	deadline := time.Now().Add(time.Second)
-	for {
-		h, loadErr := state.LoadHistory(historyDir)
-		if loadErr != nil {
-			t.Fatal(loadErr)
-		}
-		if reflect.DeepEqual(h.Workspaces, want) {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
-		}
-		time.Sleep(10 * time.Millisecond)
+	if len(got) != 0 {
+		t.Fatalf("later mutations overtook the contended mutation: %#v", got)
 	}
-	cancel()
-	if watchErr := <-watchDone; !errors.Is(watchErr, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", watchErr)
-	}
-	if err := <-serverDone; err != nil {
+	close(release)
+	if err := <-done; err != nil {
 		t.Fatal(err)
+	}
+	if want := []string{"B", "C", "D"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutations=%#v want %#v", got, want)
 	}
 }
 
@@ -1513,15 +1400,6 @@ func serveHistoryWatcherPing(listener net.Listener) error {
 			"type": "pong", "version": "0.8.2-preview", "protocol": 21,
 		},
 	})
-}
-
-func encodeHistoryFocusEvents(enc *json.Encoder, workspaceIDs ...string) error {
-	for _, workspaceID := range workspaceIDs {
-		if err := enc.Encode(map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": workspaceID}}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,17 +7,20 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestVersionCommand(t *testing.T) {
@@ -828,6 +831,7 @@ esac
 				t.Fatal(err)
 			}
 			t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+			t.Setenv("HERDR_SOCKET_PATH", "")
 			pickerWorkspaceID := "closed-workspace"
 			var warnings []string
 			warn := func(format string, args ...any) {
@@ -946,6 +950,7 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
 	t.Setenv("HERDR_FAKE_LOG", logPath)
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", "")
 	t.Setenv("HERDR_WORKSPACE_ID", "current")
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
@@ -970,49 +975,412 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	}
 }
 
-func TestPluginSyncHistoryRoutesLifecycleEvents(t *testing.T) {
-	tests := []struct {
-		name      string
-		event     string
-		workspace string
-		initial   []string
-		want      []string
-	}{
-		{name: "startup records workspace", event: "startup", workspace: "startup-workspace", want: []string{"startup-workspace"}},
-		{name: "focused workspace promotes workspace", event: "workspace.focused", workspace: "focused-workspace", initial: []string{"current-workspace", "older-workspace"}, want: []string{"focused-workspace", "current-workspace", "older-workspace"}},
-		{name: "closed workspace removes workspace", event: "workspace.closed", workspace: "closed-workspace", initial: []string{"closed-workspace", "other-workspace"}, want: []string{"other-workspace"}},
+func TestPluginManifestStartsHistoryWatcherForRuntimeLifecycleEvents(t *testing.T) {
+	//nolint:gosec // The manifest is a repository-owned test fixture.
+	b, err := os.ReadFile("../../herdr-plugin.toml")
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stateDir := filepath.Join(t.TempDir(), "state")
-			if err := state.SaveHistory(stateDir, state.History{Workspaces: tt.initial}); err != nil {
-				t.Fatal(err)
-			}
-			t.Setenv("HERDR_PLUGIN_EVENT", tt.event)
-			t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
-			t.Setenv("HERDR_WORKSPACE_ID", tt.workspace)
-
-			a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-			if err := a.Run(context.Background(), []string{"plugin", "sync-history"}); err != nil {
-				t.Fatal(err)
-			}
-			h, err := state.LoadHistory(stateDir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(h.Workspaces, tt.want) {
-				t.Fatalf("workspaces=%#v want %#v", h.Workspaces, tt.want)
-			}
-		})
+	var manifest struct {
+		Events []struct {
+			On      string   `toml:"on"`
+			Command []string `toml:"command"`
+		} `toml:"events"`
+	}
+	if err := toml.Unmarshal(b, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	wantCommand := []string{"./bin/herdr-sesh", "plugin", "watch-history"}
+	got := make(map[string][]string, len(manifest.Events))
+	for _, event := range manifest.Events {
+		got[event.On] = event.Command
+	}
+	for _, event := range []string{"workspace.focused", "workspace.closed"} {
+		if !reflect.DeepEqual(got[event], wantCommand) {
+			t.Errorf("%s command=%#v want %#v", event, got[event], wantCommand)
+		}
 	}
 }
 
-func TestPluginSyncHistoryRejectsUnknownEvent(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.renamed")
+func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-hook-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "herdr.sock")
+	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed", "other"}}); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	streamReady := make(chan struct{})
+	releaseServer := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(conn).Decode(&request); err != nil {
+			serverDone <- err
+			return
+		}
+		if request.Method != "events.subscribe" {
+			serverDone <- fmt.Errorf("method=%q", request.Method)
+			return
+		}
+		enc := json.NewEncoder(conn)
+		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		snapshotConn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if err := json.NewDecoder(snapshotConn).Decode(&request); err != nil {
+			_ = snapshotConn.Close()
+			serverDone <- err
+			return
+		}
+		if err := json.NewEncoder(snapshotConn).Encode(map[string]any{
+			"id":     "herdr-sesh-history-snapshot",
+			"result": map[string]any{"type": "session_snapshot", "snapshot": map[string]any{"focused_workspace_id": ""}},
+		}); err != nil {
+			_ = snapshotConn.Close()
+			serverDone <- err
+			return
+		}
+		_ = snapshotConn.Close()
+		// Current Herdr does not replay the hook event. A duplicate from an
+		// older server remains harmless when it is present.
+		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"workspace_id": "closed"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		close(streamReady)
+		<-releaseServer
+		serverDone <- nil
+	}()
+
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", socketPath)
+	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.closed")
+	t.Setenv("HERDR_WORKSPACE_ID", "")
+	t.Setenv("HERDR_PLUGIN_EVENT_JSON", `{"data":{"workspace_id":"closed"}}`)
+	ctx, cancel := context.WithCancel(context.Background())
+	watchDone := make(chan error, 1)
+	go func() {
+		a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		watchDone <- a.Run(ctx, []string{"plugin", "watch-history"})
+	}()
+	select {
+	case <-streamReady:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not bootstrap")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		history, loadErr := state.LoadHistory(historyDir)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		if reflect.DeepEqual(history.Workspaces, []string{"other"}) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("history after hook and duplicate replay=%#v", history.Workspaces)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	close(releaseServer)
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-watchDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", err)
+	}
+}
+
+func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "herdr.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	watcherReady := make(chan struct{})
+	releaseServer := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(conn).Decode(&request); err != nil {
+			serverDone <- err
+			return
+		}
+		if request.Method != "events.subscribe" {
+			serverDone <- fmt.Errorf("method=%q", request.Method)
+			return
+		}
+		if err := json.NewEncoder(conn).Encode(map[string]any{
+			"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
+		}); err != nil {
+			serverDone <- err
+			return
+		}
+
+		snapshotConn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = snapshotConn.Close() }()
+		if err := json.NewDecoder(snapshotConn).Decode(&request); err != nil {
+			serverDone <- err
+			return
+		}
+		if request.Method != "session.snapshot" {
+			serverDone <- fmt.Errorf("snapshot method=%q", request.Method)
+			return
+		}
+		if err := json.NewEncoder(snapshotConn).Encode(map[string]any{
+			"id": "herdr-sesh-history-snapshot",
+			"result": map[string]any{
+				"type": "session_snapshot", "snapshot": map[string]any{"focused_workspace_id": ""},
+			},
+		}); err != nil {
+			serverDone <- err
+			return
+		}
+		close(watcherReady)
+		<-releaseServer
+		serverDone <- nil
+	}()
+
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", socketPath)
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+	firstDone := make(chan error, 1)
+	go func() {
+		a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		firstDone <- a.Run(firstCtx, []string{"plugin", "watch-history"})
+	}()
+	select {
+	case <-watcherReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first watcher did not subscribe")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	err := a.Run(context.Background(), []string{"plugin", "sync-history"})
-	if err == nil || !strings.Contains(err.Error(), "unknown Herdr plugin event") {
-		t.Fatalf("err=%v, want unknown event error", err)
+	secondErr := a.Run(ctx, []string{"plugin", "watch-history"})
+	cancelFirst()
+	close(releaseServer)
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-firstDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("first watcher error=%v, want context cancellation", err)
+	}
+	if secondErr != nil {
+		t.Fatalf("second watcher returned %v, want a successful no-op", secondErr)
+	}
+}
+
+func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "herdr.sock")
+	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A"}}); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	snapshotSent := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		var request struct {
+			Method string `json:"method"`
+			Params struct {
+				Subscriptions []struct {
+					Type string `json:"type"`
+				} `json:"subscriptions"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(conn).Decode(&request); err != nil {
+			serverDone <- err
+			return
+		}
+		if request.Method != "events.subscribe" {
+			serverDone <- fmt.Errorf("method=%q", request.Method)
+			return
+		}
+		gotSubscriptions := make([]string, 0, len(request.Params.Subscriptions))
+		for _, subscription := range request.Params.Subscriptions {
+			gotSubscriptions = append(gotSubscriptions, subscription.Type)
+		}
+		if want := []string{"workspace.focused", "workspace.closed"}; !reflect.DeepEqual(gotSubscriptions, want) {
+			serverDone <- fmt.Errorf("subscriptions=%#v want %#v", gotSubscriptions, want)
+			return
+		}
+
+		enc := json.NewEncoder(conn)
+		messages := []any{
+			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
+			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "B"}},
+			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "C"}},
+			map[string]any{"event": "workspace_focused", "data": map[string]any{"type": "workspace_focused", "workspace_id": "D"}},
+		}
+		for _, message := range messages {
+			if err := enc.Encode(message); err != nil {
+				serverDone <- err
+				return
+			}
+		}
+
+		snapshotConn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		var snapshotRequest struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(snapshotConn).Decode(&snapshotRequest); err != nil {
+			_ = snapshotConn.Close()
+			serverDone <- err
+			return
+		}
+		if snapshotRequest.Method != "session.snapshot" {
+			_ = snapshotConn.Close()
+			serverDone <- fmt.Errorf("snapshot method=%q", snapshotRequest.Method)
+			return
+		}
+		if err := json.NewEncoder(snapshotConn).Encode(map[string]any{
+			"id": "herdr-sesh-history-snapshot",
+			"result": map[string]any{
+				"type":     "session_snapshot",
+				"snapshot": map[string]any{"focused_workspace_id": "D"},
+			},
+		}); err != nil {
+			_ = snapshotConn.Close()
+			serverDone <- err
+			return
+		}
+		if err := snapshotConn.Close(); err != nil {
+			serverDone <- err
+			return
+		}
+		close(snapshotSent)
+		if err := enc.Encode(map[string]any{"event": "workspace_closed", "data": map[string]any{"type": "workspace_closed", "workspace_id": "B"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}()
+
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
+	t.Setenv("HERDR_SOCKET_PATH", socketPath)
+	t.Setenv("HERDR_WORKSPACE_ID", "stale")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	watchDone := make(chan error, 1)
+	go func() { watchDone <- a.Run(ctx, []string{"plugin", "watch-history"}) }()
+	// Replayed events must wait for the history lock before the newer
+	// snapshot is installed.
+	time.Sleep(350 * time.Millisecond)
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-snapshotSent:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not request a snapshot after lock release")
+	}
+	want := []string{"D", "C", "A"}
+	deadline := time.Now().Add(time.Second)
+	for {
+		h, loadErr := state.LoadHistory(historyDir)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		if reflect.DeepEqual(h.Workspaces, want) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	if watchErr := <-watchDone; !errors.Is(watchErr, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", watchErr)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -1,0 +1,282 @@
+package herdr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	eventReconnectDelay = 100 * time.Millisecond
+	replayQuietPeriod   = 25 * time.Millisecond
+	replayDrainMax      = 150 * time.Millisecond
+	eventBufferSize     = 1024
+)
+
+type eventSubscription struct {
+	Type string `json:"type"`
+}
+
+type eventSubscribeRequest struct {
+	ID     string `json:"id"`
+	Method string `json:"method"`
+	Params struct {
+		Subscriptions []eventSubscription `json:"subscriptions"`
+	} `json:"params"`
+}
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type workspaceEvent struct {
+	Event string `json:"event"`
+	Data  struct {
+		WorkspaceID string `json:"workspace_id"`
+	} `json:"data"`
+}
+
+type sessionSnapshot struct {
+	FocusedWorkspaceID string
+	WorkspaceIDs       map[string]bool
+}
+
+func WatchWorkspaceEvents(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) error {
+	if socketPath == "" {
+		return errors.New("HERDR_SOCKET_PATH is required")
+	}
+	for {
+		reconnect, err := watchWorkspaceEventsOnce(ctx, socketPath, onFocused, onClosed)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !reconnect {
+			return err
+		}
+		timer := time.NewTimer(eventReconnectDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) (bool, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return true, fmt.Errorf("connect to Herdr event stream: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	stopClose := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopClose()
+
+	request := eventSubscribeRequest{ID: "herdr-sesh-history", Method: "events.subscribe"}
+	request.Params.Subscriptions = []eventSubscription{{Type: "workspace.focused"}, {Type: "workspace.closed"}}
+	if err := json.NewEncoder(conn).Encode(request); err != nil {
+		return true, fmt.Errorf("subscribe to Herdr workspace events: %w", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	var acknowledgement struct {
+		Result struct {
+			Type string `json:"type"`
+		} `json:"result"`
+		Error *apiError `json:"error"`
+	}
+	if err := decoder.Decode(&acknowledgement); err != nil {
+		return true, fmt.Errorf("read Herdr event subscription acknowledgement: %w", err)
+	}
+	if acknowledgement.Error != nil {
+		return false, fmt.Errorf("herdr event subscription failed: %s: %s", acknowledgement.Error.Code, acknowledgement.Error.Message)
+	}
+	if acknowledgement.Result.Type != "subscription_started" {
+		return false, fmt.Errorf("unexpected Herdr event subscription acknowledgement %q", acknowledgement.Result.Type)
+	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	events := make(chan workspaceEvent, eventBufferSize)
+	streamErrors := make(chan error, 1)
+	go decodeWorkspaceEvents(streamCtx, decoder, events, streamErrors)
+
+	replayed, err := drainRetainedReplay(ctx, events, streamErrors)
+	if err != nil {
+		return streamResult(ctx, err)
+	}
+	snapshot, err := loadSessionSnapshot(ctx, socketPath)
+	if err != nil {
+		return true, err
+	}
+	for _, event := range replayed {
+		// A close for an ID that still exists in the fresh snapshot came
+		// from Herdr 0.8.x retained history and must not prune current state.
+		if event.Event == "workspace_closed" && snapshot.WorkspaceIDs[event.Data.WorkspaceID] {
+			continue
+		}
+		if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
+			return false, err
+		}
+	}
+	if snapshot.FocusedWorkspaceID != "" {
+		if err := onFocused(snapshot.FocusedWorkspaceID); err != nil {
+			return false, err
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case err := <-streamErrors:
+			if drainErr := drainBufferedEvents(events, onFocused, onClosed); drainErr != nil {
+				return false, drainErr
+			}
+			return streamResult(ctx, err)
+		case event := <-events:
+			if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
+				return false, err
+			}
+		}
+	}
+}
+
+func decodeWorkspaceEvents(ctx context.Context, decoder *json.Decoder, events chan<- workspaceEvent, streamErrors chan<- error) {
+	for {
+		var event workspaceEvent
+		if err := decoder.Decode(&event); err != nil {
+			select {
+			case streamErrors <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+		if event.Data.WorkspaceID == "" || (event.Event != "workspace_focused" && event.Event != "workspace_closed") {
+			continue
+		}
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func drainRetainedReplay(ctx context.Context, events <-chan workspaceEvent, streamErrors <-chan error) ([]workspaceEvent, error) {
+	quiet := time.NewTimer(replayQuietPeriod)
+	defer quiet.Stop()
+	maximum := time.NewTimer(replayDrainMax)
+	defer maximum.Stop()
+	var replayed []workspaceEvent
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err := <-streamErrors:
+			return nil, err
+		case event := <-events:
+			replayed = append(replayed, event)
+			if !quiet.Stop() {
+				select {
+				case <-quiet.C:
+				default:
+				}
+			}
+			quiet.Reset(replayQuietPeriod)
+		case <-quiet.C:
+			return replayed, nil
+		case <-maximum.C:
+			return replayed, nil
+		}
+	}
+}
+
+func drainBufferedEvents(events <-chan workspaceEvent, onFocused, onClosed func(string) error) error {
+	for {
+		select {
+		case event := <-events:
+			if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
+				return err
+			}
+		default:
+			return nil
+		}
+	}
+}
+
+func applyWorkspaceEvent(event workspaceEvent, onFocused, onClosed func(string) error) error {
+	switch event.Event {
+	case "workspace_focused":
+		return onFocused(event.Data.WorkspaceID)
+	case "workspace_closed":
+		return onClosed(event.Data.WorkspaceID)
+	default:
+		return nil
+	}
+}
+
+func streamResult(ctx context.Context, err error) (bool, error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, fmt.Errorf("watch Herdr workspace events: %w", ctxErr)
+	}
+	if errors.Is(err, io.EOF) {
+		err = io.ErrUnexpectedEOF
+	}
+	return true, fmt.Errorf("read Herdr workspace event: %w", err)
+}
+
+func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapshot, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return sessionSnapshot{}, fmt.Errorf("connect to Herdr session snapshot: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	stopClose := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopClose()
+
+	request := struct {
+		ID     string   `json:"id"`
+		Method string   `json:"method"`
+		Params struct{} `json:"params"`
+	}{ID: "herdr-sesh-history-snapshot", Method: "session.snapshot"}
+	if err := json.NewEncoder(conn).Encode(request); err != nil {
+		return sessionSnapshot{}, fmt.Errorf("request Herdr session snapshot: %w", err)
+	}
+	var response struct {
+		Result struct {
+			Type     string `json:"type"`
+			Snapshot struct {
+				FocusedWorkspaceID string `json:"focused_workspace_id"`
+				Workspaces         []struct {
+					WorkspaceID string `json:"workspace_id"`
+				} `json:"workspaces"`
+			} `json:"snapshot"`
+		} `json:"result"`
+		Error *apiError `json:"error"`
+	}
+	if err := json.NewDecoder(conn).Decode(&response); err != nil {
+		return sessionSnapshot{}, fmt.Errorf("read Herdr session snapshot: %w", err)
+	}
+	if response.Error != nil {
+		return sessionSnapshot{}, fmt.Errorf("herdr session snapshot failed: %s: %s", response.Error.Code, response.Error.Message)
+	}
+	if response.Result.Type != "session_snapshot" {
+		return sessionSnapshot{}, fmt.Errorf("unexpected Herdr session snapshot response %q", response.Result.Type)
+	}
+	snapshot := sessionSnapshot{
+		FocusedWorkspaceID: response.Result.Snapshot.FocusedWorkspaceID,
+		WorkspaceIDs:       make(map[string]bool, len(response.Result.Snapshot.Workspaces)),
+	}
+	for _, workspace := range response.Result.Snapshot.Workspaces {
+		snapshot.WorkspaceIDs[workspace.WorkspaceID] = true
+	}
+	return snapshot, nil
+}

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -12,9 +12,9 @@ import (
 
 const (
 	eventReconnectDelay = 100 * time.Millisecond
-	replayQuietPeriod   = 25 * time.Millisecond
-	replayDrainMax      = 150 * time.Millisecond
 	eventBufferSize     = 1024
+	// Protocol 21 starts lifecycle subscriptions at the current EventHub sequence.
+	minimumEventProtocol = 21
 )
 
 type eventSubscription struct {
@@ -43,7 +43,6 @@ type workspaceEvent struct {
 
 type sessionSnapshot struct {
 	FocusedWorkspaceID string
-	WorkspaceIDs       map[string]bool
 }
 
 func WatchWorkspaceEvents(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) error {
@@ -71,6 +70,14 @@ func WatchWorkspaceEvents(ctx context.Context, socketPath string, onFocused, onC
 }
 
 func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) (bool, error) {
+	protocol, err := loadServerProtocol(ctx, socketPath)
+	if err != nil {
+		return true, err
+	}
+	if protocol < minimumEventProtocol {
+		return false, fmt.Errorf("workspace history requires Herdr protocol %d or newer; server uses protocol %d", minimumEventProtocol, protocol)
+	}
+
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		return true, fmt.Errorf("connect to Herdr event stream: %w", err)
@@ -108,23 +115,9 @@ func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused,
 	streamErrors := make(chan error, 1)
 	go decodeWorkspaceEvents(streamCtx, decoder, events, streamErrors)
 
-	replayed, err := drainRetainedReplay(ctx, events, streamErrors)
-	if err != nil {
-		return streamResult(ctx, err)
-	}
 	snapshot, err := loadSessionSnapshot(ctx, socketPath)
 	if err != nil {
 		return true, err
-	}
-	for _, event := range replayed {
-		// A close for an ID that still exists in the fresh snapshot came
-		// from Herdr 0.8.x retained history and must not prune current state.
-		if event.Event == "workspace_closed" && snapshot.WorkspaceIDs[event.Data.WorkspaceID] {
-			continue
-		}
-		if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
-			return false, err
-		}
 	}
 	if snapshot.FocusedWorkspaceID != "" {
 		if err := onFocused(snapshot.FocusedWorkspaceID); err != nil {
@@ -170,35 +163,6 @@ func decodeWorkspaceEvents(ctx context.Context, decoder *json.Decoder, events ch
 	}
 }
 
-func drainRetainedReplay(ctx context.Context, events <-chan workspaceEvent, streamErrors <-chan error) ([]workspaceEvent, error) {
-	quiet := time.NewTimer(replayQuietPeriod)
-	defer quiet.Stop()
-	maximum := time.NewTimer(replayDrainMax)
-	defer maximum.Stop()
-	var replayed []workspaceEvent
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case err := <-streamErrors:
-			return nil, err
-		case event := <-events:
-			replayed = append(replayed, event)
-			if !quiet.Stop() {
-				select {
-				case <-quiet.C:
-				default:
-				}
-			}
-			quiet.Reset(replayQuietPeriod)
-		case <-quiet.C:
-			return replayed, nil
-		case <-maximum.C:
-			return replayed, nil
-		}
-	}
-}
-
 func drainBufferedEvents(events <-chan workspaceEvent, onFocused, onClosed func(string) error) error {
 	for {
 		select {
@@ -233,6 +197,42 @@ func streamResult(ctx context.Context, err error) (bool, error) {
 	return true, fmt.Errorf("read Herdr workspace event: %w", err)
 }
 
+func loadServerProtocol(ctx context.Context, socketPath string) (int, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return 0, fmt.Errorf("connect to Herdr server: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	stopClose := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopClose()
+
+	request := struct {
+		ID     string   `json:"id"`
+		Method string   `json:"method"`
+		Params struct{} `json:"params"`
+	}{ID: "herdr-sesh-history-ping", Method: "ping"}
+	if err := json.NewEncoder(conn).Encode(request); err != nil {
+		return 0, fmt.Errorf("ping Herdr server: %w", err)
+	}
+	var response struct {
+		Result struct {
+			Type     string `json:"type"`
+			Protocol int    `json:"protocol"`
+		} `json:"result"`
+		Error *apiError `json:"error"`
+	}
+	if err := json.NewDecoder(conn).Decode(&response); err != nil {
+		return 0, fmt.Errorf("read Herdr ping response: %w", err)
+	}
+	if response.Error != nil {
+		return 0, fmt.Errorf("herdr ping failed: %s: %s", response.Error.Code, response.Error.Message)
+	}
+	if response.Result.Type != "pong" {
+		return 0, fmt.Errorf("unexpected Herdr ping response %q", response.Result.Type)
+	}
+	return response.Result.Protocol, nil
+}
+
 func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapshot, error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
@@ -255,9 +255,6 @@ func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapsho
 			Type     string `json:"type"`
 			Snapshot struct {
 				FocusedWorkspaceID string `json:"focused_workspace_id"`
-				Workspaces         []struct {
-					WorkspaceID string `json:"workspace_id"`
-				} `json:"workspaces"`
 			} `json:"snapshot"`
 		} `json:"result"`
 		Error *apiError `json:"error"`
@@ -271,12 +268,5 @@ func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapsho
 	if response.Result.Type != "session_snapshot" {
 		return sessionSnapshot{}, fmt.Errorf("unexpected Herdr session snapshot response %q", response.Result.Type)
 	}
-	snapshot := sessionSnapshot{
-		FocusedWorkspaceID: response.Result.Snapshot.FocusedWorkspaceID,
-		WorkspaceIDs:       make(map[string]bool, len(response.Result.Snapshot.Workspaces)),
-	}
-	for _, workspace := range response.Result.Snapshot.Workspaces {
-		snapshot.WorkspaceIDs[workspace.WorkspaceID] = true
-	}
-	return snapshot, nil
+	return sessionSnapshot{FocusedWorkspaceID: response.Result.Snapshot.FocusedWorkspaceID}, nil
 }

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	eventReconnectDelay  = 100 * time.Millisecond
-	replayQuietPeriod    = 25 * time.Millisecond
 	eventBufferSize      = 1024
 	minimumEventProtocol = 20
 	// Protocol 21 starts lifecycle subscriptions at the current EventHub sequence.
@@ -118,31 +117,28 @@ func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused,
 	streamErrors := make(chan error, 1)
 	go decodeWorkspaceEvents(streamCtx, decoder, events, streamErrors)
 
-	var replayed []workspaceEvent
-	if protocol < liveOnlyEventProtocol {
-		replayed, err = drainRetainedReplay(ctx, events, streamErrors)
-		if err != nil {
-			return streamResult(ctx, err)
-		}
-	}
 	snapshot, err := loadSessionSnapshot(ctx, socketPath)
 	if err != nil {
 		return true, err
-	}
-	for _, event := range replayed {
-		// Protocol 20 replays retained history to a new subscription. Ignore a
-		// stale close when the fresh snapshot shows that workspace still exists.
-		if event.Event == "workspace_closed" && snapshot.WorkspaceIDs[event.Data.WorkspaceID] {
-			continue
-		}
-		if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
-			return false, err
-		}
 	}
 	if snapshot.FocusedWorkspaceID != "" {
 		if err := onFocused(snapshot.FocusedWorkspaceID); err != nil {
 			return false, err
 		}
+	}
+	applyEvents := func(events []workspaceEvent) (bool, error) {
+		if len(events) == 0 {
+			return false, nil
+		}
+		var current *sessionSnapshot
+		if protocol < liveOnlyEventProtocol {
+			snapshot, err := loadSessionSnapshot(ctx, socketPath)
+			if err != nil {
+				return true, err
+			}
+			current = &snapshot
+		}
+		return false, applyWorkspaceEvents(events, current, onFocused, onClosed)
 	}
 
 	for {
@@ -150,13 +146,13 @@ func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused,
 		case <-ctx.Done():
 			return false, ctx.Err()
 		case err := <-streamErrors:
-			if drainErr := drainBufferedEvents(events, onFocused, onClosed); drainErr != nil {
-				return false, drainErr
+			if reconnect, drainErr := applyEvents(drainBufferedEvents(events, nil)); drainErr != nil {
+				return reconnect, drainErr
 			}
 			return streamResult(ctx, err)
 		case event := <-events:
-			if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
-				return false, err
+			if reconnect, err := applyEvents(drainBufferedEvents(events, []workspaceEvent{event})); err != nil {
+				return reconnect, err
 			}
 		}
 	}
@@ -183,42 +179,33 @@ func decodeWorkspaceEvents(ctx context.Context, decoder *json.Decoder, events ch
 	}
 }
 
-func drainRetainedReplay(ctx context.Context, events <-chan workspaceEvent, streamErrors <-chan error) ([]workspaceEvent, error) {
-	quiet := time.NewTimer(replayQuietPeriod)
-	defer quiet.Stop()
-	var replayed []workspaceEvent
+func drainBufferedEvents(events <-chan workspaceEvent, buffered []workspaceEvent) []workspaceEvent {
 	for {
 		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case err := <-streamErrors:
-			return nil, err
 		case event := <-events:
-			replayed = append(replayed, event)
-			if !quiet.Stop() {
-				select {
-				case <-quiet.C:
-				default:
-				}
-			}
-			quiet.Reset(replayQuietPeriod)
-		case <-quiet.C:
-			return replayed, nil
+			buffered = append(buffered, event)
+		default:
+			return buffered
 		}
 	}
 }
 
-func drainBufferedEvents(events <-chan workspaceEvent, onFocused, onClosed func(string) error) error {
-	for {
-		select {
-		case event := <-events:
-			if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
-				return err
+func applyWorkspaceEvents(events []workspaceEvent, snapshot *sessionSnapshot, onFocused, onClosed func(string) error) error {
+	for _, event := range events {
+		if snapshot != nil {
+			exists := snapshot.WorkspaceIDs[event.Data.WorkspaceID]
+			if (event.Event == "workspace_focused" && !exists) || (event.Event == "workspace_closed" && exists) {
+				continue
 			}
-		default:
-			return nil
+		}
+		if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
+			return err
 		}
 	}
+	if snapshot != nil && snapshot.FocusedWorkspaceID != "" {
+		return onFocused(snapshot.FocusedWorkspaceID)
+	}
+	return nil
 }
 
 func applyWorkspaceEvent(event workspaceEvent, onFocused, onClosed func(string) error) error {

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -72,14 +72,7 @@ func WatchWorkspaceEvents(ctx context.Context, socketPath string, onFocused, onC
 }
 
 func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) (bool, error) {
-	protocol, err := loadServerProtocol(ctx, socketPath)
-	if err != nil {
-		return true, err
-	}
-	if protocol < minimumEventProtocol {
-		return false, fmt.Errorf("workspace history requires Herdr protocol %d or newer; server uses protocol %d", minimumEventProtocol, protocol)
-	}
-
+	// Protocol 21 does not replay, so start buffering before any other request.
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		return true, fmt.Errorf("connect to Herdr event stream: %w", err)
@@ -116,6 +109,14 @@ func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused,
 	events := make(chan workspaceEvent, eventBufferSize)
 	streamErrors := make(chan error, 1)
 	go decodeWorkspaceEvents(streamCtx, decoder, events, streamErrors)
+
+	protocol, err := loadServerProtocol(ctx, socketPath)
+	if err != nil {
+		return true, err
+	}
+	if protocol < minimumEventProtocol {
+		return false, fmt.Errorf("workspace history requires Herdr protocol %d or newer; server uses protocol %d", minimumEventProtocol, protocol)
+	}
 
 	snapshot, err := loadSessionSnapshot(ctx, socketPath)
 	if err != nil {

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -11,10 +11,12 @@ import (
 )
 
 const (
-	eventReconnectDelay = 100 * time.Millisecond
-	eventBufferSize     = 1024
+	eventReconnectDelay  = 100 * time.Millisecond
+	replayQuietPeriod    = 25 * time.Millisecond
+	eventBufferSize      = 1024
+	minimumEventProtocol = 20
 	// Protocol 21 starts lifecycle subscriptions at the current EventHub sequence.
-	minimumEventProtocol = 21
+	liveOnlyEventProtocol = 21
 )
 
 type eventSubscription struct {
@@ -43,6 +45,7 @@ type workspaceEvent struct {
 
 type sessionSnapshot struct {
 	FocusedWorkspaceID string
+	WorkspaceIDs       map[string]bool
 }
 
 func WatchWorkspaceEvents(ctx context.Context, socketPath string, onFocused, onClosed func(string) error) error {
@@ -115,9 +118,26 @@ func watchWorkspaceEventsOnce(ctx context.Context, socketPath string, onFocused,
 	streamErrors := make(chan error, 1)
 	go decodeWorkspaceEvents(streamCtx, decoder, events, streamErrors)
 
+	var replayed []workspaceEvent
+	if protocol < liveOnlyEventProtocol {
+		replayed, err = drainRetainedReplay(ctx, events, streamErrors)
+		if err != nil {
+			return streamResult(ctx, err)
+		}
+	}
 	snapshot, err := loadSessionSnapshot(ctx, socketPath)
 	if err != nil {
 		return true, err
+	}
+	for _, event := range replayed {
+		// Protocol 20 replays retained history to a new subscription. Ignore a
+		// stale close when the fresh snapshot shows that workspace still exists.
+		if event.Event == "workspace_closed" && snapshot.WorkspaceIDs[event.Data.WorkspaceID] {
+			continue
+		}
+		if err := applyWorkspaceEvent(event, onFocused, onClosed); err != nil {
+			return false, err
+		}
 	}
 	if snapshot.FocusedWorkspaceID != "" {
 		if err := onFocused(snapshot.FocusedWorkspaceID); err != nil {
@@ -159,6 +179,31 @@ func decodeWorkspaceEvents(ctx context.Context, decoder *json.Decoder, events ch
 		case events <- event:
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+func drainRetainedReplay(ctx context.Context, events <-chan workspaceEvent, streamErrors <-chan error) ([]workspaceEvent, error) {
+	quiet := time.NewTimer(replayQuietPeriod)
+	defer quiet.Stop()
+	var replayed []workspaceEvent
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err := <-streamErrors:
+			return nil, err
+		case event := <-events:
+			replayed = append(replayed, event)
+			if !quiet.Stop() {
+				select {
+				case <-quiet.C:
+				default:
+				}
+			}
+			quiet.Reset(replayQuietPeriod)
+		case <-quiet.C:
+			return replayed, nil
 		}
 	}
 }
@@ -255,6 +300,9 @@ func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapsho
 			Type     string `json:"type"`
 			Snapshot struct {
 				FocusedWorkspaceID string `json:"focused_workspace_id"`
+				Workspaces         []struct {
+					WorkspaceID string `json:"workspace_id"`
+				} `json:"workspaces"`
 			} `json:"snapshot"`
 		} `json:"result"`
 		Error *apiError `json:"error"`
@@ -268,5 +316,12 @@ func loadSessionSnapshot(ctx context.Context, socketPath string) (sessionSnapsho
 	if response.Result.Type != "session_snapshot" {
 		return sessionSnapshot{}, fmt.Errorf("unexpected Herdr session snapshot response %q", response.Result.Type)
 	}
-	return sessionSnapshot{FocusedWorkspaceID: response.Result.Snapshot.FocusedWorkspaceID}, nil
+	snapshot := sessionSnapshot{
+		FocusedWorkspaceID: response.Result.Snapshot.FocusedWorkspaceID,
+		WorkspaceIDs:       make(map[string]bool, len(response.Result.Snapshot.Workspaces)),
+	}
+	for _, workspace := range response.Result.Snapshot.Workspaces {
+		snapshot.WorkspaceIDs[workspace.WorkspaceID] = true
+	}
+	return snapshot, nil
 }

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -14,11 +14,11 @@ import (
 	"time"
 )
 
-func TestWatchWorkspaceEventsReconcilesProtocol20ReplayBeforeSnapshot(t *testing.T) {
+func TestWatchWorkspaceEventsReconcilesDelayedProtocol20Replay(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveCompatiblePing(listener); err != nil {
+		if err := serveCompatiblePing(listener, 20); err != nil {
 			serverDone <- err
 			return
 		}
@@ -27,126 +27,131 @@ func TestWatchWorkspaceEventsReconcilesProtocol20ReplayBeforeSnapshot(t *testing
 			serverDone <- err
 			return
 		}
-		defer func() { _ = stream.Close() }()
-		enc := json.NewEncoder(stream)
-		for _, message := range []any{
-			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
-			workspaceEventMessage("workspace_focused", "stale"),
-			workspaceEventMessage("workspace_closed", "gone"),
-			workspaceEventMessage("workspace_closed", "still-open"),
-		} {
-			if err := enc.Encode(message); err != nil {
-				serverDone <- err
-				return
-			}
-		}
-
-		snapshot, err := acceptRequest(listener, "session.snapshot")
-		if err != nil {
-			serverDone <- err
-			return
-		}
-		defer func() { _ = snapshot.Close() }()
-		if err := enc.Encode(workspaceEventMessage("workspace_focused", "live")); err != nil {
-			serverDone <- err
-			return
-		}
-		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("snapshot", "snapshot", "still-open"))
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	var got []string
-	record := func(kind, id string) error {
-		got = append(got, kind+":"+id)
-		if kind == "focus" && id == "live" {
-			cancel()
-		}
-		return nil
-	}
-	err := WatchWorkspaceEvents(ctx, socketPath,
-		func(id string) error { return record("focus", id) },
-		func(id string) error { return record("close", id) },
-	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"focus:stale", "close:gone", "focus:snapshot", "focus:live"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("mutations=%#v want %#v", got, want)
-	}
-}
-
-func TestWatchWorkspaceEventsWaitsForCompleteProtocol20ReplayBeforePublishingHistory(t *testing.T) {
-	listener, socketPath := listenTestSocket(t)
-	replayDone := make(chan struct{})
-	serverDone := make(chan error, 1)
-	go func() {
-		if err := serveCompatiblePing(listener); err != nil {
-			serverDone <- err
-			return
-		}
-		stream, err := acceptRequest(listener, "events.subscribe")
-		if err != nil {
-			serverDone <- err
-			return
-		}
-		defer func() { _ = stream.Close() }()
 		enc := json.NewEncoder(stream)
 		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			_ = stream.Close()
 			serverDone <- err
 			return
 		}
-
-		replayErr := make(chan error, 1)
-		go func() {
-			for i := 0; i < 10; i++ {
-				if err := enc.Encode(workspaceEventMessage("workspace_focused", fmt.Sprintf("stale-%d", i))); err != nil {
-					replayErr <- err
-					return
-				}
-				time.Sleep(20 * time.Millisecond)
-			}
-			close(replayDone)
-			replayErr <- nil
-		}()
+		if err := enc.Encode(workspaceEventMessage("workspace_focused", "older")); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
 
 		snapshot, err := acceptRequest(listener, "session.snapshot")
 		if err != nil {
+			_ = stream.Close()
 			serverDone <- err
 			return
 		}
-		if err := json.NewEncoder(snapshot).Encode(snapshotResponse("current", "current")); err != nil {
+		if err := json.NewEncoder(snapshot).Encode(snapshotResponse("current", "current", "older", "previous")); err != nil {
 			_ = snapshot.Close()
+			_ = stream.Close()
 			serverDone <- err
 			return
 		}
 		_ = snapshot.Close()
-		serverDone <- <-replayErr
+
+		// Protocol 20 can deliver another retained event after the initial
+		// snapshot with no replay-boundary marker.
+		if err := enc.Encode(workspaceEventMessage("workspace_focused", "previous")); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
+		if err := enc.Encode(workspaceEventMessage("workspace_closed", "current")); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
+		_ = stream.Close()
+		serverDone <- serveProtocol20Snapshots(listener, "current", "current", "older", "previous")
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	record := func(id string) error {
-		select {
-		case <-replayDone:
-		default:
-			return errors.New("history published before retained replay finished")
-		}
-		if id == "current" {
-			cancel()
-		}
-		return nil
-	}
-	err := WatchWorkspaceEvents(ctx, socketPath, record, func(string) error { return nil })
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation after complete replay", err)
+	var history []string
+	reconnect, err := watchWorkspaceEventsOnce(ctx, socketPath,
+		func(id string) error {
+			history = recordHistoryVisit(history, id)
+			return nil
+		},
+		func(id string) error {
+			history = removeHistoryWorkspace(history, id)
+			return nil
+		},
+	)
+	_ = listener.Close()
+	if !reconnect || err == nil {
+		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatal(err)
+	}
+	want := []string{"current", "previous", "older"}
+	if !reflect.DeepEqual(history, want) {
+		t.Fatalf("history=%#v want %#v", history, want)
+	}
+}
+
+func TestWatchWorkspaceEventsPreservesInterruptedProtocol20Replay(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := serveCompatiblePing(listener, 20); err != nil {
+			serverDone <- err
+			return
+		}
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		enc := json.NewEncoder(stream)
+		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
+		for _, event := range []map[string]any{
+			workspaceEventMessage("workspace_focused", "older"),
+			workspaceEventMessage("workspace_focused", "previous"),
+			workspaceEventMessage("workspace_closed", "current"),
+		} {
+			if err := enc.Encode(event); err != nil {
+				_ = stream.Close()
+				serverDone <- err
+				return
+			}
+		}
+		_ = stream.Close()
+		serverDone <- serveProtocol20Snapshots(listener, "current", "current", "older", "previous")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var history []string
+	reconnect, err := watchWorkspaceEventsOnce(ctx, socketPath,
+		func(id string) error {
+			history = recordHistoryVisit(history, id)
+			return nil
+		},
+		func(id string) error {
+			history = removeHistoryWorkspace(history, id)
+			return nil
+		},
+	)
+	_ = listener.Close()
+	if !reconnect || err == nil {
+		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"current", "previous", "older"}
+	if !reflect.DeepEqual(history, want) {
+		t.Fatalf("history=%#v want %#v", history, want)
 	}
 }
 
@@ -183,7 +188,7 @@ func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveCompatiblePing(listener); err != nil {
+		if err := serveCompatiblePing(listener, 21); err != nil {
 			serverDone <- err
 			return
 		}
@@ -240,7 +245,7 @@ func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
 	serverDone := make(chan error, 1)
 	go func() {
 		for attempt := 0; attempt < 2; attempt++ {
-			if err := serveCompatiblePing(listener); err != nil {
+			if err := serveCompatiblePing(listener, 21); err != nil {
 				serverDone <- err
 				return
 			}
@@ -346,7 +351,7 @@ func acceptRequest(listener net.Listener, method string) (net.Conn, error) {
 	return conn, nil
 }
 
-func serveCompatiblePing(listener net.Listener) error {
+func serveCompatiblePing(listener net.Listener, protocol int) error {
 	conn, err := acceptRequest(listener, "ping")
 	if err != nil {
 		return err
@@ -355,7 +360,7 @@ func serveCompatiblePing(listener net.Listener) error {
 	return json.NewEncoder(conn).Encode(map[string]any{
 		"id": "herdr-sesh-history-ping",
 		"result": map[string]any{
-			"type": "pong", "version": "0.8.2", "protocol": 20,
+			"type": "pong", "version": "compatible", "protocol": protocol,
 		},
 	})
 }
@@ -379,4 +384,41 @@ func snapshotResponse(focusedWorkspaceID string, workspaceIDs ...string) map[str
 			},
 		},
 	}
+}
+
+func serveProtocol20Snapshots(listener net.Listener, focusedWorkspaceID string, workspaceIDs ...string) error {
+	for {
+		conn, err := acceptRequest(listener, "session.snapshot")
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		err = json.NewEncoder(conn).Encode(snapshotResponse(focusedWorkspaceID, workspaceIDs...))
+		_ = conn.Close()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func recordHistoryVisit(history []string, workspaceID string) []string {
+	next := []string{workspaceID}
+	for _, existing := range history {
+		if existing != workspaceID {
+			next = append(next, existing)
+		}
+	}
+	return next
+}
+
+func removeHistoryWorkspace(history []string, workspaceID string) []string {
+	next := history[:0]
+	for _, existing := range history {
+		if existing != workspaceID {
+			next = append(next, existing)
+		}
+	}
+	return next
 }

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -9,77 +9,37 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sync"
+	"strings"
 	"testing"
 	"time"
 )
 
-func TestWatchWorkspaceEventsReconcilesRetainedReplayBeforeSnapshot(t *testing.T) {
+func TestWatchWorkspaceEventsRejectsRetainedReplayProtocol(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		stream, err := acceptRequest(listener, "events.subscribe")
+		conn, err := acceptRequest(listener, "ping")
 		if err != nil {
 			serverDone <- err
 			return
 		}
-		defer func() { _ = stream.Close() }()
-		enc := json.NewEncoder(stream)
-		for _, message := range []any{
-			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
-			workspaceEventMessage("workspace_focused", "stale"),
-			workspaceEventMessage("workspace_closed", "gone"),
-			workspaceEventMessage("workspace_closed", "still-open"),
-		} {
-			if err := enc.Encode(message); err != nil {
-				serverDone <- err
-				return
-			}
-		}
-
-		snapshot, err := acceptRequest(listener, "session.snapshot")
-		if err != nil {
-			serverDone <- err
-			return
-		}
-		defer func() { _ = snapshot.Close() }()
-		// This event occurs after snapshot acquisition starts. It must be
-		// applied after the snapshot rather than discarded with old replay.
-		if err := enc.Encode(workspaceEventMessage("workspace_focused", "live")); err != nil {
-			serverDone <- err
-			return
-		}
-		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("snapshot", "snapshot", "still-open"))
+		defer func() { _ = conn.Close() }()
+		serverDone <- json.NewEncoder(conn).Encode(map[string]any{
+			"id": "herdr-sesh-history-ping",
+			"result": map[string]any{
+				"type": "pong", "version": "0.8.2", "protocol": 20,
+			},
+		})
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	var mu sync.Mutex
-	var got []string
-	record := func(kind, id string) error {
-		mu.Lock()
-		got = append(got, kind+":"+id)
-		if kind == "focus" && id == "live" {
-			cancel()
-		}
-		mu.Unlock()
-		return nil
-	}
-	err := WatchWorkspaceEvents(ctx, socketPath,
-		func(id string) error { return record("focus", id) },
-		func(id string) error { return record("close", id) },
-	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", err)
+	err := WatchWorkspaceEvents(ctx, socketPath, func(string) error { return nil }, func(string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "requires Herdr protocol 21") {
+		t.Fatalf("watch error=%v, want protocol 21 requirement", err)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatal(err)
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	want := []string{"focus:stale", "close:gone", "focus:snapshot", "focus:live"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("mutations=%#v want %#v", got, want)
 	}
 }
 
@@ -87,6 +47,10 @@ func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
+		if err := serveCompatiblePing(listener); err != nil {
+			serverDone <- err
+			return
+		}
 		stream, err := acceptRequest(listener, "events.subscribe")
 		if err != nil {
 			serverDone <- err
@@ -140,6 +104,10 @@ func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
 	serverDone := make(chan error, 1)
 	go func() {
 		for attempt := 0; attempt < 2; attempt++ {
+			if err := serveCompatiblePing(listener); err != nil {
+				serverDone <- err
+				return
+			}
 			stream, err := acceptRequest(listener, "events.subscribe")
 			if err != nil {
 				serverDone <- err
@@ -240,6 +208,20 @@ func acceptRequest(listener net.Listener, method string) (net.Conn, error) {
 		return nil, fmt.Errorf("method=%q want %q", request.Method, method)
 	}
 	return conn, nil
+}
+
+func serveCompatiblePing(listener net.Listener) error {
+	conn, err := acceptRequest(listener, "ping")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	return json.NewEncoder(conn).Encode(map[string]any{
+		"id": "herdr-sesh-history-ping",
+		"result": map[string]any{
+			"type": "pong", "version": "0.8.2-preview", "protocol": 21,
+		},
+	})
 }
 
 func workspaceEventMessage(event, workspaceID string) map[string]any {

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -18,10 +18,6 @@ func TestWatchWorkspaceEventsReconcilesDelayedProtocol20Replay(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveCompatiblePing(listener, 20); err != nil {
-			serverDone <- err
-			return
-		}
 		stream, err := acceptRequest(listener, "events.subscribe")
 		if err != nil {
 			serverDone <- err
@@ -34,6 +30,11 @@ func TestWatchWorkspaceEventsReconcilesDelayedProtocol20Replay(t *testing.T) {
 			return
 		}
 		if err := enc.Encode(workspaceEventMessage("workspace_focused", "older")); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
+		if err := serveCompatiblePing(listener, 20); err != nil {
 			_ = stream.Close()
 			serverDone <- err
 			return
@@ -99,10 +100,6 @@ func TestWatchWorkspaceEventsPreservesInterruptedProtocol20Replay(t *testing.T) 
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveCompatiblePing(listener, 20); err != nil {
-			serverDone <- err
-			return
-		}
 		stream, err := acceptRequest(listener, "events.subscribe")
 		if err != nil {
 			serverDone <- err
@@ -110,6 +107,11 @@ func TestWatchWorkspaceEventsPreservesInterruptedProtocol20Replay(t *testing.T) 
 		}
 		enc := json.NewEncoder(stream)
 		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			_ = stream.Close()
+			serverDone <- err
+			return
+		}
+		if err := serveCompatiblePing(listener, 20); err != nil {
 			_ = stream.Close()
 			serverDone <- err
 			return
@@ -159,6 +161,18 @@ func TestWatchWorkspaceEventsRejectsPreSubscriptionProtocol(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		if err := json.NewEncoder(stream).Encode(map[string]any{
+			"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
+		}); err != nil {
+			serverDone <- err
+			return
+		}
 		conn, err := acceptRequest(listener, "ping")
 		if err != nil {
 			serverDone <- err
@@ -184,14 +198,105 @@ func TestWatchWorkspaceEventsRejectsPreSubscriptionProtocol(t *testing.T) {
 	}
 }
 
+func TestWatchWorkspaceEventsBuffersProtocol21EventsDuringProtocolProbe(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		first, method, err := acceptAnyRequest(listener)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		var stream net.Conn
+		switch method {
+		case "events.subscribe":
+			stream = first
+			if err := json.NewEncoder(stream).Encode(map[string]any{
+				"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
+			}); err != nil {
+				serverDone <- err
+				return
+			}
+			ping, err := acceptRequest(listener, "ping")
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			for _, workspaceID := range []string{"B", "C"} {
+				if err := json.NewEncoder(stream).Encode(workspaceEventMessage("workspace_focused", workspaceID)); err != nil {
+					_ = ping.Close()
+					serverDone <- err
+					return
+				}
+			}
+			if err := encodeCompatiblePing(ping, 21); err != nil {
+				_ = ping.Close()
+				serverDone <- err
+				return
+			}
+			_ = ping.Close()
+		case "ping":
+			if err := encodeCompatiblePing(first, 21); err != nil {
+				_ = first.Close()
+				serverDone <- err
+				return
+			}
+			_ = first.Close()
+			stream, err = acceptRequest(listener, "events.subscribe")
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			if err := json.NewEncoder(stream).Encode(map[string]any{
+				"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"},
+			}); err != nil {
+				serverDone <- err
+				return
+			}
+		default:
+			_ = first.Close()
+			serverDone <- fmt.Errorf("first method=%q want events.subscribe or ping", method)
+			return
+		}
+		defer func() { _ = stream.Close() }()
+
+		snapshot, err := acceptRequest(listener, "session.snapshot")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("C", "B", "C"))
+		_ = snapshot.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	history := []string{"A"}
+	reconnect, err := watchWorkspaceEventsOnce(ctx, socketPath,
+		func(id string) error {
+			history = recordHistoryVisit(history, id)
+			return nil
+		},
+		func(id string) error {
+			history = removeHistoryWorkspace(history, id)
+			return nil
+		},
+	)
+	if !reconnect || err == nil {
+		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"C", "B", "A"}; !reflect.DeepEqual(history, want) {
+		t.Fatalf("history=%#v want %#v", history, want)
+	}
+}
+
 func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
-		if err := serveCompatiblePing(listener, 21); err != nil {
-			serverDone <- err
-			return
-		}
 		stream, err := acceptRequest(listener, "events.subscribe")
 		if err != nil {
 			serverDone <- err
@@ -200,6 +305,10 @@ func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
 		defer func() { _ = stream.Close() }()
 		enc := json.NewEncoder(stream)
 		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		if err := serveCompatiblePing(listener, 21); err != nil {
 			serverDone <- err
 			return
 		}
@@ -245,10 +354,6 @@ func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
 	serverDone := make(chan error, 1)
 	go func() {
 		for attempt := 0; attempt < 2; attempt++ {
-			if err := serveCompatiblePing(listener, 21); err != nil {
-				serverDone <- err
-				return
-			}
 			stream, err := acceptRequest(listener, "events.subscribe")
 			if err != nil {
 				serverDone <- err
@@ -256,6 +361,11 @@ func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
 			}
 			enc := json.NewEncoder(stream)
 			if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+				_ = stream.Close()
+				serverDone <- err
+				return
+			}
+			if err := serveCompatiblePing(listener, 21); err != nil {
 				_ = stream.Close()
 				serverDone <- err
 				return
@@ -333,22 +443,30 @@ func listenTestSocket(t *testing.T) (net.Listener, string) {
 }
 
 func acceptRequest(listener net.Listener, method string) (net.Conn, error) {
-	conn, err := listener.Accept()
+	conn, got, err := acceptAnyRequest(listener)
 	if err != nil {
 		return nil, err
+	}
+	if got != method {
+		_ = conn.Close()
+		return nil, fmt.Errorf("method=%q want %q", got, method)
+	}
+	return conn, nil
+}
+
+func acceptAnyRequest(listener net.Listener) (net.Conn, string, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, "", err
 	}
 	var request struct {
 		Method string `json:"method"`
 	}
 	if err := json.NewDecoder(conn).Decode(&request); err != nil {
 		_ = conn.Close()
-		return nil, err
+		return nil, "", err
 	}
-	if request.Method != method {
-		_ = conn.Close()
-		return nil, fmt.Errorf("method=%q want %q", request.Method, method)
-	}
-	return conn, nil
+	return conn, request.Method, nil
 }
 
 func serveCompatiblePing(listener net.Listener, protocol int) error {
@@ -357,6 +475,10 @@ func serveCompatiblePing(listener net.Listener, protocol int) error {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
+	return encodeCompatiblePing(conn, protocol)
+}
+
+func encodeCompatiblePing(conn net.Conn, protocol int) error {
 	return json.NewEncoder(conn).Encode(map[string]any{
 		"id": "herdr-sesh-history-ping",
 		"result": map[string]any{

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -14,7 +14,143 @@ import (
 	"time"
 )
 
-func TestWatchWorkspaceEventsRejectsRetainedReplayProtocol(t *testing.T) {
+func TestWatchWorkspaceEventsReconcilesProtocol20ReplayBeforeSnapshot(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := serveCompatiblePing(listener); err != nil {
+			serverDone <- err
+			return
+		}
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		enc := json.NewEncoder(stream)
+		for _, message := range []any{
+			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
+			workspaceEventMessage("workspace_focused", "stale"),
+			workspaceEventMessage("workspace_closed", "gone"),
+			workspaceEventMessage("workspace_closed", "still-open"),
+		} {
+			if err := enc.Encode(message); err != nil {
+				serverDone <- err
+				return
+			}
+		}
+
+		snapshot, err := acceptRequest(listener, "session.snapshot")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = snapshot.Close() }()
+		if err := enc.Encode(workspaceEventMessage("workspace_focused", "live")); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("snapshot", "snapshot", "still-open"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var got []string
+	record := func(kind, id string) error {
+		got = append(got, kind+":"+id)
+		if kind == "focus" && id == "live" {
+			cancel()
+		}
+		return nil
+	}
+	err := WatchWorkspaceEvents(ctx, socketPath,
+		func(id string) error { return record("focus", id) },
+		func(id string) error { return record("close", id) },
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"focus:stale", "close:gone", "focus:snapshot", "focus:live"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutations=%#v want %#v", got, want)
+	}
+}
+
+func TestWatchWorkspaceEventsWaitsForCompleteProtocol20ReplayBeforePublishingHistory(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	replayDone := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := serveCompatiblePing(listener); err != nil {
+			serverDone <- err
+			return
+		}
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		enc := json.NewEncoder(stream)
+		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
+		}
+
+		replayErr := make(chan error, 1)
+		go func() {
+			for i := 0; i < 10; i++ {
+				if err := enc.Encode(workspaceEventMessage("workspace_focused", fmt.Sprintf("stale-%d", i))); err != nil {
+					replayErr <- err
+					return
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+			close(replayDone)
+			replayErr <- nil
+		}()
+
+		snapshot, err := acceptRequest(listener, "session.snapshot")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if err := json.NewEncoder(snapshot).Encode(snapshotResponse("current", "current")); err != nil {
+			_ = snapshot.Close()
+			serverDone <- err
+			return
+		}
+		_ = snapshot.Close()
+		serverDone <- <-replayErr
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	record := func(id string) error {
+		select {
+		case <-replayDone:
+		default:
+			return errors.New("history published before retained replay finished")
+		}
+		if id == "current" {
+			cancel()
+		}
+		return nil
+	}
+	err := WatchWorkspaceEvents(ctx, socketPath, record, func(string) error { return nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation after complete replay", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWatchWorkspaceEventsRejectsPreSubscriptionProtocol(t *testing.T) {
 	listener, socketPath := listenTestSocket(t)
 	serverDone := make(chan error, 1)
 	go func() {
@@ -27,7 +163,7 @@ func TestWatchWorkspaceEventsRejectsRetainedReplayProtocol(t *testing.T) {
 		serverDone <- json.NewEncoder(conn).Encode(map[string]any{
 			"id": "herdr-sesh-history-ping",
 			"result": map[string]any{
-				"type": "pong", "version": "0.8.2", "protocol": 20,
+				"type": "pong", "version": "0.8.1", "protocol": 19,
 			},
 		})
 	}()
@@ -35,8 +171,8 @@ func TestWatchWorkspaceEventsRejectsRetainedReplayProtocol(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	err := WatchWorkspaceEvents(ctx, socketPath, func(string) error { return nil }, func(string) error { return nil })
-	if err == nil || !strings.Contains(err.Error(), "requires Herdr protocol 21") {
-		t.Fatalf("watch error=%v, want protocol 21 requirement", err)
+	if err == nil || !strings.Contains(err.Error(), "requires Herdr protocol 20") {
+		t.Fatalf("watch error=%v, want protocol 20 requirement", err)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatal(err)
@@ -219,7 +355,7 @@ func serveCompatiblePing(listener net.Listener) error {
 	return json.NewEncoder(conn).Encode(map[string]any{
 		"id": "herdr-sesh-history-ping",
 		"result": map[string]any{
-			"type": "pong", "version": "0.8.2-preview", "protocol": 21,
+			"type": "pong", "version": "0.8.2", "protocol": 20,
 		},
 	})
 }

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -1,0 +1,264 @@
+package herdr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWatchWorkspaceEventsReconcilesRetainedReplayBeforeSnapshot(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		enc := json.NewEncoder(stream)
+		for _, message := range []any{
+			map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}},
+			workspaceEventMessage("workspace_focused", "stale"),
+			workspaceEventMessage("workspace_closed", "gone"),
+			workspaceEventMessage("workspace_closed", "still-open"),
+		} {
+			if err := enc.Encode(message); err != nil {
+				serverDone <- err
+				return
+			}
+		}
+
+		snapshot, err := acceptRequest(listener, "session.snapshot")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = snapshot.Close() }()
+		// This event occurs after snapshot acquisition starts. It must be
+		// applied after the snapshot rather than discarded with old replay.
+		if err := enc.Encode(workspaceEventMessage("workspace_focused", "live")); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("snapshot", "snapshot", "still-open"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var mu sync.Mutex
+	var got []string
+	record := func(kind, id string) error {
+		mu.Lock()
+		got = append(got, kind+":"+id)
+		if kind == "focus" && id == "live" {
+			cancel()
+		}
+		mu.Unlock()
+		return nil
+	}
+	err := WatchWorkspaceEvents(ctx, socketPath,
+		func(id string) error { return record("focus", id) },
+		func(id string) error { return record("close", id) },
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"focus:stale", "close:gone", "focus:snapshot", "focus:live"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutations=%#v want %#v", got, want)
+	}
+}
+
+func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		stream, err := acceptRequest(listener, "events.subscribe")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = stream.Close() }()
+		enc := json.NewEncoder(stream)
+		if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+			serverDone <- err
+			return
+		}
+		snapshot, err := acceptRequest(listener, "session.snapshot")
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = snapshot.Close() }()
+		if err := enc.Encode(workspaceEventMessage("workspace_focused", "during-snapshot")); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- json.NewEncoder(snapshot).Encode(snapshotResponse("snapshot", "snapshot"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var got []string
+	err := WatchWorkspaceEvents(ctx, socketPath,
+		func(id string) error {
+			got = append(got, id)
+			if len(got) == 2 {
+				cancel()
+			}
+			return nil
+		},
+		func(string) error { return nil },
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"snapshot", "during-snapshot"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("focuses=%#v want %#v", got, want)
+	}
+}
+
+func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
+	listener, socketPath := listenTestSocket(t)
+	serverDone := make(chan error, 1)
+	go func() {
+		for attempt := 0; attempt < 2; attempt++ {
+			stream, err := acceptRequest(listener, "events.subscribe")
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			enc := json.NewEncoder(stream)
+			if err := enc.Encode(map[string]any{"id": "herdr-sesh-history", "result": map[string]any{"type": "subscription_started"}}); err != nil {
+				_ = stream.Close()
+				serverDone <- err
+				return
+			}
+			snapshot, err := acceptRequest(listener, "session.snapshot")
+			if err != nil {
+				_ = stream.Close()
+				serverDone <- err
+				return
+			}
+			if err := json.NewEncoder(snapshot).Encode(snapshotResponse("")); err != nil {
+				_ = snapshot.Close()
+				_ = stream.Close()
+				serverDone <- err
+				return
+			}
+			_ = snapshot.Close()
+			if attempt == 1 {
+				if err := enc.Encode(workspaceEventMessage("workspace_focused", "after-reconnect")); err != nil {
+					_ = stream.Close()
+					serverDone <- err
+					return
+				}
+				if err := enc.Encode(workspaceEventMessage("workspace_closed", "after-reconnect")); err != nil {
+					_ = stream.Close()
+					serverDone <- err
+					return
+				}
+			}
+			_ = stream.Close()
+		}
+		serverDone <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var got []string
+	err := WatchWorkspaceEvents(ctx, socketPath,
+		func(id string) error {
+			got = append(got, "focus:"+id)
+			return nil
+		},
+		func(id string) error {
+			got = append(got, "close:"+id)
+			cancel()
+			return nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch error=%v, want context cancellation", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"focus:after-reconnect", "close:after-reconnect"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutations=%#v want %#v", got, want)
+	}
+}
+
+func listenTestSocket(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "herdr-sesh-events-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "herdr.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener, socketPath
+}
+
+func acceptRequest(listener net.Listener, method string) (net.Conn, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.NewDecoder(conn).Decode(&request); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if request.Method != method {
+		_ = conn.Close()
+		return nil, fmt.Errorf("method=%q want %q", request.Method, method)
+	}
+	return conn, nil
+}
+
+func workspaceEventMessage(event, workspaceID string) map[string]any {
+	return map[string]any{"event": event, "data": map[string]any{"workspace_id": workspaceID}}
+}
+
+func snapshotResponse(focusedWorkspaceID string, workspaceIDs ...string) map[string]any {
+	workspaces := make([]map[string]any, 0, len(workspaceIDs))
+	for _, workspaceID := range workspaceIDs {
+		workspaces = append(workspaces, map[string]any{"workspace_id": workspaceID})
+	}
+	return map[string]any{
+		"id": "herdr-sesh-history-snapshot",
+		"result": map[string]any{
+			"type": "session_snapshot",
+			"snapshot": map[string]any{
+				"focused_workspace_id": focusedWorkspaceID,
+				"workspaces":           workspaces,
+			},
+		},
+	}
+}

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 type History struct {
@@ -34,52 +35,83 @@ func SaveHistory(dir string, h History) error {
 	if dir == "" {
 		return nil
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return err
-	}
-	return writeJSONFile(Path(dir), h)
+	return withHistoryLock(dir, func() error {
+		return writeJSONFile(Path(dir), h)
+	})
 }
 
 func Record(dir, workspaceID string) error {
-	if workspaceID == "" {
+	if dir == "" || workspaceID == "" {
 		return nil
 	}
-	h, err := loadHistoryForWrite(dir)
-	if err != nil {
-		return err
-	}
-	h.Workspaces = dedupeWorkspaces([]string{workspaceID}, h.Workspaces)
-	return SaveHistory(dir, h)
+	return withHistoryLock(dir, func() error {
+		h, err := loadHistoryForWrite(dir)
+		if err != nil {
+			return err
+		}
+		if len(h.Workspaces) > 0 && h.Workspaces[0] == workspaceID {
+			return nil
+		}
+		h.Workspaces = dedupeWorkspaces([]string{workspaceID}, h.Workspaces)
+		return writeJSONFile(Path(dir), h)
+	})
 }
 
 func RecordSwitch(dir, fromWorkspaceID, toWorkspaceID string) error {
-	if toWorkspaceID == "" {
+	if dir == "" || toWorkspaceID == "" {
 		return nil
 	}
-	h, err := loadHistoryForWrite(dir)
-	if err != nil {
-		return err
-	}
-	h.Workspaces = dedupeWorkspaces([]string{toWorkspaceID, fromWorkspaceID}, h.Workspaces)
-	return SaveHistory(dir, h)
+	return withHistoryLock(dir, func() error {
+		h, err := loadHistoryForWrite(dir)
+		if err != nil {
+			return err
+		}
+		h.Workspaces = dedupeWorkspaces([]string{toWorkspaceID, fromWorkspaceID}, h.Workspaces)
+		return writeJSONFile(Path(dir), h)
+	})
 }
 
 func RemoveWorkspace(dir, workspaceID string) error {
-	if workspaceID == "" {
+	if dir == "" || workspaceID == "" {
 		return nil
 	}
-	h, err := loadHistoryForWrite(dir)
+	return withHistoryLock(dir, func() error {
+		h, err := loadHistoryForWrite(dir)
+		if err != nil {
+			return err
+		}
+		workspaces := h.Workspaces[:0]
+		for _, id := range h.Workspaces {
+			if id != workspaceID {
+				workspaces = append(workspaces, id)
+			}
+		}
+		h.Workspaces = workspaces
+		return writeJSONFile(Path(dir), h)
+	})
+}
+
+func withHistoryLock(dir string, fn func() error) (err error) {
+	// ponytail: serializes writes, not hook scheduling; add an event queue only if ordering guarantees are required.
+	//nolint:gosec // dir is the trusted plugin-owned state directory supplied to this API.
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	//nolint:gosec // dir is the trusted plugin-owned state directory supplied to this API.
+	lock, err := os.OpenFile(filepath.Join(dir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return err
 	}
-	workspaces := h.Workspaces[:0]
-	for _, id := range h.Workspaces {
-		if id != workspaceID {
-			workspaces = append(workspaces, id)
-		}
+	defer func() {
+		err = errors.Join(err, lock.Close())
+	}()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return err
 	}
-	h.Workspaces = workspaces
-	return SaveHistory(dir, h)
+	defer func() {
+		err = errors.Join(err, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))
+	}()
+	return fn()
 }
 
 func loadHistoryForWrite(dir string) (History, error) {

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -49,19 +49,18 @@ func SessionHistoryDir(dir, socketPath string) (string, error) {
 	}
 
 	err := withHistoryLock(dir, func() error {
-		if _, err := os.Stat(Path(sessionDir)); err == nil {
-			return nil
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-		contents, err := os.ReadFile(Path(dir))
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(sessionDir, 0700); err != nil {
-			return err
-		}
-		return writeFile(Path(sessionDir), contents)
+		return withHistoryLock(sessionDir, func() error {
+			if _, err := os.Stat(Path(sessionDir)); err == nil {
+				return nil
+			} else if !os.IsNotExist(err) {
+				return err
+			}
+			contents, err := os.ReadFile(Path(dir))
+			if err != nil {
+				return err
+			}
+			return writeFile(Path(sessionDir), contents)
+		})
 	})
 	if err != nil {
 		return "", err

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -1,20 +1,108 @@
 package state
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 type History struct {
 	Workspaces []string `json:"workspaces"`
 }
 
-const maxWorkspaces = 50
+var ErrHistoryLockTimeout = errors.New("timed out waiting for history lock")
+
+const (
+	maxWorkspaces       = 50
+	historyLockTimeout  = 250 * time.Millisecond
+	historyLockInterval = 10 * time.Millisecond
+)
 
 func Path(dir string) string { return filepath.Join(dir, "history.json") }
+
+// SessionHistoryDir resolves a socket-scoped history directory. Existing
+// unscoped history belongs to the default session and is copied on first use;
+// named sessions never inherit it.
+func SessionHistoryDir(dir, socketPath string) (string, error) {
+	if dir == "" || socketPath == "" {
+		return dir, nil
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(socketPath)))
+	sessionDir := filepath.Join(dir, "history", fmt.Sprintf("%x", sum))
+	if !isDefaultSessionSocket(socketPath) {
+		return sessionDir, nil
+	}
+	if _, err := os.Stat(Path(sessionDir)); err == nil {
+		return sessionDir, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if _, err := os.Stat(Path(dir)); os.IsNotExist(err) {
+		return sessionDir, nil
+	} else if err != nil {
+		return "", err
+	}
+
+	err := withHistoryLock(dir, func() error {
+		if _, err := os.Stat(Path(sessionDir)); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		contents, err := os.ReadFile(Path(dir))
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(sessionDir, 0700); err != nil {
+			return err
+		}
+		return writeFile(Path(sessionDir), contents)
+	})
+	if err != nil {
+		return "", err
+	}
+	return sessionDir, nil
+}
+
+func isDefaultSessionSocket(socketPath string) bool {
+	clean := filepath.Clean(socketPath)
+	parent := filepath.Dir(clean)
+	if filepath.Base(clean) != "herdr.sock" || filepath.Base(parent) != "herdr" {
+		return false
+	}
+	return filepath.Base(filepath.Dir(parent)) != "sessions"
+}
+
+// TryHistoryWatcherLock permits one event subscriber per Herdr socket.
+func TryHistoryWatcherLock(dir, socketPath string) (release func() error, acquired bool, err error) {
+	if dir == "" {
+		return nil, false, errors.New("HERDR_PLUGIN_STATE_DIR is required")
+	}
+	//nolint:gosec // dir is the trusted plugin-owned state directory supplied to this API.
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, false, err
+	}
+	lockName := fmt.Sprintf("history-watch-%x.lock", sha256.Sum256([]byte(socketPath)))
+	//nolint:gosec // dir is the trusted plugin-owned state directory supplied to this API.
+	lock, err := os.OpenFile(filepath.Join(dir, lockName), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, false, lock.Close()
+		}
+		return nil, false, errors.Join(err, lock.Close())
+	}
+	return func() error {
+		return errors.Join(syscall.Flock(int(lock.Fd()), syscall.LOCK_UN), lock.Close())
+	}, true, nil
+}
 
 func LoadHistory(dir string) (History, error) {
 	var h History
@@ -92,7 +180,6 @@ func RemoveWorkspace(dir, workspaceID string) error {
 }
 
 func withHistoryLock(dir string, fn func() error) (err error) {
-	// ponytail: serializes writes, not hook scheduling; add an event queue only if ordering guarantees are required.
 	//nolint:gosec // dir is the trusted plugin-owned state directory supplied to this API.
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
@@ -105,8 +192,19 @@ func withHistoryLock(dir string, fn func() error) (err error) {
 	defer func() {
 		err = errors.Join(err, lock.Close())
 	}()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		return err
+	deadline := time.Now().Add(historyLockTimeout)
+	for {
+		err = syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			return err
+		}
+		if time.Now().Add(historyLockInterval).After(deadline) {
+			return fmt.Errorf("%w after %s", ErrHistoryLockTimeout, historyLockTimeout)
+		}
+		time.Sleep(historyLockInterval)
 	}
 	defer func() {
 		err = errors.Join(err, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,81 @@ import (
 	"testing"
 	"time"
 )
+
+func TestSessionHistoryDirIsolatesSockets(t *testing.T) {
+	stateDir := t.TempDir()
+	firstDir, err := SessionHistoryDir(stateDir, "/tmp/herdr-a.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDir, err := SessionHistoryDir(stateDir, "/tmp/herdr-b.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstDir == secondDir {
+		t.Fatalf("session history dirs are shared: %q", firstDir)
+	}
+
+	if err := SaveHistory(firstDir, History{Workspaces: []string{"w1", "first-only"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveHistory(secondDir, History{Workspaces: []string{"w1", "second-only"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordSwitch(firstDir, "w1", "first-only"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveWorkspace(secondDir, "w1"); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := LoadHistory(firstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := LoadHistory(secondDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"first-only", "w1"}; !reflect.DeepEqual(first.Workspaces, want) {
+		t.Fatalf("first workspaces=%#v want %#v", first.Workspaces, want)
+	}
+	if want := []string{"second-only"}; !reflect.DeepEqual(second.Workspaces, want) {
+		t.Fatalf("second workspaces=%#v want %#v", second.Workspaces, want)
+	}
+}
+
+func TestSessionHistoryDirMigratesOnlyDefaultSessionHistory(t *testing.T) {
+	stateDir := t.TempDir()
+	legacy := History{Workspaces: []string{"current", "previous"}}
+	if err := SaveHistory(stateDir, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	namedDir, err := SessionHistoryDir(stateDir, filepath.Join("/config", "herdr", "sessions", "work", "herdr.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	named, err := LoadHistory(namedDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(named.Workspaces) != 0 {
+		t.Fatalf("named session imported legacy history: %#v", named.Workspaces)
+	}
+
+	defaultDir, err := SessionHistoryDir(stateDir, filepath.Join("/config", "herdr", "herdr.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrated, err := LoadHistory(defaultDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(migrated, legacy) {
+		t.Fatalf("migrated history=%#v want %#v", migrated, legacy)
+	}
+}
 
 func TestHistoryRecordsMostRecentWithoutDuplicates(t *testing.T) {
 	d := t.TempDir()
@@ -95,6 +171,41 @@ func TestHistoryMutationsWaitForProcessLock(t *testing.T) {
 			}
 			assertHistoryMutationWaitsForLock(t, d, tc.action)
 		})
+	}
+}
+
+func TestHistoryMutationTimesOutWaitingForProcessLock(t *testing.T) {
+	d := t.TempDir()
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(d, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- Record(d, "blocked") }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrHistoryLockTimeout) {
+			t.Fatalf("err=%v, want history lock timeout", err)
+		}
+	case <-time.After(2 * time.Second):
+		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+			t.Fatal(err)
+		}
+		locked = false
+		<-done
+		t.Fatal("history mutation remained blocked for two seconds")
 	}
 }
 

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -1,11 +1,15 @@
 package state
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestHistoryRecordsMostRecentWithoutDuplicates(t *testing.T) {
@@ -26,6 +30,189 @@ func TestHistoryRecordsMostRecentWithoutDuplicates(t *testing.T) {
 	if !ok || last != "a" {
 		t.Fatalf("last=%q ok=%v", last, ok)
 	}
+}
+
+func TestRecordKeepsCurrentHistoryFile(t *testing.T) {
+	d := t.TempDir()
+	if err := SaveHistory(d, History{Workspaces: []string{"current", "older"}}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(Path(d))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Record(d, "current"); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.Stat(Path(d))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("Record rewrote history.json for the current workspace")
+	}
+}
+
+func TestHistoryMutationsWaitForProcessLock(t *testing.T) {
+	if os.Getenv("HERDR_SESH_HISTORY_LOCK_HELPER") == "1" {
+		runHistoryLockHelper(t)
+		return
+	}
+
+	for _, tc := range []struct {
+		name   string
+		action string
+		setup  func(string) error
+	}{
+		{
+			name:   "record",
+			action: "record",
+		},
+		{
+			name:   "record switch",
+			action: "record-switch",
+		},
+		{
+			name:   "remove workspace",
+			action: "remove-workspace",
+			setup: func(dir string) error {
+				return SaveHistory(dir, History{Workspaces: []string{"remove"}})
+			},
+		},
+		{
+			name:   "save history",
+			action: "save-history",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := t.TempDir()
+			if tc.setup != nil {
+				if err := tc.setup(d); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertHistoryMutationWaitsForLock(t, d, tc.action)
+		})
+	}
+}
+
+func assertHistoryMutationWaitsForLock(t *testing.T, dir, action string) {
+	t.Helper()
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(dir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		}
+	}()
+
+	//nolint:gosec // Test re-executes its own test binary.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHistoryMutationsWaitForProcessLock$")
+	cmd.Env = append(os.Environ(), "HERDR_SESH_HISTORY_LOCK_HELPER=1", "HERDR_SESH_HISTORY_LOCK_DIR="+dir, "HERDR_SESH_HISTORY_LOCK_ACTION="+action)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitDone := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-waitDone:
+			return
+		default:
+		}
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitDone:
+		case <-time.After(time.Second):
+			t.Error("history mutation helper did not exit after being killed")
+		}
+	})
+
+	lines := make(chan string, 8)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+	select {
+	case line := <-lines:
+		if line != "ready" {
+			t.Fatalf("helper readiness = %q", line)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("history mutation helper did not start")
+	}
+
+	select {
+	case line := <-lines:
+		t.Fatalf("history mutation bypassed held process lock: %q", line)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+	select {
+	case <-waitDone:
+		if waitErr != nil {
+			t.Fatal(waitErr)
+		}
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitDone:
+			t.Fatalf("history mutation helper did not exit after lock release: %v", waitErr)
+		case <-time.After(time.Second):
+			t.Fatal("history mutation helper did not exit after being killed")
+		}
+	}
+}
+
+func runHistoryLockHelper(t *testing.T) {
+	t.Helper()
+	dir := os.Getenv("HERDR_SESH_HISTORY_LOCK_DIR")
+	action := os.Getenv("HERDR_SESH_HISTORY_LOCK_ACTION")
+	fmt.Println("ready")
+	var mutateErr error
+	switch action {
+	case "record":
+		mutateErr = Record(dir, "record")
+	case "record-switch":
+		mutateErr = RecordSwitch(dir, "from", "to")
+	case "remove-workspace":
+		mutateErr = RemoveWorkspace(dir, "remove")
+	case "save-history":
+		mutateErr = SaveHistory(dir, History{Workspaces: []string{"saved"}})
+	default:
+		t.Fatalf("unknown helper action %q", action)
+	}
+	if mutateErr != nil {
+		t.Fatal(mutateErr)
+	}
+	fmt.Println("done")
 }
 
 func TestHistoryNoopsWithoutStateDir(t *testing.T) {

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -88,6 +88,69 @@ func TestSessionHistoryDirMigratesOnlyDefaultSessionHistory(t *testing.T) {
 	}
 }
 
+func TestSessionHistoryDirMigrationWaitsForDestinationLock(t *testing.T) {
+	stateDir := t.TempDir()
+	socketPath := filepath.Join(t.TempDir(), "herdr", "herdr.sock")
+	sessionDir, err := SessionHistoryDir(stateDir, socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := History{Workspaces: []string{"legacy"}}
+	if err := SaveHistory(stateDir, legacy); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sessionDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	//nolint:gosec // Test lock path is derived from t.TempDir().
+	lock, err := os.OpenFile(filepath.Join(sessionDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, migrateErr := SessionHistoryDir(stateDir, socketPath)
+		done <- migrateErr
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("migration bypassed destination lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	concurrent := History{Workspaces: []string{"concurrent"}}
+	if err := writeJSONFile(Path(sessionDir), concurrent); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadHistory(sessionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, concurrent) {
+		t.Fatalf("migrated history=%#v want concurrent history %#v", got, concurrent)
+	}
+}
+
 func TestHistoryRecordsMostRecentWithoutDuplicates(t *testing.T) {
 	d := t.TempDir()
 	if err := Record(d, "a"); err != nil {

--- a/internal/state/json.go
+++ b/internal/state/json.go
@@ -29,3 +29,24 @@ func writeJSONFile(path string, v any) error {
 	}
 	return os.Rename(tmpName, path)
 }
+
+func writeFile(path string, contents []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(contents); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/state/json.go
+++ b/internal/state/json.go
@@ -1,33 +1,20 @@
 package state
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 )
 
 func writeJSONFile(path string, v any) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	defer func() { _ = os.Remove(tmpName) }()
-
-	enc := json.NewEncoder(tmp)
+	var contents bytes.Buffer
+	enc := json.NewEncoder(&contents)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(v); err != nil {
-		_ = tmp.Close()
 		return err
 	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmpName, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmpName, path)
+	return writeFile(path, contents.Bytes())
 }
 
 func writeFile(path string, contents []byte) error {

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,6 +13,7 @@ nav = [
   { "Configuration" = "config.md" },
   { "Keybindings" = "keybindings.md" },
   { "Development" = [
+    { "Workspace history" = "development/workspace-history.md" },
     { "Benchmarks" = "development/benchmarks.md" },
   ] },
 ]
@@ -27,6 +28,7 @@ favicon = "assets/favicon.svg"
 language = "en"
 features = [
   "content.code.copy",
+  "content.footnote.tooltips",
   "navigation.footer",
   "navigation.instant",
   "navigation.path",
@@ -62,13 +64,16 @@ toggle.name = "Switch to system preference"
 [project.markdown_extensions]
 admonition = {}
 attr_list = {}
+footnotes = {}
 md_in_html = {}
 tables = {}
 toc.permalink = true
 pymdownx.details = {}
 pymdownx.highlight.anchor_linenums = true
 pymdownx.highlight.pygments_lang_class = true
-pymdownx.superfences = {}
+pymdownx.superfences.custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
+]
 pymdownx.tabbed.alternate_style = true
 pymdownx.keys = {}
 pymdownx.smartsymbols = {}


### PR DESCRIPTION
## Summary

- start one socket-scoped history watcher from Herdr startup, focus, and close hooks
- subscribe before protocol probing so protocol-21 live events are buffered across bootstrap
- reconcile protocol-20 replay batches against fresh snapshots without timing heuristics
- serialize session-scoped history mutations with bounded advisory locks while preserving standalone herdr-sesh writes
- keep non-winning focus hooks mutation-free, use close-event payload IDs, and retry subscriber lock timeouts in stream order
- document the implementation, lifecycle, recovery behavior, and tradeoffs in the Zensical development guide

## Related issue

N/A

## Validation

- [x] just check (417 race-enabled tests)
- [x] just build
- [x] just build-docs (strict build)
- [x] protocol-probe regression repeated 100 times
- [x] lock-contention regressions repeated 20 times

## Performance

Local Apple M4 Pro measurements against main found:

- persisted history mutations are 9–12% slower, about 14 microseconds per operation
- repeated-current focus records are 82.6% faster because they skip the atomic rewrite
- the idle watcher uses 9.44 MiB RSS and 0.0% CPU
- a losing focus-hook child takes about 14.0 ms wall time, dominated by process startup
- the binary grows by 0.64 MiB (8.2%)

The benchmark harness was temporary and is not included in this branch.

## User-facing changes

The last command and picker metadata now follow workspace focus and close events initiated outside herdr-sesh. A new Development → Workspace history page explains the integration with Mermaid diagrams and source references.

## Notes

- The ordered watcher supports the stable Herdr 0.8.2 protocol 20 and protocol 21 or newer. Protocol 20 replay is reconciled against current session snapshots because the host exposes no replay-completion marker.
- The resident watcher intentionally consumes one Herdr command slot per socket while active.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
