### PR TITLE
feat(picker): resize preview by dragging divider

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -208,6 +208,11 @@ equivalent; native decoding rejects them like any other unknown key.
 | `show_last_workspace` | Shows the workspace targeted by `herdr-sesh last` in the picker footer. The default is `true`; set it to `false` to disable the feature. |
 | `show_last_workspace_path` | Shows the Herdr workspace working directory beside the last workspace name. The default is `true`; set it to `false` to show only the workspace name. |
 
+When the native picker shows the preview beside the workspace list, click and
+drag the vertical divider with the left mouse button to resize it. Both panels
+keep a minimum width. The chosen width lasts until the picker closes; narrow
+terminals continue to show the preview below the list.
+
 Set `HERDR_SESH_SMEAR_PRESET` to choose the cursor animation:
 
 | Preset | Effect |

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -38,6 +38,7 @@ const (
 	defaultWidth       = 80
 	previewSplitWidth  = 92
 	minPreviewWidth    = 36
+	minListWidth       = 36
 	maxPreviewWidth    = 52
 	previewTitleRows   = 1
 	pickerChromeRows   = 8
@@ -205,6 +206,8 @@ type teaModel struct {
 	smear               smearPreset
 
 	preview              string
+	previewWidth         int
+	draggingPreview      bool
 	previewKey           string
 	previewParentContext context.Context
 	previewContext       context.Context
@@ -544,7 +547,11 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width = size.Width
 		m.height = size.Height
+		m.draggingPreview = false
 		return m, nil
+	}
+	if mouse, ok := msg.(tea.MouseMsg); ok {
+		return m.resizePreview(mouse), nil
 	}
 	if _, ok := msg.(tea.PasteMsg); ok {
 		return m.updateInput(msg)
@@ -721,7 +728,7 @@ func refreshAgentStatusesCommand(refresh func() (map[string]string, error)) tea.
 
 func (m teaModel) View() tea.View {
 	width := m.contentWidth()
-	listWidth, previewWidth := previewLayout(width)
+	listWidth, previewWidth := m.previewLayout()
 	lines := []string{"", m.header(width), horizontalRule(width)}
 	input := m.input
 	input.SetWidth(maxInt(8, width-lipgloss.Width(input.Prompt)-1))
@@ -771,6 +778,9 @@ func (m teaModel) View() tea.View {
 	}
 	view := tea.NewView(strings.Join(framed, "\n"))
 	view.AltScreen = true
+	if previewWidth > 0 {
+		view.MouseMode = tea.MouseModeCellMotion
+	}
 	return view
 }
 
@@ -1198,7 +1208,7 @@ func (m teaModel) focusSmearDistance() int {
 	visibleRows := m.previewBodyLines()
 	if m.hidePreview {
 		visibleRows = m.listOnlyBodyLines()
-	} else if _, previewWidth := previewLayout(m.contentWidth()); previewWidth == 0 {
+	} else if _, previewWidth := m.previewLayout(); previewWidth == 0 {
 		visibleRows, _ = m.stackedBodyLines()
 	}
 	start, _, moreAbove, _ := listWindow(len(m.list.Filtered), m.list.Selected, visibleRows)
@@ -1356,18 +1366,44 @@ func previewCommand(ctx context.Context, key string, requestID uint64, s session
 	}
 }
 
-func previewLayout(width int) (int, int) {
-	if width < previewSplitWidth-horizontalPadding*2 {
+func (m teaModel) previewLayout() (int, int) {
+	width := m.contentWidth()
+	if m.hidePreview || width < previewSplitWidth-horizontalPadding*2 {
 		return width, 0
 	}
-	previewWidth := width / 2
-	if previewWidth > maxPreviewWidth {
-		previewWidth = maxPreviewWidth
+	previewWidth := m.previewWidth
+	if previewWidth == 0 {
+		previewWidth = min(width/2, maxPreviewWidth)
 	}
-	if previewWidth < minPreviewWidth {
-		previewWidth = minPreviewWidth
-	}
+	previewWidth = min(max(previewWidth, minPreviewWidth), width-minListWidth-3)
 	return width - previewWidth - 3, previewWidth
+}
+
+func (m teaModel) resizePreview(msg tea.MouseMsg) teaModel {
+	listWidth, previewWidth := m.previewLayout()
+	if previewWidth == 0 {
+		m.draggingPreview = false
+		return m
+	}
+	switch mouse := msg.(type) {
+	case tea.MouseClickMsg:
+		// joinPanels places the divider after the list and one space.
+		m.draggingPreview = mouse.Button == tea.MouseLeft &&
+			mouse.X == horizontalPadding+listWidth+1 &&
+			mouse.Y >= listFirstRowIndex-previewTitleRows &&
+			mouse.Y < listFirstRowIndex+m.previewBodyLines()
+	case tea.MouseMotionMsg:
+		if mouse.Button != tea.MouseLeft {
+			m.draggingPreview = false
+		}
+		if m.draggingPreview {
+			width := m.contentWidth()
+			m.previewWidth = min(max(width+horizontalPadding-mouse.X-2, minPreviewWidth), width-minListWidth-3)
+		}
+	case tea.MouseReleaseMsg:
+		m.draggingPreview = false
+	}
+	return m
 }
 
 func fixedVisualLines(text string, width, count int) string {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -46,6 +46,90 @@ func TestTeaModelHomePrioritizationOption(t *testing.T) {
 	}
 }
 
+func TestTeaModelDragsPreviewDivider(t *testing.T) {
+	m := newTeaModel([]model.Session{{Name: "api"}, {Name: "web"}}, Options{})
+	t.Cleanup(func() { m.cancelActivePreview() })
+	m.width, m.height = 120, 28
+	m.list.Selected = 1
+	m.preview = strings.Repeat("preview ", 30)
+	previewID := m.previewRequestID
+	if m.View().MouseMode != tea.MouseModeCellMotion {
+		t.Fatal("picker must request mouse drag events")
+	}
+	for _, step := range []struct {
+		name string
+		msg  tea.Msg
+		x    int
+	}{
+		{"press", tea.MouseClickMsg{X: 64, Y: 5, Button: tea.MouseLeft}, 64},
+		{"widen", tea.MouseMotionMsg{X: 54, Y: 6, Button: tea.MouseLeft}, 54},
+		{"minimum list", tea.MouseMotionMsg{X: 0, Y: 0, Button: tea.MouseLeft}, 39},
+		{"minimum preview", tea.MouseMotionMsg{X: 200, Y: 40, Button: tea.MouseLeft}, 80},
+		{"drag back", tea.MouseMotionMsg{X: 54, Y: 6, Button: tea.MouseLeft}, 54},
+		{"release outside", tea.MouseReleaseMsg{X: 54, Y: 40, Button: tea.MouseLeft}, 54},
+		{"motion after release", tea.MouseMotionMsg{X: 70, Y: 6, Button: tea.MouseLeft}, 54},
+		{"terminal shrinks", tea.WindowSizeMsg{Width: 92, Height: 28}, 39},
+		{"terminal expands", tea.WindowSizeMsg{Width: 120, Height: 28}, 54},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			updated, cmd := m.Update(step.msg)
+			m = updated.(teaModel)
+			if cmd != nil || m.previewRequestID != previewID || m.list.Selected != 1 || m.input.Value() != "" {
+				t.Fatal("resizing changed picker selection/input or requested a new preview")
+			}
+			lines := strings.Split(ansi.Strip(m.View().Content), "\n")
+			for y := 5; y < 5+previewTitleRows+m.previewBodyLines(); y++ {
+				if cell := ansi.Cut(lines[y], step.x, step.x+1); cell != "│" {
+					t.Fatalf("divider at (%d,%d) = %q", step.x, y, cell)
+				}
+				if width := lipgloss.Width(lines[y]); width != m.width {
+					t.Fatalf("rendered width = %d, want %d", width, m.width)
+				}
+			}
+		})
+	}
+}
+
+func TestTeaModelIgnoresMouseOutsidePreviewDivider(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		width  int
+		hidden bool
+		click  tea.MouseClickMsg
+		after  tea.Msg
+	}{
+		{name: "list", width: 120, click: tea.MouseClickMsg{X: 63, Y: 6, Button: tea.MouseLeft}},
+		{name: "preview", width: 120, click: tea.MouseClickMsg{X: 65, Y: 6, Button: tea.MouseLeft}},
+		{name: "header", width: 120, click: tea.MouseClickMsg{X: 64, Y: 4, Button: tea.MouseLeft}},
+		{name: "footer", width: 120, click: tea.MouseClickMsg{X: 64, Y: 25, Button: tea.MouseLeft}},
+		{name: "right button", width: 120, click: tea.MouseClickMsg{X: 64, Y: 6, Button: tea.MouseRight}},
+		{name: "hidden", width: 120, hidden: true, click: tea.MouseClickMsg{X: 64, Y: 6, Button: tea.MouseLeft}},
+		{name: "stacked", width: 80, click: tea.MouseClickMsg{X: 64, Y: 6, Button: tea.MouseLeft}},
+		{name: "resize cancels drag", width: 120, click: tea.MouseClickMsg{X: 64, Y: 6, Button: tea.MouseLeft}, after: tea.WindowSizeMsg{Width: 120, Height: 28}},
+		{name: "buttonless motion cancels drag", width: 120, click: tea.MouseClickMsg{X: 64, Y: 6, Button: tea.MouseLeft}, after: tea.MouseMotionMsg{X: 64, Y: 6}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTeaModel(nil, Options{HidePreview: tc.hidden})
+			m.width, m.height = tc.width, 28
+			before := m.View()
+			if (tc.hidden || tc.width < previewSplitWidth) && before.MouseMode != tea.MouseModeNone {
+				t.Fatal("mouse reporting enabled without a divider")
+			}
+			updated, _ := m.Update(tc.click)
+			m = updated.(teaModel)
+			if tc.after != nil {
+				updated, _ = m.Update(tc.after)
+				m = updated.(teaModel)
+			}
+			updated, _ = m.Update(tea.MouseMotionMsg{X: 54, Y: 6, Button: tea.MouseLeft})
+			m = updated.(teaModel)
+			if got := m.View().Content; got != before.Content {
+				t.Fatal("mouse events outside an active divider drag changed the view")
+			}
+		})
+	}
+}
+
 func TestTeaModelFiltersMovesAndChooses(t *testing.T) {
 	m := newTeaModel([]model.Session{
 		{Name: "api-service", Path: "/tmp/api"},


### PR DESCRIPTION
## Summary

Allow users to resize the native picker's side-by-side preview by left-clicking and dragging the vertical divider. Keep both panels at least 36 columns wide, retain the chosen width for the picker session, and preserve the stacked layout on narrow terminals.

Use Bubble Tea's existing mouse support without adding dependencies. Regression tests cover divider hit testing, width limits, release and terminal-resize handling, and preserving selection, input, and preview requests.

## Related issue

N/A

## Validation

- [x] `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-preview-drag-lint just check` — 464 tests passed, including race checks; lint, formatting, and release-reference checks passed.
- [x] `just build`
- [x] `just build-docs` — strict build passed.
- [x] `go vet ./...`
- [x] `./bin/herdr-sesh --version`
- [x] `./bin/herdr-sesh list --json --config testdata/sesh.toml >/dev/null`
- [x] `git diff --check`

Validated after rebasing onto `main` at `a843c11`.

## User-facing changes

Drag the vertical divider to change preview width; the width resets when the picker closes. Documented in `docs/config.md`.

Build smoke output:

```text
herdr-sesh v0.10.1-10-g7cb2e35
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

