### PR TITLE
feat(picker): add configurable active-pane previews

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -55,6 +55,7 @@ path_components = 1
 [picker]
 show_icons = true
 show_preview = true
+preview_mode = "command"
 prioritize_home = false
 herdr_theme_inherit = true
 replace_worktree_icon = true
@@ -196,6 +197,7 @@ equivalent; native decoding rejects them like any other unknown key.
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
 | `show_preview` | Shows the preview panel in the native picker. The default is `true`; set it to `false` to give the workspace list the full available width and height without running preview commands. This does not change fzf preview behavior. |
+| `preview_mode` | Sets the native picker's initial preview to `command` (the configured preview command or built-in fallback, the default) or `pane` (the active pane of the selected Herdr workspace, refreshed once per second). Press ++ctrl+o++ to switch modes while the picker is open. `show_preview = false` still disables previews. This does not affect fzf or `herdr-sesh preview`. |
 | `prioritize_home` | Controls exact case-insensitive `home` searches in the native picker. The default is `true`, which promotes the actual home-directory session ahead of real-name and ordinary path matches. Set it to `false` to keep real-name matches first, then path matches in their existing order; the actual home-directory session remains searchable through the exact `home` alias. |
 | `herdr_theme_inherit` | Inherits colors from Herdr's active theme. The default is `true`; set it to `false` to keep the native picker's built-in colors. |
 | `replace_worktree_icon` | Replaces the Herdr sheep icon with `↳` for linked worktree rows. The default is `true`. Set it to `false` to keep the sheep icon (or plain `[herdr]` when icons are hidden); the purple type color and tree branches remain. |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,5 +1,18 @@
 # Keybindings
 
+In the native picker, press ++ctrl+o++ to switch between the configured preview
+and **Pane** mode. Pane mode shows the visible terminal contents of the selected
+Herdr workspace's active pane, in its active tab, and refreshes once per second.
+It works for background workspaces without changing focus. Press ++ctrl+o++ again
+to return to the configured preview. ++ctrl+v++ pastes into the filter.
+
+Set `[picker].preview_mode = "pane"` in `config.toml` to start in Pane mode;
+the default is `"command"`. Switching modes in the picker does not change the file.
+
+Configured sessions and directories have no running pane and display an
+unavailable message in Pane mode. The toggle is disabled when
+`[picker].show_preview = false` and does not affect the fzf picker.
+
 !!! note "Prerequisite"
 
     Build and link this checkout, or install a published release with

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -212,6 +212,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		SeparatorAware:                 cfg.SeparatorAware,
 		DisableHomePrioritization:      !cfg.TUI.PrioritizeHome,
 		HidePreview:                    !cfg.TUI.ShowPreview,
+		PreviewMode:                    cfg.TUI.PreviewMode,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
 		WorkspaceSort:                  cfg.TUI.DefaultSort,
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -621,6 +621,17 @@ func TestPickerOptionsPropagatePreviewVisibility(t *testing.T) {
 	}
 }
 
+func TestPickerOptionsPropagatePreviewMode(t *testing.T) {
+	cfg := config.Default()
+	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode; got != "command" {
+		t.Fatalf("default preview mode = %q, want command", got)
+	}
+	cfg.TUI.PreviewMode = "pane"
+	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode; got != "pane" {
+		t.Fatalf("preview mode = %q, want pane", got)
+	}
+}
+
 func TestPickerOptionsPropagateHomePrioritization(t *testing.T) {
 	cfg := config.Default()
 	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.DisableHomePrioritization {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ const (
 	// Preview output is captured through sh rather than a TTY, so eza's
 	// automatic modes must be forced on explicitly.
 	DefaultPreviewCommand = "eza --icons=always --color=always -la {}"
+	DefaultPreviewMode    = "command"
 	DefaultWorkspaceSort  = "workspace"
 )
 
@@ -42,6 +43,7 @@ type TUIConfig struct {
 	ShowIcons bool `toml:"show_icons"`
 	// ShowPreview is native-only; the legacy Sesh schema has no equivalent setting.
 	ShowPreview           bool   `toml:"-"`
+	PreviewMode           string `toml:"-"`
 	PrioritizeHome        bool   `toml:"-"`
 	HerdrThemeInherit     bool   `toml:"herdr_theme_inherit"`
 	ReplaceWorktreeIcon   bool   `toml:"replace_worktree_icon"`
@@ -68,6 +70,7 @@ func Default() Config {
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
 			ShowPreview:           true,
+			PreviewMode:           DefaultPreviewMode,
 			PrioritizeHome:        true,
 			HerdrThemeInherit:     true,
 			ReplaceWorktreeIcon:   true,

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -43,6 +43,7 @@ type nativePicker struct {
 	// an always-present value keeps icon behavior self-documenting.
 	ShowIcons             bool   `toml:"show_icons"`
 	ShowPreview           *bool  `toml:"show_preview,omitempty"`
+	PreviewMode           string `toml:"preview_mode,omitempty"`
 	PrioritizeHome        *bool  `toml:"prioritize_home,omitempty"`
 	HerdrThemeInherit     *bool  `toml:"herdr_theme_inherit,omitempty"`
 	ReplaceWorktreeIcon   *bool  `toml:"replace_worktree_icon,omitempty"`
@@ -126,6 +127,9 @@ func (n nativeConfig) validate(path string) error {
 	if s := n.Picker.WorkspaceSort; s != "" && s != "workspace" && s != "recent" && s != "agent" {
 		return fail("picker.workspace_sort", "must be \"workspace\" or \"recent\" or \"agent\", got %q", s)
 	}
+	if mode := n.Picker.PreviewMode; mode != "" && mode != "command" && mode != "pane" {
+		return fail("picker.preview_mode", "must be \"command\" or \"pane\", got %q", mode)
+	}
 	seenSources := map[string]bool{}
 	for _, s := range n.List.SourceOrder {
 		if !knownSources[s] {
@@ -201,6 +205,9 @@ func (n nativeConfig) apply(cfg *Config) {
 	cfg.TUI.ShowIcons = n.Picker.ShowIcons
 	if n.Picker.ShowPreview != nil {
 		cfg.TUI.ShowPreview = *n.Picker.ShowPreview
+	}
+	if n.Picker.PreviewMode != "" {
+		cfg.TUI.PreviewMode = n.Picker.PreviewMode
 	}
 	if n.Picker.PrioritizeHome != nil {
 		cfg.TUI.PrioritizeHome = *n.Picker.PrioritizeHome

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -35,6 +35,7 @@ path_components = 2
 [picker]
 show_icons = true
 show_preview = false
+preview_mode = "pane"
 prioritize_home = false
 herdr_theme_inherit = true
 show_last_workspace = true
@@ -78,7 +79,7 @@ tabs = ["git"]
 		SeparatorAware: true,
 		SortOrder:      []string{"config", "herdr"},
 		Blacklist:      []string{"^scratch$"},
-		TUI:            TUIConfig{ShowIcons: true, PrioritizeHome: false, HerdrThemeInherit: true, ReplaceWorktreeIcon: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
+		TUI:            TUIConfig{ShowIcons: true, PreviewMode: "pane", PrioritizeHome: false, HerdrThemeInherit: true, ReplaceWorktreeIcon: true, ShowLastWorkspace: true, ShowLastWorkspacePath: true, Prompt: "P> ", Placeholder: "find", DefaultSort: "recent"},
 		DefaultSessionConfig: DefaultSessionConfig{
 			StartupCommand: "make dev",
 			PreviewCommand: "ls {}",
@@ -181,6 +182,31 @@ show_preview = false
 	}
 	if !defaults.TUI.ShowPreview {
 		t.Fatal("show_preview=false by default, want true")
+	}
+}
+
+func TestNativePickerPreviewMode(t *testing.T) {
+	for _, tc := range []struct {
+		name, setting, want string
+	}{
+		{name: "omitted", want: "command"},
+		{name: "command", setting: `preview_mode = "command"`, want: "command"},
+		{name: "pane", setting: `preview_mode = "pane"`, want: "pane"},
+		{name: "empty", setting: `preview_mode = ""`, want: "command"},
+		{name: "invalid", setting: `preview_mode = "terminal"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadNative(t, "version = 1\n[picker]\n"+tc.setting+"\n")
+			if tc.want == "" {
+				if err == nil || !strings.Contains(err.Error(), "picker.preview_mode") {
+					t.Fatalf("expected preview_mode validation error, got %v", err)
+				}
+				return
+			}
+			if err != nil || cfg.TUI.PreviewMode != tc.want {
+				t.Fatalf("mode=%q err=%v, want %q", cfg.TUI.PreviewMode, err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/herdr/pane_preview.go
+++ b/internal/herdr/pane_preview.go
@@ -1,0 +1,50 @@
+package herdr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// WorkspacePaneRead reads the selected pane of a workspace's active tab,
+// including when that workspace is not globally focused.
+func (c *CLIClient) WorkspacePaneRead(ctx context.Context, workspaceID string) (string, error) {
+	if workspaceID == "" {
+		return "", fmt.Errorf("no Herdr workspace selected")
+	}
+	out, err := c.run(ctx, "api", "snapshot")
+	if err != nil {
+		return "", err
+	}
+	raw, _, err := responseJSON(out, "api snapshot")
+	if err != nil {
+		return "", err
+	}
+	var response struct {
+		Snapshot struct {
+			Workspaces []Workspace `json:"workspaces"`
+			Layouts    []struct {
+				WorkspaceID   string `json:"workspace_id"`
+				TabID         string `json:"tab_id"`
+				FocusedPaneID string `json:"focused_pane_id"`
+			} `json:"layouts"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return "", fmt.Errorf("decode herdr api snapshot JSON: %w", err)
+	}
+	activeTabID := ""
+	for _, workspace := range response.Snapshot.Workspaces {
+		if workspace.ID == workspaceID {
+			activeTabID = workspace.ActiveTabID
+			break
+		}
+	}
+	for _, layout := range response.Snapshot.Layouts {
+		if activeTabID != "" && layout.WorkspaceID == workspaceID && layout.TabID == activeTabID && layout.FocusedPaneID != "" {
+			out, err := c.run(ctx, "pane", "read", layout.FocusedPaneID, "--source", "visible", "--format", "ansi")
+			return string(out), err
+		}
+	}
+	return "", fmt.Errorf("no active pane available for workspace %s", workspaceID)
+}

--- a/internal/herdr/pane_preview_test.go
+++ b/internal/herdr/pane_preview_test.go
@@ -1,0 +1,66 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type panePreviewRunner struct {
+	calls    [][]string
+	snapshot string
+	err      error
+}
+
+func (r *panePreviewRunner) Run(_ context.Context, _ string, args ...string) ([]byte, []byte, error) {
+	r.calls = append(r.calls, args)
+	if len(r.calls) == 1 {
+		return []byte(r.snapshot), nil, r.err
+	}
+	return []byte("\x1b[32mactive pane\x1b[0m\n"), nil, r.err
+}
+
+func TestWorkspacePaneReadTargetsBackgroundWorkspaceActiveTab(t *testing.T) {
+	r := &panePreviewRunner{snapshot: `{"result":{"snapshot":{
+		"focused_pane_id":"w1:p1",
+		"workspaces":[{"workspace_id":"w1","active_tab_id":"w1:t1"},{"workspace_id":"w2","active_tab_id":"w2:t2"}],
+		"layouts":[
+			{"workspace_id":"w1","tab_id":"w1:t1","focused_pane_id":"w1:p1"},
+			{"workspace_id":"w2","tab_id":"w2:t1","focused_pane_id":"w2:p1"},
+			{"workspace_id":"w2","tab_id":"w2:t2","focused_pane_id":"w2:p3"}]
+	}}}`}
+	c := &CLIClient{Bin: "herdr", Runner: r}
+	text, err := c.WorkspacePaneRead(context.Background(), "w2")
+	if err != nil || text != "\x1b[32mactive pane\x1b[0m\n" {
+		t.Fatalf("text=%q err=%v", text, err)
+	}
+	want := [][]string{{"api", "snapshot"}, {"pane", "read", "w2:p3", "--source", "visible", "--format", "ansi"}}
+	if !reflect.DeepEqual(r.calls, want) {
+		t.Fatalf("calls=%v want=%v", r.calls, want)
+	}
+}
+
+func TestWorkspacePaneReadRejectsMissingTargetsAndErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name, id, snapshot string
+		err                error
+	}{
+		{name: "empty workspace"},
+		{name: "closed workspace", id: "w2", snapshot: `{"result":{"snapshot":{"workspaces":[]}}}`},
+		{name: "missing layout", id: "w2", snapshot: `{"result":{"snapshot":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t2"}]}}}`},
+		{name: "invalid JSON", id: "w2", snapshot: `{`},
+		{name: "unavailable", id: "w2", err: errors.New("offline")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &panePreviewRunner{snapshot: tc.snapshot, err: tc.err}
+			c := &CLIClient{Bin: "herdr", Runner: r}
+			if _, err := c.WorkspacePaneRead(context.Background(), tc.id); err == nil {
+				t.Fatal("expected error")
+			}
+			if len(r.calls) > 1 || tc.id == "" && len(r.calls) != 0 {
+				t.Fatalf("unexpected calls: %v", r.calls)
+			}
+		})
+	}
+}

--- a/internal/herdr/pane_preview_test.go
+++ b/internal/herdr/pane_preview_test.go
@@ -58,8 +58,12 @@ func TestWorkspacePaneReadRejectsMissingTargetsAndErrors(t *testing.T) {
 			if _, err := c.WorkspacePaneRead(context.Background(), tc.id); err == nil {
 				t.Fatal("expected error")
 			}
-			if len(r.calls) > 1 || tc.id == "" && len(r.calls) != 0 {
-				t.Fatalf("unexpected calls: %v", r.calls)
+			var wantCalls [][]string
+			if tc.id != "" {
+				wantCalls = [][]string{{"api", "snapshot"}}
+			}
+			if !reflect.DeepEqual(r.calls, wantCalls) {
+				t.Fatalf("calls=%v, want %v", r.calls, wantCalls)
 			}
 		})
 	}

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -32,7 +32,11 @@ func TestPanePreviewToggleRefreshAndSelection(t *testing.T) {
 	}
 	// A completed read schedules one refresh; refreshing preserves the visible text.
 	refreshID := m.previewRequestID
-	updated, cmd = m.Update(panePreviewTickMsg{requestID: refreshID})
+	refreshTick := tick().(panePreviewTickMsg)
+	if refreshTick.requestID != refreshID {
+		t.Fatal("refresh tick did not retain the completed request ID")
+	}
+	updated, cmd = m.Update(refreshTick)
 	m = updated.(teaModel)
 	if cmd == nil || m.preview != "pane w1" {
 		t.Fatal("refresh should retain pane contents")
@@ -43,6 +47,9 @@ func TestPanePreviewToggleRefreshAndSelection(t *testing.T) {
 	m, cmd = m.refreshPreview()
 	if refreshContext.Err() == nil {
 		t.Fatal("selection change must cancel refresh")
+	}
+	if m.preview != "Loading preview..." {
+		t.Fatal("selection change must replace the previous pane snapshot with a loading message")
 	}
 	updated, _ = m.Update(cmd())
 	m = updated.(teaModel)

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -1,0 +1,144 @@
+package picker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+)
+
+func TestPanePreviewToggleRefreshAndSelection(t *testing.T) {
+	oldPane, oldPreview := renderPanePreview, renderPreview
+	t.Cleanup(func() { renderPanePreview, renderPreview = oldPane, oldPreview })
+	renderPanePreview = func(_ context.Context, s model.Session) (string, error) { return "pane " + s.WorkspaceID, nil }
+	renderPreview = func(_ context.Context, _ model.Session, command string) (string, error) { return command, nil }
+	m := newTeaModel([]model.Session{
+		{Source: "herdr", Name: "one", WorkspaceID: "w1"},
+		{Source: "herdr", Name: "two", WorkspaceID: "w2"},
+	}, Options{DefaultPreviewCommand: "configured preview"})
+	initialContext, initialID, initialKey := m.previewContext, m.previewRequestID, m.previewKey
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	if !m.panePreview || initialContext.Err() == nil || cmd == nil {
+		t.Fatal("toggle must cancel the old preview and start pane mode")
+	}
+	updated, tick := m.Update(cmd())
+	m = updated.(teaModel)
+	if m.preview != "pane w1" || tick == nil || !strings.Contains(ansi.Strip(m.previewTitle()), "PANE [ctrl+o]") {
+		t.Fatalf("preview=%q tick=%v title=%q", m.preview, tick, m.previewTitle())
+	}
+	// A completed read schedules one refresh; refreshing preserves the visible text.
+	refreshID := m.previewRequestID
+	updated, cmd = m.Update(panePreviewTickMsg{requestID: refreshID})
+	m = updated.(teaModel)
+	if cmd == nil || m.preview != "pane w1" {
+		t.Fatal("refresh should retain pane contents")
+	}
+	staleResult := cmd()
+	refreshContext := m.previewContext
+	m.list.Move(1)
+	m, cmd = m.refreshPreview()
+	if refreshContext.Err() == nil {
+		t.Fatal("selection change must cancel refresh")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(teaModel)
+	for _, stale := range []tea.Msg{staleResult, previewMsg{key: initialKey, requestID: initialID, text: "stale command"}, panePreviewTickMsg{requestID: refreshID}} {
+		updated, cmd = m.Update(stale)
+		m = updated.(teaModel)
+		if m.preview != "pane w2" || cmd != nil {
+			t.Fatal("stale preview changed selection or scheduled work")
+		}
+	}
+	paneID := m.previewRequestID
+	updated, cmd = m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	m = updated.(teaModel)
+	updated, _ = m.Update(cmd())
+	m = updated.(teaModel)
+	if m.panePreview || m.preview != "configured preview" {
+		t.Fatalf("toggle back: %q", m.preview)
+	}
+	updated, cmd = m.Update(panePreviewTickMsg{requestID: paneID})
+	m = updated.(teaModel)
+	if cmd != nil {
+		t.Fatal("pane timer survived mode switch")
+	}
+	m = m.cancelActivePreview()
+}
+
+func TestPanePreviewHiddenAndEmptyPicker(t *testing.T) {
+	for _, opts := range []Options{{HidePreview: true}, {}} {
+		m := newTeaModel(nil, opts)
+		updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+		m = updated.(teaModel)
+		if cmd != nil || opts.HidePreview && m.panePreview {
+			t.Fatal("unexpected pane preview work")
+		}
+	}
+}
+
+func TestCtrlVPastesWithoutChangingPreviewMode(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		hidden, pane bool
+	}{
+		{name: "configured preview"},
+		{name: "pane preview", pane: true},
+		{name: "hidden preview", hidden: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTeaModel([]model.Session{{Name: "api"}}, Options{HidePreview: tc.hidden})
+			m.panePreview = tc.pane
+			updated, cmd := m.Update(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+			m = updated.(teaModel)
+			if cmd == nil || m.panePreview != tc.pane {
+				t.Fatal("Ctrl+V must request clipboard paste without changing the preview")
+			}
+			m = m.cancelActivePreview()
+		})
+	}
+}
+
+func TestInitialPreviewMode(t *testing.T) {
+	oldPane, oldPreview := renderPanePreview, renderPreview
+	t.Cleanup(func() { renderPanePreview, renderPreview = oldPane, oldPreview })
+	for _, tc := range []struct {
+		name, mode, want string
+		hidden           bool
+	}{
+		{name: "default", want: "command"},
+		{name: "command", mode: "command", want: "command"},
+		{name: "pane", mode: "pane", want: "pane"},
+		{name: "hidden pane", mode: "pane", hidden: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var rendered string
+			renderPanePreview = func(context.Context, model.Session) (string, error) {
+				rendered += "pane"
+				return rendered, nil
+			}
+			renderPreview = func(context.Context, model.Session, string) (string, error) {
+				rendered += "command"
+				return rendered, nil
+			}
+			m := newTeaModel([]model.Session{{Source: "herdr", WorkspaceID: "w1"}}, Options{PreviewMode: tc.mode, HidePreview: tc.hidden})
+			executeTeaCommand(m.Init())
+			if rendered != tc.want {
+				t.Fatalf("initial renderer = %q, want %q", rendered, tc.want)
+			}
+			if !tc.hidden {
+				rendered = ""
+				updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+				m = updated.(teaModel)
+				executeTeaCommand(cmd)
+				if rendered == "" || rendered == tc.want {
+					t.Fatalf("Ctrl+O did not change renderer: %q", rendered)
+				}
+			}
+			_ = m.cancelActivePreview()
+		})
+	}
+}

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	defaultVisibleRows    = 12
-	statusRefreshInterval = time.Second
+	defaultVisibleRows         = 12
+	statusRefreshInterval      = time.Second
+	panePreviewRefreshInterval = time.Second
 
 	workspaceSortWorkspace = "workspace"
 	workspaceSortRecent    = "recent"
@@ -479,27 +480,10 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.smearTick()
 	}
 	if preview, ok := msg.(previewMsg); ok {
-		if preview.requestID == m.previewRequestID && preview.key == m.previewKey {
-			m.preview = preview.text
-			if current, ok := m.list.Current(); ok && m.panePreview && !m.hidePreview && current.Source == "herdr" && current.WorkspaceID != "" {
-				return m, tea.Tick(time.Second, func(time.Time) tea.Msg {
-					return panePreviewTickMsg{requestID: preview.requestID}
-				})
-			}
-		}
-		return m, nil
+		return m.receivePreview(preview)
 	}
 	if tick, ok := msg.(panePreviewTickMsg); ok {
-		if tick.requestID != m.previewRequestID || !m.panePreview || m.hidePreview {
-			return m, nil
-		}
-		if current, ok := m.list.Current(); ok {
-			previous := m.preview
-			m, cmd := m.startPreview(current)
-			m.preview = previous
-			return m, cmd
-		}
-		return m, nil
+		return m.refreshPanePreview(tick)
 	}
 	if closed, ok := msg.(workspaceCloseMsg); ok {
 		if closed.workspaceID != m.closingWorkspaceID {
@@ -1107,6 +1091,30 @@ func (m teaModel) previewTitle() string {
 	return title
 }
 
+func (m teaModel) receivePreview(preview previewMsg) (teaModel, tea.Cmd) {
+	if preview.requestID != m.previewRequestID || preview.key != m.previewKey {
+		return m, nil
+	}
+	m.preview = preview.text
+	if current, ok := m.list.Current(); ok && m.panePreview && !m.hidePreview && current.Source == "herdr" && current.WorkspaceID != "" {
+		return m, tea.Tick(panePreviewRefreshInterval, func(time.Time) tea.Msg {
+			return panePreviewTickMsg{requestID: preview.requestID}
+		})
+	}
+	return m, nil
+}
+
+func (m teaModel) refreshPanePreview(tick panePreviewTickMsg) (teaModel, tea.Cmd) {
+	if tick.requestID != m.previewRequestID || !m.panePreview || m.hidePreview {
+		return m, nil
+	}
+	if current, ok := m.list.Current(); ok {
+		// Keep the last snapshot visible while the next read is in flight.
+		return m.requestPreview(current)
+	}
+	return m, nil
+}
+
 func (m teaModel) refreshPreview() (teaModel, tea.Cmd) {
 	if m.hidePreview {
 		m = m.cancelActivePreview()
@@ -1137,14 +1145,18 @@ func (m teaModel) cancelActivePreview() teaModel {
 	return m
 }
 
-//nolint:contextcheck // Bubble Tea persists the caller context on the model between messages.
 func (m teaModel) startPreview(s sessionmodel.Session) (teaModel, tea.Cmd) {
+	m.preview = "Loading preview..."
+	return m.requestPreview(s)
+}
+
+//nolint:contextcheck // Bubble Tea persists the caller context on the model between messages.
+func (m teaModel) requestPreview(s sessionmodel.Session) (teaModel, tea.Cmd) {
 	m = m.cancelActivePreview()
 	ctx, cancel := context.WithCancel(m.previewParentContext)
 	m.previewContext = ctx
 	m.cancelPreview = cancel
 	m.previewKey = sessionmodel.Key(s)
-	m.preview = "Loading preview..."
 	return m, previewCommand(ctx, m.previewKey, m.previewRequestID, s, m.defaultPreviewCommand, m.panePreview)
 }
 

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -125,6 +125,7 @@ var (
 )
 
 var renderPreview = previewpkg.Render
+var renderPanePreview = previewpkg.RenderPane
 
 type Options struct {
 	Context                        context.Context
@@ -139,6 +140,7 @@ type Options struct {
 	SeparatorAware                 bool
 	DisableHomePrioritization      bool
 	HidePreview                    bool
+	PreviewMode                    string
 	DefaultPreviewCommand          string
 	FZFCommand                     string
 	RefreshAgentStatuses           func() (map[string]string, error)
@@ -207,6 +209,7 @@ type teaModel struct {
 	previewContext       context.Context
 	cancelPreview        context.CancelFunc
 	previewRequestID     uint64
+	panePreview          bool
 
 	defaultPreviewCommand   string
 	hidePreview             bool
@@ -235,6 +238,8 @@ type previewMsg struct {
 	requestID uint64
 	text      string
 }
+
+type panePreviewTickMsg struct{ requestID uint64 }
 
 type statusRefreshTickMsg struct{}
 
@@ -304,6 +309,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		hidePreview:           opts.HidePreview,
+		panePreview:           opts.PreviewMode == "pane",
 		showIcons:             opts.ShowIcons,
 		replaceWorktreeIcon:   !opts.DisableWorktreeIconReplacement,
 		hideLastWorkspace:     opts.HideLastWorkspace,
@@ -331,7 +337,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 func (m teaModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{m.input.Focus()}
 	if current, ok := m.list.Current(); ok && m.previewKey != "" {
-		cmds = append(cmds, previewCommand(m.previewContext, m.previewKey, m.previewRequestID, current, m.defaultPreviewCommand))
+		cmds = append(cmds, previewCommand(m.previewContext, m.previewKey, m.previewRequestID, current, m.defaultPreviewCommand, m.panePreview))
 	}
 	if m.refreshAgentStatuses != nil {
 		cmds = append(cmds, scheduleStatusRefresh(), m.agentSpinner.Tick)
@@ -475,6 +481,23 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if preview, ok := msg.(previewMsg); ok {
 		if preview.requestID == m.previewRequestID && preview.key == m.previewKey {
 			m.preview = preview.text
+			if current, ok := m.list.Current(); ok && m.panePreview && !m.hidePreview && current.Source == "herdr" && current.WorkspaceID != "" {
+				return m, tea.Tick(time.Second, func(time.Time) tea.Msg {
+					return panePreviewTickMsg{requestID: preview.requestID}
+				})
+			}
+		}
+		return m, nil
+	}
+	if tick, ok := msg.(panePreviewTickMsg); ok {
+		if tick.requestID != m.previewRequestID || !m.panePreview || m.hidePreview {
+			return m, nil
+		}
+		if current, ok := m.list.Current(); ok {
+			previous := m.preview
+			m, cmd := m.startPreview(current)
+			m.preview = previous
+			return m, cmd
 		}
 		return m, nil
 	}
@@ -600,6 +623,13 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(focusCmd, previewCmd)
 	case "ctrl+r":
 		return m.toggleWorkspaceSort()
+	case "ctrl+o":
+		if m.hidePreview || m.closingWorkspaceID != "" {
+			return m, nil
+		}
+		m.panePreview = !m.panePreview
+		m.previewKey = ""
+		return m.refreshPreview()
 	case "ctrl+x":
 		return m.closeSelectedWorkspace()
 	case "right":
@@ -1053,6 +1083,10 @@ func (m teaModel) previewView(width, maxLines int) string {
 
 func (m teaModel) previewTitle() string {
 	title := sectionStyle.Render("PREVIEW")
+	if m.panePreview {
+		title = sectionStyle.Render("PANE")
+	}
+	title += countStyle.Render(" [ctrl+o]")
 	current, ok := m.list.Current()
 	if !ok {
 		return title
@@ -1111,7 +1145,7 @@ func (m teaModel) startPreview(s sessionmodel.Session) (teaModel, tea.Cmd) {
 	m.cancelPreview = cancel
 	m.previewKey = sessionmodel.Key(s)
 	m.preview = "Loading preview..."
-	return m, previewCommand(ctx, m.previewKey, m.previewRequestID, s, m.defaultPreviewCommand)
+	return m, previewCommand(ctx, m.previewKey, m.previewRequestID, s, m.defaultPreviewCommand, m.panePreview)
 }
 
 func (m teaModel) focusList() (teaModel, tea.Cmd) {
@@ -1290,9 +1324,15 @@ func overlayCell(line string, column int, cell string, width int) string {
 	return fitLine(ansi.Cut(line, 0, column)+cell+ansi.Cut(line, column+1, width), width)
 }
 
-func previewCommand(ctx context.Context, key string, requestID uint64, s sessionmodel.Session, defaultPreviewCommand string) tea.Cmd {
+func previewCommand(ctx context.Context, key string, requestID uint64, s sessionmodel.Session, defaultPreviewCommand string, pane bool) tea.Cmd {
 	return func() tea.Msg {
-		text, err := renderPreview(ctx, s, defaultPreviewCommand)
+		var text string
+		var err error
+		if pane {
+			text, err = renderPanePreview(ctx, s)
+		} else {
+			text, err = renderPreview(ctx, s, defaultPreviewCommand)
+		}
 		if err != nil {
 			text = err.Error()
 		}

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -901,10 +901,10 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 30})
 	m = updated.(teaModel)
-	updated, _ = m.Update(previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)())
+	updated, _ = m.Update(previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand, false)())
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
-	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "LAST WORKSPACE · workspace-api  /tmp/workspace-api", "WORKSPACES", "PREVIEW · workspace-api · working", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
+	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "LAST WORKSPACE · workspace-api  /tmp/workspace-api", "WORKSPACES", "PREVIEW [ctrl+o] · workspace-api", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}
@@ -964,7 +964,7 @@ func TestTeaModelViewGroupsAndDescribesWorktreeFamily(t *testing.T) {
 	if parentLine < 0 || firstChildLine != parentLine+1 || lastChildLine != firstChildLine+1 {
 		t.Fatalf("worktree family is not parent-first with tree branches:\n%s", view)
 	}
-	if !strings.Contains(view, "PREVIEW · feature · worktree of project") {
+	if !strings.Contains(view, "PREVIEW [ctrl+o] · feature · worktree of project") {
 		t.Fatalf("view missing worktree preview context:\n%s", view)
 	}
 	if got, want := maxLineWidth(view), 160; got != want {
@@ -1376,7 +1376,7 @@ func TestPreviewTitleShowsUnresolvedLinkedWorktree(t *testing.T) {
 	}}, Options{})
 
 	got := ansi.Strip(m.previewTitle())
-	if !strings.Contains(got, "PREVIEW · feature · linked worktree") || strings.Contains(got, "worktree of") {
+	if !strings.Contains(got, "PREVIEW [ctrl+o] · feature · linked worktree") || strings.Contains(got, "worktree of") {
 		t.Fatalf("preview title=%q", got)
 	}
 }
@@ -1399,14 +1399,14 @@ func TestPreviewTitleShowsWorktreeParentBeforeAgentStatus(t *testing.T) {
 	m.list.Selected = 1
 
 	got := ansi.Strip(m.previewTitle())
-	if !strings.Contains(got, "PREVIEW · feature · worktree of parent · working") {
+	if !strings.Contains(got, "PREVIEW [ctrl+o] · feature · worktree of parent · working") {
 		t.Fatalf("preview title=%q", got)
 	}
 }
 
 func TestTeaModelPreviewUsesConfiguredCommand(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}}, Options{DefaultPreviewCommand: "printf preview:%s {}"})
-	msg := previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand)()
+	msg := previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand, false)()
 	preview := msg.(previewMsg)
 	if got := strings.TrimSpace(preview.text); got != "preview:/tmp/api" {
 		t.Fatalf("preview=%q", preview.text)
@@ -1939,7 +1939,7 @@ func TestTeaModelStacksPreviewAtNarrowWidth(t *testing.T) {
 	if got, want := lipgloss.Height(view), 28; got != want {
 		t.Fatalf("view height=%d, want %d:\n%s", got, want, view)
 	}
-	if !strings.Contains(view, "WORKSPACES") || !strings.Contains(view, "PREVIEW · api · blocked") {
+	if !strings.Contains(view, "WORKSPACES") || !strings.Contains(view, "PREVIEW [ctrl+o] · api · blocked") {
 		t.Fatalf("narrow view missing stacked sections:\n%s", view)
 	}
 	if strings.Contains(view, "│") {

--- a/internal/preview/preview.go
+++ b/internal/preview/preview.go
@@ -14,8 +14,18 @@ import (
 	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
+	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
+
+func RenderPane(ctx context.Context, s model.Session) (string, error) {
+	if s.Source != "herdr" || s.WorkspaceID == "" {
+		return "Pane preview is only available for running Herdr workspaces\n", nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return herdr.NewCLIClient().WorkspacePaneRead(ctx, s.WorkspaceID)
+}
 
 func Render(ctx context.Context, s model.Session, fallbackCommand string) (string, error) {
 	if s.Path == "" {

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
 
+func TestRenderPaneWithoutRunningWorkspace(t *testing.T) {
+	t.Setenv("HERDR_BIN_PATH", "/does-not-exist")
+	for _, s := range []model.Session{{Source: "config", Path: "/tmp"}, {Source: "herdr"}} {
+		text, err := RenderPane(context.Background(), s)
+		if err != nil || !strings.Contains(text, "only available for running Herdr workspaces") {
+			t.Fatalf("text=%q err=%v", text, err)
+		}
+	}
+}
+
+func TestRenderPaneUsesHerdrWithoutSessionPath(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "herdr")
+	script := `#!/bin/sh
+case "$*" in
+  'api snapshot')
+    printf '%s' '{"result":{"snapshot":{"workspaces":[{"workspace_id":"w2","active_tab_id":"w2:t1"}],"layouts":[{"workspace_id":"w2","tab_id":"w2:t1","focused_pane_id":"w2:p2"}]}}}' ;;
+  'pane read w2:p2 --source visible --format ansi')
+    printf '\033[32mterminal output\033[0m\n' ;;
+  *) exit 1 ;;
+esac
+`
+	//nolint:gosec // the fake Herdr binary must be executable for this test.
+	if err := os.WriteFile(bin, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_BIN_PATH", bin)
+	text, err := RenderPane(context.Background(), model.Session{Source: "herdr", WorkspaceID: "w2", PreviewCommand: "exit 1"})
+	if err != nil || text != "\x1b[32mterminal output\x1b[0m\n" {
+		t.Fatalf("text=%q err=%v", text, err)
+	}
+}
+
 func TestRenderUsesPreviewCommand(t *testing.T) {
 	out, err := Render(context.Background(), model.Session{Path: "/tmp/has space", PreviewCommand: "printf %s {}"}, "")
 	if err != nil {


### PR DESCRIPTION
## Summary

Add a native picker preview that displays the active pane of the selected Herdr workspace, including background workspaces, with colors and automatic refreshes. Resolve the pane from the workspace's active tab and cancel outdated reads when selection or mode changes.

Use Ctrl+O to switch between command and pane previews, preserving Ctrl+V paste. Add `picker.preview_mode` to choose the initial mode, defaulting to `command`.

## Related issue

N/A

## Validation

- [x] `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-pane-preview-lint-cache just check` — 444 race-enabled tests, lint, formatting, and release-reference checks passed.
- [x] `just build`
- [x] `just build-docs`
- [x] `go vet ./...`
- [x] `./bin/herdr-sesh --version` — `herdr-sesh v0.10.1-9-g647cbb4`
- [x] `env HERDR_BIN_PATH=/usr/bin/false ./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml`
- [x] `git diff --check origin/main...HEAD`

Regression coverage includes background-workspace targeting, missing panes and API errors, mode switching, stale results, initial configuration, hidden previews, and clipboard paste. Pane reads were verified with a fake Herdr CLI and the Herdr v0.8.2 source schema; a live Herdr session was unavailable.

## User-facing changes

Start the native picker in pane mode with:

```toml
[picker]
preview_mode = "pane"
```

`command` preserves the existing preview behavior. `show_preview = false` disables either mode. Updated configuration and keybinding documentation explains the setting and Ctrl+O toggle; fzf and the standalone preview command retain their existing behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

