### PR TITLE
docs(wiki): add release-versioned wiki with latest docs

### DIFF
--- a/.github/scripts/build-docs-versions.py
+++ b/.github/scripts/build-docs-versions.py
@@ -2,8 +2,8 @@
 
 import io
 import json
+import logging
 import os
-from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -11,21 +11,53 @@ import tarfile
 import tempfile
 import tomllib
 from contextlib import chdir
+from pathlib import Path
 
 from mike import commands, utils
 
-
-def git(repo, *args):
-    return subprocess.check_output(["git", "-C", str(repo), *args])
+logger = logging.getLogger(__name__)
 
 
-def extract(repo, ref, destination, *paths):
+def executable(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise FileNotFoundError(f"Required executable not found: {name}")
+    return path
+
+
+def git(repo: Path, *args: str) -> bytes:
+    # Internal callers supply Git arguments; tag refs are validated and no shell is used.
+    return subprocess.check_output([executable("git"), "-C", str(repo), *args])  # noqa: S603
+
+
+def extract(repo: Path, ref: str, destination: Path, *paths: str) -> None:
     archive = git(repo, "archive", ref, *paths)
     with tarfile.open(fileobj=io.BytesIO(archive)) as files:
         files.extractall(destination, filter="data")
 
 
-def build(source, output):
+def hydrate_assets(source: Path, docs: Path) -> None:
+    """Replace git archive's LFS pointers with the fetched asset contents."""
+    for path in docs.rglob("*"):
+        if not path.is_file():
+            continue
+        with path.open("rb") as file:
+            pointer = file.read(1024)
+        if not pointer.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
+            continue
+        # Pointer contents are stdin data, never executable arguments or shell input.
+        result = subprocess.run(  # noqa: S603
+            [executable("git"), "-C", str(source), "lfs", "smudge"],
+            input=pointer,
+            capture_output=True,
+            check=True,
+        )
+        if result.stdout.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
+            raise RuntimeError(f"Unresolved LFS pointer: {path}")
+        path.write_bytes(result.stdout)
+
+
+def build(source: Path, output: Path) -> None:
     source, output = source.resolve(), output.resolve()
     tags = git(source, "tag", "--list", "v*", "--sort=version:refname").decode().splitlines()
     versions = []
@@ -37,7 +69,7 @@ def build(source, output):
         if "zensical.toml" in paths and "docs" in paths:
             versions.append((tag, ref))
         else:
-            print(f"Skipping {tag}: predates the Zensical wiki", flush=True)
+            logger.info("Skipping %s: predates the Zensical wiki", tag)
 
     # ponytail: rebuild all tags; cache immutable snapshots if release builds get slow.
     with tempfile.TemporaryDirectory(prefix="herdr-sesh-docs-") as directory:
@@ -56,19 +88,7 @@ def build(source, output):
                 shutil.copytree(source / "docs", snapshot / "docs")
                 shutil.copy2(source / "zensical.toml", snapshot / "zensical.toml")
 
-            # git archive preserves LFS pointers; hydrate them from fetched objects.
-            for path in (snapshot / "docs").rglob("*"):
-                if path.is_file():
-                    with path.open("rb") as file:
-                        pointer = file.read(1024)
-                    if pointer.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
-                        result = subprocess.run(
-                            ["git", "-C", str(source), "lfs", "smudge"],
-                            input=pointer, capture_output=True, check=True,
-                        )
-                        if result.stdout.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
-                            raise RuntimeError(f"Unresolved LFS pointer: {path}")
-                        path.write_bytes(result.stdout)
+            hydrate_assets(source, snapshot / "docs")
 
             config = tomllib.loads((snapshot / "zensical.toml").read_text())["project"]
             config.setdefault("extra", {})["version"] = {"provider": "mike", "default": "latest"}
@@ -76,13 +96,15 @@ def build(source, output):
             # JSON is YAML: retain each tag's config without adding a TOML writer.
             config_file = snapshot / "mkdocs.yml"
             config_file.write_text(json.dumps(config))
-            print(f"Building documentation: {version}", flush=True)
+            logger.info("Building documentation: %s", version)
             with chdir(work):
                 cfg = utils.load_config(str(config_file))
                 with commands.deploy(cfg, version, message=f"docs: build {version}"):
-                    subprocess.run(
-                        ["zensical", "build", "--clean", "--strict", "-f", str(config_file)],
-                        env={**os.environ, "MIKE_DOCS_VERSION": version}, check=True,
+                    # The config path is generated locally and passed without a shell.
+                    subprocess.run(  # noqa: S603
+                        [executable("zensical"), "build", "--clean", "--strict", "-f", str(config_file)],
+                        env={**os.environ, "MIKE_DOCS_VERSION": version},
+                        check=True,
                     )
         with chdir(work):
             commands.set_default("latest")
@@ -107,5 +129,6 @@ def build(source, output):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     root = Path(__file__).resolve().parents[2]
     build(root, root / "site")

--- a/.github/scripts/build-docs-versions.py
+++ b/.github/scripts/build-docs-versions.py
@@ -113,12 +113,14 @@ def build(source: Path, output: Path) -> None:
             shutil.rmtree(output)
         output.mkdir(parents=True)
         extract(work, "refs/heads/gh-pages", output)
+        # Zensical's 404 uses site-root paths, so its latest navigation and assets remain valid here.
+        shutil.copy2(output / "latest/404.html", output / "404.html")
         # Preserve unversioned page links using mike's query/fragment-aware redirect.
         template = commands._redirect_template()
         for page in (output / "latest").rglob("*.html"):
             relative = page.relative_to(output / "latest")
             redirect = output / relative
-            if redirect.exists() or relative == Path("404.html"):
+            if redirect.exists():
                 continue
             target = page.parent if page.name == "index.html" else page
             href = Path(os.path.relpath(target, redirect.parent)).as_posix()

--- a/.github/scripts/build-docs-versions.py
+++ b/.github/scripts/build-docs-versions.py
@@ -1,0 +1,111 @@
+"""Build a complete Pages artifact without pushing a deployment branch."""
+
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import tomllib
+from contextlib import chdir
+
+from mike import commands, utils
+
+
+def git(repo, *args):
+    return subprocess.check_output(["git", "-C", str(repo), *args])
+
+
+def extract(repo, ref, destination, *paths):
+    archive = git(repo, "archive", ref, *paths)
+    with tarfile.open(fileobj=io.BytesIO(archive)) as files:
+        files.extractall(destination, filter="data")
+
+
+def build(source, output):
+    source, output = source.resolve(), output.resolve()
+    tags = git(source, "tag", "--list", "v*", "--sort=version:refname").decode().splitlines()
+    versions = []
+    for tag in tags:
+        if not re.fullmatch(r"v[0-9A-Za-z][0-9A-Za-z._+-]*", tag):
+            raise ValueError(f"Unsafe documentation version: {tag}")
+        ref = f"refs/tags/{tag}"
+        paths = git(source, "ls-tree", "--name-only", ref).decode().splitlines()
+        if "zensical.toml" in paths and "docs" in paths:
+            versions.append((tag, ref))
+        else:
+            print(f"Skipping {tag}: predates the Zensical wiki", flush=True)
+
+    # ponytail: rebuild all tags; cache immutable snapshots if release builds get slow.
+    with tempfile.TemporaryDirectory(prefix="herdr-sesh-docs-") as directory:
+        work = Path(directory)
+        git(work, "init", "--quiet")
+        git(work, "config", "user.name", "Docs builder")
+        git(work, "config", "user.email", "docs@localhost")
+        git(work, "commit", "--quiet", "--allow-empty", "-m", "docs: initialize build")
+        for version, ref in [*versions, ("latest", None)]:
+            snapshot = work / "snapshot"
+            shutil.rmtree(snapshot, ignore_errors=True)
+            snapshot.mkdir()
+            if ref:
+                extract(source, ref, snapshot, "docs", "zensical.toml")
+            else:
+                shutil.copytree(source / "docs", snapshot / "docs")
+                shutil.copy2(source / "zensical.toml", snapshot / "zensical.toml")
+
+            # git archive preserves LFS pointers; hydrate them from fetched objects.
+            for path in (snapshot / "docs").rglob("*"):
+                if path.is_file():
+                    with path.open("rb") as file:
+                        pointer = file.read(1024)
+                    if pointer.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
+                        result = subprocess.run(
+                            ["git", "-C", str(source), "lfs", "smudge"],
+                            input=pointer, capture_output=True, check=True,
+                        )
+                        if result.stdout.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
+                            raise RuntimeError(f"Unresolved LFS pointer: {path}")
+                        path.write_bytes(result.stdout)
+
+            config = tomllib.loads((snapshot / "zensical.toml").read_text())["project"]
+            config.setdefault("extra", {})["version"] = {"provider": "mike", "default": "latest"}
+            config["edit_uri"] = "edit/main/docs/" if ref is None else ""
+            # JSON is YAML: retain each tag's config without adding a TOML writer.
+            config_file = snapshot / "mkdocs.yml"
+            config_file.write_text(json.dumps(config))
+            print(f"Building documentation: {version}", flush=True)
+            with chdir(work):
+                cfg = utils.load_config(str(config_file))
+                with commands.deploy(cfg, version, message=f"docs: build {version}"):
+                    subprocess.run(
+                        ["zensical", "build", "--clean", "--strict", "-f", str(config_file)],
+                        env={**os.environ, "MIKE_DOCS_VERSION": version}, check=True,
+                    )
+        with chdir(work):
+            commands.set_default("latest")
+        # Replace the previous artifact only after every version has built successfully.
+        if output.exists():
+            shutil.rmtree(output)
+        output.mkdir(parents=True)
+        extract(work, "refs/heads/gh-pages", output)
+        # Preserve unversioned page links using mike's query/fragment-aware redirect.
+        template = commands._redirect_template()
+        for page in (output / "latest").rglob("*.html"):
+            relative = page.relative_to(output / "latest")
+            redirect = output / relative
+            if redirect.exists() or relative == Path("404.html"):
+                continue
+            target = page.parent if page.name == "index.html" else page
+            href = Path(os.path.relpath(target, redirect.parent)).as_posix()
+            if page.name == "index.html":
+                href += "/"
+            redirect.parent.mkdir(parents=True, exist_ok=True)
+            redirect.write_text(template.render(href=href))
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[2]
+    build(root, root / "site")

--- a/.github/scripts/test-docs-versions.py
+++ b/.github/scripts/test-docs-versions.py
@@ -1,14 +1,19 @@
 """Integration regression: release snapshots, latest, selector and redirects."""
 
+# Assertions are the checks in this standalone regression script, not input validation.
+# ruff: noqa: S101
+
 import importlib.util
 import json
-from pathlib import Path
+import logging
 import re
 import tempfile
+from pathlib import Path
 
-spec = importlib.util.spec_from_file_location(
-    "docs_versions", Path(__file__).with_name("build-docs-versions.py")
-)
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+spec = importlib.util.spec_from_file_location("docs_versions", Path(__file__).with_name("build-docs-versions.py"))
 builder = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(builder)
 
@@ -47,16 +52,17 @@ with tempfile.TemporaryDirectory() as directory:
     assert {item["version"] for item in versions} == {"latest", "v1.0.0"}
     release = (output / "v1.0.0/index.html").read_text()
     latest = (output / "latest/index.html").read_text()
-    assert "Released documentation" in release and "Latest documentation" not in release
+    assert "Released documentation" in release
+    assert "Latest documentation" not in release
     assert "Latest documentation" in latest
     assert "Uncommitted preview guide" in (output / "latest/guide/index.html").read_text()
     assert "Released guide" in (output / "v1.0.0/guide/index.html").read_text()
     assert 'href="guide/"' in release
     assert 'rel="canonical" href="https://example.com/wiki/v1.0.0/"' in release
     assert 'rel="canonical" href="https://example.com/wiki/latest/"' in latest
-    runtime_config = json.loads(re.search(
-        r'<script id="__config" type="application/json">(.*?)</script>', release
-    ).group(1))
+    runtime_config = json.loads(
+        re.search(r'<script id="__config" type="application/json">(.*?)</script>', release).group(1)
+    )
     assert runtime_config["version"] == {"default": "latest", "provider": "mike"}
     assert "edit/main/docs/" not in release
     assert 'href="latest/"' in (output / "index.html").read_text()
@@ -71,4 +77,4 @@ with tempfile.TemporaryDirectory() as directory:
         assert (output / page).parent.joinpath(href).resolve().joinpath("index.html").is_file()
     assert builder.git(source, "status", "--porcelain") == before
     assert not builder.git(source, "branch", "--list", "gh-pages").strip()
-    print("Versioned documentation checks passed")
+    logger.info("Versioned documentation checks passed")

--- a/.github/scripts/test-docs-versions.py
+++ b/.github/scripts/test-docs-versions.py
@@ -1,0 +1,74 @@
+"""Integration regression: release snapshots, latest, selector and redirects."""
+
+import importlib.util
+import json
+from pathlib import Path
+import re
+import tempfile
+
+spec = importlib.util.spec_from_file_location(
+    "docs_versions", Path(__file__).with_name("build-docs-versions.py")
+)
+builder = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(builder)
+
+with tempfile.TemporaryDirectory() as directory:
+    source = Path(directory) / "repo"
+    source.mkdir()
+    builder.git(source, "init", "--quiet")
+    builder.git(source, "config", "user.name", "Docs test")
+    builder.git(source, "config", "user.email", "docs@localhost")
+    builder.git(source, "commit", "--quiet", "--allow-empty", "-m", "before wiki")
+    builder.git(source, "tag", "v0.1.0")
+    (source / "docs").mkdir()
+    (source / "zensical.toml").write_text(
+        '[project]\nsite_name = "Test"\nsite_url = "https://example.com/wiki/"\n'
+        'repo_url = "https://github.com/example/test"\nedit_uri = "edit/main/docs/"\n'
+        'nav = [{"Overview" = "index.md"}, {"Guide" = "guide.md"}, '
+        '{"Benchmarks" = "development/benchmarks.md"}]\n'
+    )
+    (source / "docs/index.md").write_text("# Released documentation\n\n[Guide](guide.md)\n")
+    (source / "docs/guide.md").write_text("# Released guide\n")
+    (source / "docs/development").mkdir()
+    (source / "docs/development/benchmarks.md").write_text("# Benchmarks\n")
+    builder.git(source, "add", ".")
+    builder.git(source, "commit", "--quiet", "-m", "release docs")
+    builder.git(source, "tag", "-a", "v1.0.0", "-m", "release")
+    # A same-named branch must never replace the release tag's snapshot.
+    builder.git(source, "checkout", "--quiet", "-b", "v1.0.0")
+    (source / "docs/index.md").write_text("# Latest documentation\n\n[Guide](guide.md)\n")
+    builder.git(source, "add", ".")
+    builder.git(source, "commit", "--quiet", "-m", "main docs")
+    (source / "docs/guide.md").write_text("# Uncommitted preview guide\n")
+    before = builder.git(source, "status", "--porcelain")
+    output = Path(directory) / "site"
+    builder.build(source, output)
+    versions = json.loads((output / "versions.json").read_text())
+    assert {item["version"] for item in versions} == {"latest", "v1.0.0"}
+    release = (output / "v1.0.0/index.html").read_text()
+    latest = (output / "latest/index.html").read_text()
+    assert "Released documentation" in release and "Latest documentation" not in release
+    assert "Latest documentation" in latest
+    assert "Uncommitted preview guide" in (output / "latest/guide/index.html").read_text()
+    assert "Released guide" in (output / "v1.0.0/guide/index.html").read_text()
+    assert 'href="guide/"' in release
+    assert 'rel="canonical" href="https://example.com/wiki/v1.0.0/"' in release
+    assert 'rel="canonical" href="https://example.com/wiki/latest/"' in latest
+    runtime_config = json.loads(re.search(
+        r'<script id="__config" type="application/json">(.*?)</script>', release
+    ).group(1))
+    assert runtime_config["version"] == {"default": "latest", "provider": "mike"}
+    assert "edit/main/docs/" not in release
+    assert 'href="latest/"' in (output / "index.html").read_text()
+    for page, href in (
+        ("guide/index.html", "../latest/guide/"),
+        ("development/benchmarks/index.html", "../../latest/development/benchmarks/"),
+    ):
+        redirect = (output / page).read_text()
+        assert f'href="{href}"' in redirect
+        assert "window.location.replace(" in redirect
+        assert "window.location.search + window.location.hash" in redirect
+        assert (output / page).parent.joinpath(href).resolve().joinpath("index.html").is_file()
+    assert builder.git(source, "status", "--porcelain") == before
+    assert not builder.git(source, "branch", "--list", "gh-pages").strip()
+    print("Versioned documentation checks passed")

--- a/.github/scripts/test-docs-versions.py
+++ b/.github/scripts/test-docs-versions.py
@@ -66,6 +66,12 @@ with tempfile.TemporaryDirectory() as directory:
     assert runtime_config["version"] == {"default": "latest", "provider": "mike"}
     assert "edit/main/docs/" not in release
     assert 'href="latest/"' in (output / "index.html").read_text()
+    not_found = (output / "404.html").read_text()
+    assert not_found == (output / "latest/404.html").read_text()
+    assert 'href="/wiki/latest/guide/"' in not_found
+    assert 'href="/wiki/latest/assets/stylesheets/' in not_found
+    assert 'src="/wiki/latest/assets/javascripts/' in not_found
+    assert "window.location.replace(" not in not_found
     for page, href in (
         ("guide/index.html", "../latest/guide/"),
         ("development/benchmarks/index.html", "../../latest/development/benchmarks/"),

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
   workflow_dispatch:
 
@@ -23,6 +25,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Tags trigger a rebuild, but latest must always come from main.
+          ref: ${{ github.event_name == 'pull_request' && github.ref || 'main' }}
+          fetch-depth: 0
           lfs: true
 
       - name: Install uv
@@ -36,8 +41,14 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Build docs
-        run: uv run --frozen zensical build --clean --strict
+      - name: Fetch historical documentation assets
+        run: git lfs fetch --all
+
+      - name: Test documentation versioning
+        run: uv run --frozen python .github/scripts/test-docs-versions.py
+
+      - name: Build versioned docs
+        run: uv run --frozen python .github/scripts/build-docs-versions.py
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
     rev: 0.12.5
     hooks:
       - id: uv-lock
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.6
+    hooks:
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 43.269.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,38 @@ just build-docs
 
 The generated `site/` directory is build output and should not be committed.
 
+### Documentation versions
+
+The wiki's version selector offers `latest` (the `main` branch) and release tags
+that contain `docs/` and `zensical.toml`. The site root redirects to `latest`.
+Unversioned page URLs redirect to the corresponding `latest` page, preserving
+query strings and section anchors when JavaScript is enabled.
+Tags before `v0.10.0` predate the wiki and are omitted.
+
+The Pages workflow rebuilds all versions on pushes to `main`, `v*` tag pushes,
+and manual runs. Each release uses the Markdown, assets, navigation, and theme
+from that exact tag, built with the current pinned documentation toolchain.
+Release pages disable editing links; `latest` links to edits on `main`.
+The [Zensical-compatible mike fork](https://zensical.org/docs/compatibility/mkdocs/mike/)
+provides the selector metadata and root redirect. Its deployment branch exists
+only in a temporary local repository; Pages still deploys an Actions artifact.
+
+To build and test the complete versioned site locally:
+
+```bash
+git fetch origin --tags
+git lfs fetch --all
+just test-docs-versions
+just build-docs-versions
+uv run --frozen python -m http.server 8000 --directory site
+```
+
+Open `http://localhost:8000/`. Local and pull-request builds use the current
+checkout, including documentation edits, for `latest`; deployments always check
+out `main`, even when a tag triggers the workflow. All builds are strict and
+replace `site/` only after every version succeeds. No tags or deployment branches
+are pushed by these commands.
+
 ## Pull requests
 
 Before opening a pull request:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,10 @@ herdr plugin action invoke fullerzz.sesh.open-picker
 
 ## Documentation
 
+Use the version selector in the header to choose a release's documentation.
+`latest` follows the `main` branch and may describe changes not yet released.
+Release snapshots are available starting with `v0.10.0`, when the wiki was added.
+
 - [Configuration](config.md) explains config discovery, picker behavior,
   workspaces, tabs, and legacy Sesh migration.
 - [Keybindings](keybindings.md) shows how to invoke the picker and related

--- a/justfile
+++ b/justfile
@@ -8,6 +8,14 @@ run:
 build-docs:
     uv run --frozen zensical build --clean --strict
 
+# Build latest and all release-tag documentation for GitHub Pages
+build-docs-versions:
+    uv run --frozen python .github/scripts/build-docs-versions.py
+
+# Exercise versioned documentation with isolated Git history
+test-docs-versions:
+    uv run --frozen python .github/scripts/test-docs-versions.py
+
 # Preview the documentation site locally
 serve-docs:
     uv run --frozen zensical serve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,12 @@ name = "herdr-sesh-docs"
 version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
+    "mike",
     "zensical==0.0.57",
 ]
 
 [tool.uv]
 exclude-newer = "1 day"
+
+[tool.uv.sources]
+mike = { git = "https://github.com/squidfunk/mike.git", rev = "2d4ad799442f4592db8ad53b179bfb33db8c69ac" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ mike = { git = "https://github.com/squidfunk/mike.git", rev = "2d4ad799442f4592d
 
 [dependency-groups]
 dev = [
-    "ruff>=0.16.6",
+    "ruff==0.16.6",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,58 @@ exclude-newer = "1 day"
 
 [tool.uv.sources]
 mike = { git = "https://github.com/squidfunk/mike.git", rev = "2d4ad799442f4592db8ad53b179bfb33db8c69ac" }
+
+[dependency-groups]
+dev = [
+    "ruff>=0.16.6",
+]
+
+[tool.ruff]
+include = [".github/scripts/**/*.py"]
+line-length = 120
+indent-width = 4
+
+target-version = "py314"
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "W",
+    "C90",
+    "I",
+    "N",
+    "UP",
+    "ASYNC",
+    "S",
+    "B",
+    "ERA",
+    "PLE",
+    "PLW",
+    "PLC",
+    "PLW",
+    "PERF",
+    "RUF",
+    "SIM",
+    "PT",
+    "T20",
+    "PTH",
+    "LOG",
+    "G",
+    "FA",
+    "ANN"
+]
+ignore = ["E501", "PLC0415"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.16.6" }]
+dev = [{ name = "ruff", specifier = "==0.16.6" }]
 
 [[package]]
 name = "jinja2"

--- a/uv.lock
+++ b/uv.lock
@@ -45,11 +45,19 @@ dependencies = [
     { name = "zensical" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac" },
     { name = "zensical", specifier = "==0.0.57" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.16.6" }]
 
 [[package]]
 name = "jinja2"
@@ -168,6 +176,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -41,11 +41,15 @@ name = "herdr-sesh-docs"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "mike" },
     { name = "zensical" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zensical", specifier = "==0.0.57" }]
+requires-dist = [
+    { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac" },
+    { name = "zensical", specifier = "==0.0.57" },
+]
 
 [[package]]
 name = "jinja2"
@@ -99,6 +103,17 @@ wheels = [
 ]
 
 [[package]]
+name = "mike"
+version = "2.2.0+zensical.0.1.0"
+source = { git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac#2d4ad799442f4592db8ad53b179bfb33db8c69ac" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyparsing" },
+    { name = "verspec" },
+    { name = "zensical" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -118,6 +133,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -171,6 +195,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,6 +22,10 @@ nav = [
 icon = "fontawesome/brands/github"
 link = "https://github.com/fullerzz/herdr-plugin-sesh"
 
+[project.extra.version]
+provider = "mike"
+default = "latest"
+
 [project.theme]
 variant = "modern"
 favicon = "assets/favicon.svg"


### PR DESCRIPTION
Add a wiki version selector for release tags and `latest`, which tracks `main`. Release snapshots use the documentation, navigation, and assets from each tag; tags before `v0.10.0` are omitted because they predate the wiki.

The Pages workflow rebuilds the versioned artifact with a pinned Zensical-compatible mike fork. Existing URLs such as `/config/` and `/development/benchmarks/` redirect to their `latest` equivalents, preserving query strings and anchors with JavaScript enabled. Contributor instructions cover local builds and previews.

Ruff linting, formatting, and type-annotation rules cover the Python documentation scripts and run through pre-commit hooks. Discovery excludes Bash scripts and JSON fixtures.

Closes #108.

Validation:
- `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` passed with only the two Python scripts selected.
- `just test-docs-versions` — release snapshots, tag/branch name collision, current checkout preview, exact canonical URLs, selector metadata, and top-level/nested redirects.
- `just build-docs` and `just build-docs-versions` — strict builds passed for `latest`, `v0.10.0`, and `v0.10.1`.
- `GOLANGCI_LINT_CACHE=/tmp/herdr-sesh-108-golangci just check` — lint, formatting, all 417 Go tests, and release-ref regression passed.
- `go vet ./...`, `just build`, `./bin/herdr-sesh --version`, and `./bin/herdr-sesh list --json --config testdata/sesh.toml` passed.
- `uv lock --check`, `git diff --check`, and commit hooks passed.
- Local HTTP checks confirmed four legacy routes and their destinations return 200; generated links, canonical URLs, and LFS images were verified.

Interactive browser verification was blocked by browser-tool local-address restrictions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


