### PR TITLE
fix: embed Git version in local plugin builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Lint](https://github.com/fullerzz/herdr-plugin-sesh/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/fullerzz/herdr-plugin-sesh/actions/workflows/lint.yml)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://app.codspeed.io/fullerzz/herdr-plugin-sesh?utm_source=badge)
 
-
 A [Sesh](https://github.com/joshmedeski/sesh)-inspired workspace picker and
 session manager for [Herdr](https://herdr.dev/).
 
@@ -154,7 +153,14 @@ just install-plugin
 ```
 
 `just install-plugin` builds the binary and links the current checkout into
-Herdr. Verify the local plugin with:
+Herdr. Local builds (`just build` and `just install-plugin`) embed a Git-derived
+version, for example `v0.10.1-5-g0686c01`: the nearest reachable version tag,
+commits since that tag, and the commit hash. Uncommitted tracked changes append
+`-dirty`; an exact clean tag uses the tag alone. Without a reachable version tag,
+the commit hash is used; without Git metadata, the version falls back to `dev`.
+Release builds continue to use the release version.
+
+Verify the local plugin with:
 
 ```bash
 herdr plugin action list --plugin fullerzz.sesh

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ clean:
 build:
     @echo "{{ BOLD + BLUE + BG_BLACK }} Building the project...{{ NORMAL }}"
     mkdir -p bin
-    go build -o bin/herdr-sesh ./cmd/herdr-sesh
+    go build -ldflags "-X github.com/fullerzz/herdr-plugin-sesh/internal/app.Version=$(git describe --tags --match 'v[0-9]*' --always --dirty 2>/dev/null || printf 'dev')" -o bin/herdr-sesh ./cmd/herdr-sesh
 
 # Rebuild and relink this checkout as a local Herdr plugin
 install-plugin: build


### PR DESCRIPTION
## Summary
- Stamp `just build` / `just install-plugin` binaries with the nearest version tag, commit distance, hash, and tracked dirty state using `git describe`.
- Fall back to the commit hash without tags and `dev` without Git metadata; leave release builds unchanged.
- Document local version semantics in README.md.

## Validation
- `just check` (lint, formatting, 417 race-enabled tests, release-ref checks)
- `go vet ./...`
- `just build`
- `./bin/herdr-sesh --version` → `herdr-sesh v0.10.1-5-g0686c01-dirty` before commit; matched `git describe` output
- `./bin/herdr-sesh list --json --config testdata/sesh.toml >/dev/null` (passed with expected legacy-schema deprecation warning)
- `just build-docs`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

