### PR TITLE
test: adopt testify assertions across the test suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@
 version: "2"
 linters:
   settings:
+    testifylint:
+      enable-all: true
     revive:
       rules:
         - name: exported

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ Tool versions belong in `mise.toml`; update that file when adding or changing sh
 
 Tests use Go's standard `testing` package and live beside the code as `*_test.go`. Name tests as `Test<Behavior>` and keep file fixtures in `testdata/`. New behavior should include the smallest focused regression test.
 
+Use Testify `require` for prerequisites (errors, lengths, and nil checks before accessing results) and `assert` for independent expectations. Keep `require` on the test goroutine; report worker errors back to it. `testifylint` checks assertion usage through `just lint`.
+
 ## Commit & Pull Request Guidelines
 
 Recent commits use Conventional Commit-style subjects, for example `feat: cache session list when enabled` and `fix: pad native picker top border`. Keep subjects imperative and scoped when useful (`feat:`, `fix:`, `ci:`, `docs:`).

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/pelletier/go-toml/v2 v2.4.3
+	github.com/stretchr/testify v1.12.1
 )
 
 require (
@@ -25,6 +26,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/perf v0.0.0-20260825160852-19be9d8e6c70 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,12 @@ github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdD
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b h1:3XR0v9KL97wjTmRb+6RqMylL4d7ZWM1sQYIITGDxtmg=
 golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/perf v0.0.0-20260825160852-19be9d8e6c70 h1:M+kM03JKR23KkrutTue5KEQYDSbZTZTJ4FJ1v5zYrHM=

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -21,17 +21,15 @@ import (
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/state"
 	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionCommand(t *testing.T) {
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"--version"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != "herdr-sesh dev" {
-		t.Fatalf("got %q", out.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"--version"}))
+	assert.Equal(t, "herdr-sesh dev", strings.TrimSpace(out.String()))
 }
 
 func TestConfigPathCommand(t *testing.T) {
@@ -42,25 +40,15 @@ func TestConfigPathCommand(t *testing.T) {
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"config", "path"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "path"}))
 	want := filepath.Join(d, "config.toml")
-	if strings.TrimSpace(out.String()) != want {
-		t.Fatalf("no-candidate path = %q, want %q", out.String(), want)
-	}
+	require.Equal(t, want, strings.TrimSpace(out.String()))
 
 	legacy := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 	out.Reset()
-	if err := a.Run(context.Background(), []string{"config", "path"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != legacy {
-		t.Fatalf("legacy path = %q, want %q", out.String(), legacy)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "path"}))
+	assert.Equal(t, legacy, strings.TrimSpace(out.String()))
 }
 
 func TestConfigValidatePrintsResolvedNativePath(t *testing.T) {
@@ -69,80 +57,52 @@ func TestConfigValidatePrintsResolvedNativePath(t *testing.T) {
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", d)
 	native := filepath.Join(d, config.NativeFileName)
-	if err := os.WriteFile(native, []byte("version = 1\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(native, []byte("version = 1\n"), 0600))
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"config", "validate"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != native {
-		t.Fatalf("stdout = %q, want %q", out.String(), native)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "validate"}))
+	assert.Equal(t, native, strings.TrimSpace(out.String()))
 }
 
 func TestConfigValidateWarnsForLegacyConfig(t *testing.T) {
 	legacy := filepath.Join(t.TempDir(), config.LegacyFileName)
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 
 	var out, errb bytes.Buffer
 	a := &App{Out: &out, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "validate", legacy}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != legacy {
-		t.Fatalf("stdout = %q, want %q", out.String(), legacy)
-	}
-	if !strings.Contains(errb.String(), "deprecated Sesh-compatible schema") {
-		t.Fatalf("stderr = %q, want legacy deprecation warning", errb.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "validate", legacy}))
+	require.Equal(t, legacy, strings.TrimSpace(out.String()))
+	assert.Contains(t, errb.String(), "deprecated Sesh-compatible schema")
 }
 
 func TestConfigValidateRejectsUnknownLegacyKey(t *testing.T) {
 	legacy := filepath.Join(t.TempDir(), config.LegacyFileName)
-	if err := os.WriteFile(legacy, []byte("cahe = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cahe = true\n"), 0600))
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate", legacy})
-	if err == nil || !strings.Contains(err.Error(), "cahe") {
-		t.Fatalf("err = %v, want unknown legacy key", err)
-	}
+	require.ErrorContains(t, err, "cahe")
 }
 
 func TestConfigValidateRejectsUnknownLegacyKeyInImport(t *testing.T) {
 	d := t.TempDir()
-	if err := os.WriteFile(filepath.Join(d, "extra.toml"), []byte("cahe = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(d, "extra.toml"), []byte("cahe = true\n"), 0600))
 	legacy := filepath.Join(d, config.LegacyFileName)
-	if err := os.WriteFile(legacy, []byte("import = [\"extra.toml\"]\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("import = [\"extra.toml\"]\n"), 0600))
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate", legacy})
-	if err == nil || !strings.Contains(err.Error(), "cahe") {
-		t.Fatalf("err = %v, want unknown imported legacy key", err)
-	}
+	require.ErrorContains(t, err, "cahe")
 }
 
 func TestConfigValidateRejectsInvalidNativeConfig(t *testing.T) {
 	native := filepath.Join(t.TempDir(), config.NativeFileName)
-	if err := os.WriteFile(native, []byte("version = 1\nunknown = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(native, []byte("version = 1\nunknown = true\n"), 0600))
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate", native})
-	if err == nil || !strings.Contains(err.Error(), "unknown keys") {
-		t.Fatalf("err = %v, want native validation error", err)
-	}
+	require.ErrorContains(t, err, "unknown keys")
 }
 
 func TestConfigValidateRequiresExistingConfig(t *testing.T) {
@@ -153,17 +113,13 @@ func TestConfigValidateRequiresExistingConfig(t *testing.T) {
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate"})
-	if err == nil || !strings.Contains(err.Error(), "no config file found") {
-		t.Fatalf("err = %v, want missing config error", err)
-	}
+	require.ErrorContains(t, err, "no config file found")
 }
 
 func TestConfigValidateAcceptsAtMostOnePath(t *testing.T) {
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate", "first.toml", "second.toml"})
-	if err == nil || !strings.Contains(err.Error(), "accepts at most one path") {
-		t.Fatalf("err = %v, want extra path error", err)
-	}
+	require.ErrorContains(t, err, "accepts at most one path")
 }
 
 func TestConfigValidateRejectsEmptyPath(t *testing.T) {
@@ -174,9 +130,7 @@ func TestConfigValidateRejectsEmptyPath(t *testing.T) {
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "validate", ""})
-	if err == nil || !strings.Contains(err.Error(), "path must not be empty") {
-		t.Fatalf("err = %v, want empty path error", err)
-	}
+	require.ErrorContains(t, err, "path must not be empty")
 }
 
 func TestConfigInitDoesNotShadowActiveLegacyConfig(t *testing.T) {
@@ -185,21 +139,14 @@ func TestConfigInitDoesNotShadowActiveLegacyConfig(t *testing.T) {
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", d)
 	legacy := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"config", "init"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != legacy {
-		t.Fatalf("init printed %q, want existing legacy %q", out.String(), legacy)
-	}
-	if _, err := os.Stat(filepath.Join(d, "config.toml")); !os.IsNotExist(err) {
-		t.Fatalf("init created shadowing config.toml: %v", err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "init"}))
+	require.Equal(t, legacy, strings.TrimSpace(out.String()))
+	_, err := os.Stat(filepath.Join(d, "config.toml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestConfigInitHonorsEnvTarget(t *testing.T) {
@@ -211,19 +158,11 @@ func TestConfigInitHonorsEnvTarget(t *testing.T) {
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"config", "init"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != target {
-		t.Fatalf("init printed %q, want env target %q", out.String(), target)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "init"}))
+	require.Equal(t, target, strings.TrimSpace(out.String()))
 	cfg, _, err := config.Load(config.LoadOptions{Path: target, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != config.DefaultPreviewCommand {
-		t.Fatalf("starter preview = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, config.DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestConfigInitRejectsDirectoryCandidate(t *testing.T) {
@@ -231,15 +170,11 @@ func TestConfigInitRejectsDirectoryCandidate(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", d)
-	if err := os.Mkdir(filepath.Join(d, config.NativeFileName), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(filepath.Join(d, config.NativeFileName), 0700))
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "init"})
-	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
-		t.Fatalf("err = %v, want non-regular config path error", err)
-	}
+	require.ErrorContains(t, err, "not a regular file")
 }
 
 func TestConfigInitPropagatesResolveError(t *testing.T) {
@@ -247,21 +182,14 @@ func TestConfigInitPropagatesResolveError(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", "")
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", home)
-	if err := os.MkdirAll(filepath.Join(home, ".config"), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".config", "sesh"), []byte("blocked\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".config", "sesh"), []byte("blocked\n"), 0600))
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	err := a.Run(context.Background(), []string{"config", "init"})
-	if !errors.Is(err, syscall.ENOTDIR) {
-		t.Fatalf("err = %v, want higher-priority filesystem error", err)
-	}
-	if _, statErr := os.Stat(filepath.Join(home, ".config", "herdr-sesh", config.NativeFileName)); !os.IsNotExist(statErr) {
-		t.Fatalf("init created config after resolver error: %v", statErr)
-	}
+	require.ErrorIs(t, err, syscall.ENOTDIR)
+	_, statErr := os.Stat(filepath.Join(home, ".config", "herdr-sesh", config.NativeFileName))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
 func TestConfigMigrateCommand(t *testing.T) {
@@ -270,34 +198,23 @@ func TestConfigMigrateCommand(t *testing.T) {
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", d)
 	legacy := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(legacy, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600))
 
 	var out, errb bytes.Buffer
 	a := &App{Out: &out, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "migrate"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate"}))
 	native := filepath.Join(d, "config.toml")
-	if strings.TrimSpace(out.String()) != native {
-		t.Fatalf("stdout = %q, want %q", out.String(), native)
-	}
-	if !strings.Contains(errb.String(), "delete the legacy file") {
-		t.Fatalf("stderr = %q", errb.String())
-	}
+	require.Equal(t, native, strings.TrimSpace(out.String()))
+	require.Contains(t, errb.String(), "delete the legacy file")
 	cfg, _, err := config.Load(config.LoadOptions{Path: native, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.Cache || len(cfg.SessionConfigs) != 1 || cfg.SessionConfigs[0].Name != "api" {
-		t.Fatalf("migrated cfg = %#v", cfg)
-	}
+	require.NoError(t, err)
+	require.True(t, cfg.Cache)
+	require.Len(t, cfg.SessionConfigs, 1)
+	require.Equal(t, "api", cfg.SessionConfigs[0].Name)
 	// The native file now wins discovery over the untouched legacy file.
 	got, err := config.ResolvePath(config.LoadOptions{})
-	if err != nil || got != native {
-		t.Fatalf("resolved %q err %v, want %q", got, err, native)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, native, got)
 }
 
 func TestConfigMigrateForceOverwritesExistingNativeConfig(t *testing.T) {
@@ -306,29 +223,17 @@ func TestConfigMigrateForceOverwritesExistingNativeConfig(t *testing.T) {
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", d)
 	legacy := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 	native := filepath.Join(d, config.NativeFileName)
-	if err := os.WriteFile(native, []byte("version = 1\n[list]\ncache = false\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(native, []byte("version = 1\n[list]\ncache = false\n"), 0600))
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"config", "migrate", legacy, "--force"}); err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out.String()) != native {
-		t.Fatalf("stdout = %q, want %q", out.String(), native)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate", legacy, "--force"}))
+	require.Equal(t, native, strings.TrimSpace(out.String()))
 	cfg, _, err := config.Load(config.LoadOptions{Path: native, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.Cache {
-		t.Fatal("forced migration did not replace existing native config")
-	}
+	require.NoError(t, err)
+	assert.True(t, cfg.Cache, "forced migration did not replace existing native config")
 }
 
 func TestConfigMigrateWarnsToRepointEnvBeforeDeletingLegacy(t *testing.T) {
@@ -338,19 +243,13 @@ func TestConfigMigrateWarnsToRepointEnvBeforeDeletingLegacy(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", d)
 	t.Setenv("HERDR_SESH_CONFIG", legacy)
 	t.Setenv("HOME", d)
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 
 	var errb bytes.Buffer
 	a := &App{Out: &bytes.Buffer{}, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "migrate"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate"}))
 	warning := errb.String()
-	if !strings.Contains(warning, "set HERDR_SESH_CONFIG="+native+" before deleting "+legacy) {
-		t.Fatalf("stderr = %q", warning)
-	}
+	assert.Contains(t, warning, "set HERDR_SESH_CONFIG="+native+" before deleting "+legacy)
 }
 
 func TestConfigMigrateKeepsUnrelatedEnvSelection(t *testing.T) {
@@ -361,23 +260,16 @@ func TestConfigMigrateKeepsUnrelatedEnvSelection(t *testing.T) {
 	t.Setenv("HERDR_SESH_CONFIG", active)
 	t.Setenv("HOME", d)
 	for _, p := range []string{active, legacy} {
-		if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(p, []byte("cache = true\n"), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0700))
+		require.NoError(t, os.WriteFile(p, []byte("cache = true\n"), 0600))
 	}
 
 	var errb bytes.Buffer
 	a := &App{Out: &bytes.Buffer{}, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "migrate", "--config", legacy}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate", "--config", legacy}))
 	warning := errb.String()
-	if strings.Contains(warning, "set HERDR_SESH_CONFIG=") || !strings.Contains(warning, "HERDR_SESH_CONFIG continues to select "+active) {
-		t.Fatalf("stderr = %q", warning)
-	}
+	require.NotContains(t, warning, "set HERDR_SESH_CONFIG=")
+	assert.Contains(t, warning, "HERDR_SESH_CONFIG continues to select "+active)
 }
 
 func TestConfigMigrateExplicitPathWarnsWhenNativeIsNotDiscovered(t *testing.T) {
@@ -388,19 +280,14 @@ func TestConfigMigrateExplicitPathWarnsWhenNativeIsNotDiscovered(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", filepath.Join(home, "plugin-config"))
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", home)
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
 
 	var errb bytes.Buffer
 	a := &App{Out: &bytes.Buffer{}, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "migrate", legacy}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate", legacy}))
 	warning := errb.String()
-	if strings.Contains(warning, "now takes precedence") || !strings.Contains(warning, "set HERDR_SESH_CONFIG="+native+" before deleting "+legacy) {
-		t.Fatalf("stderr = %q", warning)
-	}
+	require.NotContains(t, warning, "now takes precedence")
+	assert.Contains(t, warning, "set HERDR_SESH_CONFIG="+native+" before deleting "+legacy)
 }
 
 func TestConfigMigrateLegacySymlinkDoesNotClaimNativePrecedence(t *testing.T) {
@@ -413,91 +300,58 @@ func TestConfigMigrateLegacySymlinkDoesNotClaimNativePrecedence(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginDir)
 	t.Setenv("HERDR_SESH_CONFIG", "")
 	t.Setenv("HOME", home)
-	if err := os.MkdirAll(pluginDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(legacy, []byte("cache = true\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(native, legacyLink); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(pluginDir, 0700))
+	require.NoError(t, os.WriteFile(legacy, []byte("cache = true\n"), 0600))
+	require.NoError(t, os.Symlink(native, legacyLink))
 
 	var errb bytes.Buffer
 	a := &App{Out: &bytes.Buffer{}, Err: &errb}
-	if err := a.Run(context.Background(), []string{"config", "migrate", legacy}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"config", "migrate", legacy}))
 	cfg, resolved, err := config.Load(config.LoadOptions{Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolved != legacyLink || cfg.Cache {
-		t.Fatalf("resolved %q with cache=%t, want legacy decoding through %q", resolved, cfg.Cache, legacyLink)
-	}
+	require.NoError(t, err)
+	require.Equal(t, legacyLink, resolved)
+	require.False(t, cfg.Cache)
 	warning := errb.String()
-	if strings.Contains(warning, "now takes precedence") || !strings.Contains(warning, "set HERDR_SESH_CONFIG="+native) {
-		t.Fatalf("stderr = %q", warning)
-	}
+	require.NotContains(t, warning, "now takes precedence")
+	assert.Contains(t, warning, "set HERDR_SESH_CONFIG="+native)
 }
 
 func TestListIgnoresCorruptSessionCache(t *testing.T) {
 	d := t.TempDir()
 	cfgPath := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(cfgPath, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600))
 	stateDir := filepath.Join(d, "state")
-	if err := os.MkdirAll(stateDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(stateDir, "sessions.json"), []byte("{"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(stateDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "sessions.json"), []byte("{"), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
 
 	var out, errb bytes.Buffer
 	a := &App{Out: &out, Err: &errb}
-	if err := a.Run(context.Background(), []string{"list", "--json", "--config", cfgPath}); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), `"name": "api"`) {
-		t.Fatalf("output = %q", out.String())
-	}
-	if !strings.Contains(errb.String(), "warning: ignoring session cache") {
-		t.Fatalf("stderr = %q", errb.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"list", "--json", "--config", cfgPath}))
+	require.Contains(t, out.String(), `"name": "api"`)
+	assert.Contains(t, errb.String(), "warning: ignoring session cache")
 }
 
 func TestListWarnsWhenSessionCacheCannotBeSaved(t *testing.T) {
 	d := t.TempDir()
 	cfgPath := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(cfgPath, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600))
 	statePath := filepath.Join(d, "state-file")
-	if err := os.WriteFile(statePath, []byte("not a directory"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(statePath, []byte("not a directory"), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", statePath)
 
 	var out, errb bytes.Buffer
 	a := &App{Out: &out, Err: &errb}
-	if err := a.Run(context.Background(), []string{"list", "--json", "--config", cfgPath}); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), `"name": "api"`) {
-		t.Fatalf("output = %q", out.String())
-	}
-	if !strings.Contains(errb.String(), "warning: ignoring session cache") || !strings.Contains(errb.String(), "warning: could not save session cache") {
-		t.Fatalf("stderr = %q", errb.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"list", "--json", "--config", cfgPath}))
+	require.Contains(t, out.String(), `"name": "api"`)
+	require.Contains(t, errb.String(), "warning: ignoring session cache")
+	assert.Contains(t, errb.String(), "warning: could not save session cache")
 }
 
 func TestListCacheDoesNotMaskBlacklistedResults(t *testing.T) {
 	d := t.TempDir()
 	cfgPath := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte(`cache = true
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`cache = true
 blacklist = ["^scratch$"]
 
 [[session]]
@@ -507,60 +361,48 @@ path = "/tmp/api"
 [[session]]
 name = "scratch"
 path = "/tmp/scratch"
-`), 0600); err != nil {
-		t.Fatal(err)
-	}
+`), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
 
-	if got := runListJSON(t, cfgPath, ""); len(got) != 1 || got[0].Name != "api" {
-		t.Fatalf("normal sessions = %#v", got)
-	}
-	if got := runListJSON(t, cfgPath, "", "--blacklisted"); len(got) != 1 || got[0].Name != "scratch" {
-		t.Fatalf("blacklisted sessions = %#v", got)
-	}
+	got := runListJSON(t, cfgPath, "")
+	require.Len(t, got, 1)
+	assert.Equal(t, "api", got[0].Name)
+	got = runListJSON(t, cfgPath, "", "--blacklisted")
+	require.Len(t, got, 1)
+	assert.Equal(t, "scratch", got[0].Name)
 }
 
 func TestListCacheDoesNotMaskDuplicateResults(t *testing.T) {
 	d := t.TempDir()
 	cfgPath := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte(`cache = true
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`cache = true
 sort_order = ["config", "zoxide"]
 
 [[session]]
 name = "api"
 path = "/configured/api"
-`), 0600); err != nil {
-		t.Fatal(err)
-	}
+`), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
 	zoxideOutput := "42 /discovered/api\n"
 
-	if got := runListJSON(t, cfgPath, zoxideOutput); len(got) != 1 {
-		t.Fatalf("deduplicated sessions = %#v", got)
-	}
-	if got := runListJSON(t, cfgPath, zoxideOutput, "--hide-duplicates=false"); len(got) != 2 {
-		t.Fatalf("duplicate sessions = %#v", got)
-	}
+	require.Len(t, runListJSON(t, cfgPath, zoxideOutput), 1)
+	require.Len(t, runListJSON(t, cfgPath, zoxideOutput, "--hide-duplicates=false"), 2)
 }
 
 func TestListCacheDoesNotCrossConfigFiles(t *testing.T) {
 	d := t.TempDir()
 	firstConfig := filepath.Join(d, "first.toml")
 	secondConfig := filepath.Join(d, "second.toml")
-	if err := os.WriteFile(firstConfig, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(secondConfig, []byte("cache = true\n[[session]]\nname = \"web\"\npath = \"/tmp/web\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(firstConfig, []byte("cache = true\n[[session]]\nname = \"api\"\npath = \"/tmp/api\"\n"), 0600))
+	require.NoError(t, os.WriteFile(secondConfig, []byte("cache = true\n[[session]]\nname = \"web\"\npath = \"/tmp/web\"\n"), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
 
-	if got := runListJSON(t, firstConfig, ""); len(got) != 1 || got[0].Name != "api" {
-		t.Fatalf("first config sessions = %#v", got)
-	}
-	if got := runListJSON(t, secondConfig, ""); len(got) != 1 || got[0].Name != "web" {
-		t.Fatalf("second config sessions = %#v", got)
-	}
+	got := runListJSON(t, firstConfig, "")
+	require.Len(t, got, 1)
+	assert.Equal(t, "api", got[0].Name)
+	got = runListJSON(t, secondConfig, "")
+	require.Len(t, got, 1)
+	assert.Equal(t, "web", got[0].Name)
 }
 
 func TestListCacheDistinguishesRelativeConfigsAcrossWorkingDirectories(t *testing.T) {
@@ -568,98 +410,68 @@ func TestListCacheDistinguishesRelativeConfigsAcrossWorkingDirectories(t *testin
 	firstDir := filepath.Join(d, "first")
 	secondDir := filepath.Join(d, "second")
 	for dir, name := range map[string]string{firstDir: "api", secondDir: "web"} {
-		if err := os.Mkdir(dir, 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Mkdir(dir, 0700))
 		body := fmt.Sprintf("cache = true\n[[session]]\nname = %q\npath = %q\n", name, filepath.Join("/tmp", name))
-		if err := os.WriteFile(filepath.Join(dir, "sesh.toml"), []byte(body), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "sesh.toml"), []byte(body), 0600))
 	}
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", filepath.Join(d, "state"))
 
 	t.Chdir(firstDir)
-	if got := runListJSON(t, "sesh.toml", ""); len(got) != 1 || got[0].Name != "api" {
-		t.Fatalf("first config sessions = %#v", got)
-	}
+	got := runListJSON(t, "sesh.toml", "")
+	require.Len(t, got, 1)
+	assert.Equal(t, "api", got[0].Name)
 	t.Chdir(secondDir)
-	if got := runListJSON(t, "sesh.toml", ""); len(got) != 1 || got[0].Name != "web" {
-		t.Fatalf("second config sessions = %#v", got)
-	}
+	got = runListJSON(t, "sesh.toml", "")
+	require.Len(t, got, 1)
+	assert.Equal(t, "web", got[0].Name)
 }
 
 func TestPickerOptionsPropagateWorkspaceSort(t *testing.T) {
 	cfg := config.Default()
-	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort; got != "workspace" {
-		t.Fatalf("default workspace sort = %q, want workspace", got)
-	}
+	require.Equal(t, "workspace", pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort)
 	cfg.TUI.DefaultSort = "agent"
-	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort; got != "agent" {
-		t.Fatalf("workspace sort = %q, want agent", got)
-	}
+	assert.Equal(t, "agent", pickerOptionsFromConfig(context.Background(), io.Discard, cfg).WorkspaceSort)
 }
 
 func TestPickerOptionsPropagateWorktreeIconReplacement(t *testing.T) {
 	cfg := config.Default()
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.DisableWorktreeIconReplacement {
-		t.Fatal("default config disabled worktree icon replacement")
-	}
+	require.False(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).DisableWorktreeIconReplacement, "default config disabled worktree icon replacement")
 	cfg.TUI.ReplaceWorktreeIcon = false
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.DisableWorktreeIconReplacement {
-		t.Fatal("disabled worktree icon replacement was not propagated")
-	}
+	assert.True(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).DisableWorktreeIconReplacement, "disabled worktree icon replacement was not propagated")
 }
 
 func TestPickerOptionsPropagatePreviewVisibility(t *testing.T) {
 	cfg := config.Default()
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.HidePreview {
-		t.Fatal("default config hid native picker preview")
-	}
+	require.False(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).HidePreview, "default config hid native picker preview")
 	cfg.TUI.ShowPreview = false
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.HidePreview {
-		t.Fatal("show_preview=false was not propagated")
-	}
+	assert.True(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).HidePreview, "show_preview=false was not propagated")
 }
 
 func TestPickerOptionsPropagatePreviewMode(t *testing.T) {
 	cfg := config.Default()
-	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode; got != "command" {
-		t.Fatalf("default preview mode = %q, want command", got)
-	}
+	require.Equal(t, "command", pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode)
 	cfg.TUI.PreviewMode = "pane"
-	if got := pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode; got != "pane" {
-		t.Fatalf("preview mode = %q, want pane", got)
-	}
+	assert.Equal(t, "pane", pickerOptionsFromConfig(context.Background(), io.Discard, cfg).PreviewMode)
 }
 
 func TestPickerOptionsPropagateHomePrioritization(t *testing.T) {
 	cfg := config.Default()
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); opts.DisableHomePrioritization {
-		t.Fatal("default config disabled home prioritization")
-	}
+	require.False(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).DisableHomePrioritization, "default config disabled home prioritization")
 	cfg.TUI.PrioritizeHome = false
-	if opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg); !opts.DisableHomePrioritization {
-		t.Fatal("prioritize_home=false was not propagated")
-	}
+	assert.True(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).DisableHomePrioritization, "prioritize_home=false was not propagated")
 }
 
 func TestPickerJSONCommand(t *testing.T) {
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"picker", "--json", "--config", filepath.Join("..", "..", "testdata", "sesh.toml")}); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), `"name": "sesh"`) {
-		t.Fatalf("output = %q", out.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"picker", "--json", "--config", filepath.Join("..", "..", "testdata", "sesh.toml")}))
+	assert.Contains(t, out.String(), `"name": "sesh"`)
 }
 
 func TestNativePickerFailsWhenWorkspaceHistoryCannotResolve(t *testing.T) {
 	configureFakeSources(t, "")
 	statePath := filepath.Join(t.TempDir(), "state")
-	if err := os.WriteFile(statePath, []byte("not a directory"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(statePath, []byte("not a directory"), 0600))
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", statePath)
 	t.Setenv("HERDR_SOCKET_PATH", filepath.Join(t.TempDir(), "herdr", "herdr.sock"))
 
@@ -667,36 +479,29 @@ func TestNativePickerFailsWhenWorkspaceHistoryCannotResolve(t *testing.T) {
 		context.Background(),
 		[]string{"picker", "--config", filepath.Join("..", "..", "testdata", "sesh.toml")},
 	)
-	if err == nil || !strings.Contains(err.Error(), "resolve workspace history") {
-		t.Fatalf("picker error=%v, want workspace history resolution failure", err)
-	}
+	require.ErrorContains(t, err, "resolve workspace history")
 }
 
 func TestPickerJSONAppliesDefaultStartupCommand(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte(`[default_session]
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`[default_session]
 startup_command = "printf default:{}"
 
 [[session]]
 name = "api"
 path = "/tmp/api"
-`), 0600); err != nil {
-		t.Fatal(err)
-	}
+`), 0600))
 
 	sessions := runPickerJSON(t, cfgPath, "")
-	if len(sessions) != 1 || sessions[0].StartupCommand != "printf default:{}" {
-		t.Fatalf("sessions = %#v", sessions)
-	}
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "printf default:{}", sessions[0].StartupCommand)
 }
 
 func TestPickerJSONAppliesWildcardSettings(t *testing.T) {
 	project := filepath.Join(t.TempDir(), "project")
-	if err := os.Mkdir(project, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(project, 0700))
 	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte(`strict_mode = true
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`strict_mode = true
 
 [[wildcard]]
 pattern = "`+project+`"
@@ -708,30 +513,23 @@ windows = ["git"]
 [[window]]
 name = "git"
 startup_script = "git status"
-`), 0600); err != nil {
-		t.Fatal(err)
-	}
+`), 0600))
 
 	sessions := runPickerJSON(t, cfgPath, "42 "+project+"\n")
-	if len(sessions) != 1 {
-		t.Fatalf("sessions = %#v", sessions)
-	}
+	require.Len(t, sessions, 1)
 	s := sessions[0]
-	if s.StartupCommand != "" || s.PreviewCommand != "printf preview:{}" || !s.DisableStartupCommand || !reflect.DeepEqual(s.WindowNames, []string{"git"}) {
-		t.Fatalf("wildcard session = %#v", s)
-	}
-	if len(s.WindowConfigs) != 0 {
-		t.Fatalf("window configs leaked into JSON: %#v", s.WindowConfigs)
-	}
+	require.Empty(t, s.StartupCommand)
+	require.Equal(t, "printf preview:{}", s.PreviewCommand)
+	require.True(t, s.DisableStartupCommand)
+	require.Equal(t, []string{"git"}, s.WindowNames)
+	assert.Empty(t, s.WindowConfigs)
 }
 
 func TestPickerJSONExplicitFalseOverridesWildcardDisable(t *testing.T) {
 	project := filepath.Join(t.TempDir(), "project")
-	if err := os.Mkdir(project, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(project, 0700))
 	cfgPath := filepath.Join(t.TempDir(), "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte(`[default_session]
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`[default_session]
 startup_command = "printf default:{}"
 
 [[session]]
@@ -743,59 +541,43 @@ disable_startup_command = false
 pattern = "`+project+`"
 startup_command = "printf wildcard:{}"
 disable_startup_command = true
-`), 0600); err != nil {
-		t.Fatal(err)
-	}
+`), 0600))
 
 	sessions := runPickerJSON(t, cfgPath, "")
-	if len(sessions) != 1 {
-		t.Fatalf("sessions = %#v", sessions)
-	}
-	if sessions[0].DisableStartupCommand || sessions[0].StartupCommand != "printf wildcard:{}" {
-		t.Fatalf("session = %#v", sessions[0])
-	}
+	require.Len(t, sessions, 1)
+	require.False(t, sessions[0].DisableStartupCommand)
+	assert.Equal(t, "printf wildcard:{}", sessions[0].StartupCommand)
 }
 
 func TestCollectDirectPathUsesConfiguredDirLength(t *testing.T) {
 	parent := filepath.Join(t.TempDir(), "parent")
 	target := filepath.Join(parent, "child")
-	if err := os.MkdirAll(target, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(target, 0700))
 	configureFakeSources(t, "")
 	cfg := config.Default()
 	cfg.DirLength = 2
 
 	sessions, err := (&App{}).collectAllowUnavailableHerdr(context.Background(), cfg, target)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(sessions) != 1 || sessions[0].Name != filepath.Join("parent", "child") {
-		t.Fatalf("sessions = %#v", sessions)
-	}
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, filepath.Join("parent", "child"), sessions[0].Name)
 }
 
 func TestCollectPropagatesHerdrErrors(t *testing.T) {
 	configureFakeSources(t, "")
 
-	if _, err := (&App{}).collect(context.Background(), config.Default(), ""); err == nil {
-		t.Fatal("collect succeeded when Herdr workspace listing failed")
-	}
+	_, err := (&App{}).collect(context.Background(), config.Default(), "")
+	require.Error(t, err)
 }
 
 func TestCollectPickerPreservesHerdrError(t *testing.T) {
 	configureFakeSources(t, "")
 
 	col, err := (&App{}).collectPicker(context.Background(), config.Default())
-	if err != nil {
-		t.Fatalf("collect picker sources: %v", err)
-	}
-	if col.HerdrErr == nil {
-		t.Fatal("collectPicker discarded Herdr workspace listing error")
-	}
-	if len(col.Sessions) != 0 || col.HerdrWorkspaces != nil {
-		t.Fatalf("sessions=%#v workspaces=%#v", col.Sessions, col.HerdrWorkspaces)
-	}
+	require.NoError(t, err)
+	require.Error(t, col.HerdrErr)
+	require.Empty(t, col.Sessions)
+	require.Nil(t, col.HerdrWorkspaces)
 }
 
 func TestCollectPickerReturnsRawHerdrWorkspaces(t *testing.T) {
@@ -808,13 +590,10 @@ esac
 `)
 
 	col, err := (&App{}).collectPicker(context.Background(), config.Default())
-	if err != nil || col.HerdrErr != nil {
-		t.Fatalf("collect picker: err=%v herdrErr=%v", err, col.HerdrErr)
-	}
+	require.NoError(t, err)
+	require.NoError(t, col.HerdrErr)
 	want := []model.Session{{Source: "herdr", Name: "api", Path: "/live/api", WorkspaceID: "w1"}}
-	if !reflect.DeepEqual(col.HerdrWorkspaces, want) {
-		t.Fatalf("herdr workspaces=%#v want %#v", col.HerdrWorkspaces, want)
-	}
+	assert.Equal(t, want, col.HerdrWorkspaces)
 }
 
 func TestReloadPickerStateResolvesFocusedWorkspace(t *testing.T) {
@@ -856,9 +635,7 @@ case "$1 $2" in
 esac
 `, tt.paneCurrent))
 			stateDir := filepath.Join(t.TempDir(), "state")
-			if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"focused", "previous"}}); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, state.SaveHistory(stateDir, state.History{Workspaces: []string{"focused", "previous"}}))
 			t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
 			t.Setenv("HERDR_SOCKET_PATH", "")
 			pickerWorkspaceID := "closed-workspace"
@@ -868,23 +645,17 @@ esac
 			}
 
 			result, err := (&App{}).reloadPickerState(context.Background(), config.Default(), herdr.NewCLIClient(), &pickerWorkspaceID, warn)
-			if err != nil {
-				t.Fatalf("reload picker state: %v", err)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantID, pickerWorkspaceID)
+			require.Equal(t, tt.wantUnknown, result.LastWorkspaceUnknown)
+			if !tt.wantUnknown {
+				assert.Equal(t, tt.wantLast, result.LastWorkspaceID)
 			}
-			if pickerWorkspaceID != tt.wantID {
-				t.Fatalf("picker workspace=%q, want %q", pickerWorkspaceID, tt.wantID)
-			}
-			if result.LastWorkspaceUnknown != tt.wantUnknown {
-				t.Fatalf("last workspace unknown=%v, want %v", result.LastWorkspaceUnknown, tt.wantUnknown)
-			}
-			if !tt.wantUnknown && result.LastWorkspaceID != tt.wantLast {
-				t.Fatalf("last workspace=%q, want %q", result.LastWorkspaceID, tt.wantLast)
-			}
-			if tt.wantWarning == "" && len(warnings) > 0 {
-				t.Fatalf("unexpected warnings: %v", warnings)
-			}
-			if tt.wantWarning != "" && (len(warnings) != 1 || !strings.Contains(warnings[0], tt.wantWarning)) {
-				t.Fatalf("warnings=%v, want one containing %q", warnings, tt.wantWarning)
+			if tt.wantWarning == "" {
+				assert.Empty(t, warnings)
+			} else {
+				require.Len(t, warnings, 1)
+				assert.Contains(t, warnings[0], tt.wantWarning)
 			}
 		})
 	}
@@ -909,73 +680,50 @@ printf '[]\n'
 `
 	for name, script := range map[string]string{"herdr": herdrScript, "zoxide": zoxideScript} {
 		//nolint:gosec // test creates local executable fixtures.
-		if err := os.WriteFile(filepath.Join(d, name), []byte(script), 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(d, name), []byte(script), 0700))
 	}
 	t.Setenv("HERDR_BIN_PATH", filepath.Join(d, "herdr"))
 	t.Setenv("CONCURRENT_SOURCE_MARKER", marker)
 	t.Setenv("PATH", d+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	col, err := (&App{}).collectPicker(context.Background(), config.Default())
-	if err != nil {
-		t.Fatalf("collect picker sources: %v", err)
-	}
-	if col.HerdrErr != nil {
-		t.Fatalf("Herdr ran before zoxide: %v", col.HerdrErr)
-	}
+	require.NoError(t, err)
+	require.NoError(t, col.HerdrErr)
 }
 
 func TestPreviewCommandUsesExplicitConfig(t *testing.T) {
 	d := t.TempDir()
 	targetDir := filepath.Join(d, "target")
-	if err := os.Mkdir(targetDir, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(targetDir, 0700))
 	cfgPath := filepath.Join(d, "sesh.toml")
-	if err := os.WriteFile(cfgPath, []byte("[default_session]\npreview_command = \"printf configured:%s {}\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(cfgPath, []byte("[default_session]\npreview_command = \"printf configured:%s {}\"\n"), 0600))
 	fakeBin := filepath.Join(d, "bin")
-	if err := os.MkdirAll(fakeBin, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(fakeBin, 0700))
 	for _, name := range []string{"herdr", "zoxide"} {
 		//nolint:gosec // test creates local executable fixtures.
-		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte("#!/bin/sh\nexit 1\n"), 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(fakeBin, name), []byte("#!/bin/sh\nexit 1\n"), 0700))
 	}
 	//nolint:gosec // test creates a local executable fixture.
-	if err := os.WriteFile(filepath.Join(fakeBin, "eza"), []byte("#!/bin/sh\nprintf 'default:%s\\n' \"$*\"\n"), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "eza"), []byte("#!/bin/sh\nprintf 'default:%s\\n' \"$*\"\n"), 0700))
 	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"preview", "--config", cfgPath, targetDir}); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), "configured:") || !strings.Contains(out.String(), targetDir) {
-		t.Fatalf("output = %q", out.String())
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"preview", "--config", cfgPath, targetDir}))
+	require.Contains(t, out.String(), "configured:")
+	assert.Contains(t, out.String(), targetDir)
 }
 
 func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	d := t.TempDir()
 	stateDir := filepath.Join(d, "state")
-	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, state.SaveHistory(stateDir, state.History{Workspaces: []string{"current", "previous", "older"}}))
 	fakeHerdr := filepath.Join(d, "herdr")
 	logPath := filepath.Join(d, "herdr.log")
 	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"
 	//nolint:gosec // test creates a local executable fixture.
-	if err := os.WriteFile(fakeHerdr, []byte(script), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(fakeHerdr, []byte(script), 0700))
 	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
 	t.Setenv("HERDR_FAKE_LOG", logPath)
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
@@ -983,33 +731,21 @@ func TestLastFocusesPreviousWorkspaceAndRotatesHistory(t *testing.T) {
 	t.Setenv("HERDR_WORKSPACE_ID", "current")
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"last"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"last"}))
 	//nolint:gosec // logPath is a test-owned temp file.
 	log, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := strings.TrimSpace(string(log)); got != "workspace focus previous" {
-		t.Fatalf("herdr args = %q", got)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "workspace focus previous", strings.TrimSpace(string(log)))
 	h, err := state.LoadHistory(stateDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := []string{"previous", "current", "older"}
-	if !reflect.DeepEqual(h.Workspaces, want) {
-		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
-	}
+	assert.Equal(t, want, h.Workspaces)
 }
 
 func TestPluginManifestStartsHistoryWatcherForRuntimeLifecycleEvents(t *testing.T) {
 	//nolint:gosec // The manifest is a repository-owned test fixture.
 	b, err := os.ReadFile("../../herdr-plugin.toml")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var manifest struct {
 		MinHerdrVersion string `toml:"min_herdr_version"`
 		Events          []struct {
@@ -1017,87 +753,57 @@ func TestPluginManifestStartsHistoryWatcherForRuntimeLifecycleEvents(t *testing.
 			Command []string `toml:"command"`
 		} `toml:"events"`
 	}
-	if err := toml.Unmarshal(b, &manifest); err != nil {
-		t.Fatal(err)
-	}
-	if manifest.MinHerdrVersion != "0.8.2" {
-		t.Fatalf("min_herdr_version=%q, want 0.8.2", manifest.MinHerdrVersion)
-	}
+	require.NoError(t, toml.Unmarshal(b, &manifest))
+	require.Equal(t, "0.8.2", manifest.MinHerdrVersion)
 	wantCommand := []string{"./bin/herdr-sesh", "plugin", "watch-history"}
 	got := make(map[string][]string, len(manifest.Events))
 	for _, event := range manifest.Events {
 		got[event.On] = event.Command
 	}
 	for _, event := range []string{"workspace.focused", "workspace.closed"} {
-		if !reflect.DeepEqual(got[event], wantCommand) {
-			t.Errorf("%s command=%#v want %#v", event, got[event], wantCommand)
-		}
+		assert.Equal(t, wantCommand, got[event])
 	}
 }
 
 func TestApplyHistoryHookLeavesFocusedEventsToSubscriber(t *testing.T) {
 	historyDir := t.TempDir()
 	want := state.History{Workspaces: []string{"current", "older"}}
-	if err := state.SaveHistory(historyDir, want); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, state.SaveHistory(historyDir, want))
 	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.focused")
 	t.Setenv("HERDR_WORKSPACE_ID", "late-hook")
 
 	err := applyHistoryHook(historyDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	history, err := state.LoadHistory(historyDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(history, want) {
-		t.Fatalf("history=%#v want %#v", history, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, want, history)
 }
 
 func TestApplyHistoryHookUsesClosedEventPayloadWorkspace(t *testing.T) {
 	historyDir := t.TempDir()
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"context", "closed", "older"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, state.SaveHistory(historyDir, state.History{Workspaces: []string{"context", "closed", "older"}}))
 	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.closed")
 	t.Setenv("HERDR_WORKSPACE_ID", "context")
 	t.Setenv("HERDR_PLUGIN_EVENT_JSON", `{"data":{"workspace_id":"closed"}}`)
 
-	if err := applyHistoryHook(historyDir); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, applyHistoryHook(historyDir))
 	history, err := state.LoadHistory(historyDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := []string{"context", "older"}
-	if !reflect.DeepEqual(history.Workspaces, want) {
-		t.Fatalf("workspaces=%#v want %#v", history.Workspaces, want)
-	}
+	assert.Equal(t, want, history.Workspaces)
 }
 
 func TestPluginWatchHistoryBoundsClosedHookLockWait(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	socketPath := filepath.Join(t.TempDir(), "herdr.sock")
 	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed"}}))
 	//nolint:gosec // Test lock path is derived from t.TempDir().
 	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = lock.Close() })
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_EX))
 	t.Cleanup(func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) })
 
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
@@ -1108,30 +814,20 @@ func TestPluginWatchHistoryBoundsClosedHookLockWait(t *testing.T) {
 	defer cancel()
 
 	err = (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(ctx, []string{"plugin", "watch-history"})
-	if !errors.Is(err, state.ErrHistoryLockTimeout) {
-		t.Fatalf("watch error=%v, want history lock timeout", err)
-	}
+	require.ErrorIs(t, err, state.ErrHistoryLockTimeout)
 }
 
 func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-hook-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
 	socketPath := filepath.Join(socketDir, "herdr.sock")
 	historyDir, err := state.SessionHistoryDir(stateDir, socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed", "other"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, state.SaveHistory(historyDir, state.History{Workspaces: []string{"closed", "other"}}))
 	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
 	streamReady := make(chan struct{})
@@ -1207,51 +903,35 @@ func TestPluginWatchHistoryAppliesClosedHookBeforeNoHistoryStream(t *testing.T) 
 	select {
 	case <-streamReady:
 	case <-time.After(time.Second):
-		t.Fatal("watcher did not bootstrap")
+		require.FailNow(t, "watcher did not bootstrap")
 	}
 
 	deadline := time.Now().Add(time.Second)
 	for {
 		history, loadErr := state.LoadHistory(historyDir)
-		if loadErr != nil {
-			t.Fatal(loadErr)
-		}
+		require.NoError(t, loadErr)
 		if reflect.DeepEqual(history.Workspaces, []string{"other"}) {
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("history after hook and duplicate replay=%#v", history.Workspaces)
-		}
+		require.False(t, time.Now().After(deadline))
 		time.Sleep(10 * time.Millisecond)
 	}
 	cancel()
 	close(releaseServer)
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	if err := <-watchDone; !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", err)
-	}
+	require.NoError(t, <-serverDone)
+	require.ErrorIs(t, <-watchDone, context.Canceled)
 }
 
 func TestPluginWatchHistoryNonWinningFocusDoesNotMigrateLegacyHistory(t *testing.T) {
 	root := t.TempDir()
 	stateDir := filepath.Join(root, "state")
 	socketPath := filepath.Join(root, "herdr", "herdr.sock")
-	if err := state.SaveHistory(stateDir, state.History{Workspaces: []string{"legacy"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, state.SaveHistory(stateDir, state.History{Workspaces: []string{"legacy"}}))
 	release, acquired, err := state.TryHistoryWatcherLock(stateDir, socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !acquired {
-		t.Fatal("failed to hold watcher election lock")
-	}
+	require.NoError(t, err)
+	require.True(t, acquired, "failed to hold watcher election lock")
 	t.Cleanup(func() {
-		if err := release(); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, release())
 	})
 
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", stateDir)
@@ -1259,26 +939,19 @@ func TestPluginWatchHistoryNonWinningFocusDoesNotMigrateLegacyHistory(t *testing
 	t.Setenv("HERDR_PLUGIN_EVENT", "workspace.focused")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(ctx, []string{"plugin", "watch-history"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(stateDir, "history")); !os.IsNotExist(err) {
-		t.Fatalf("non-winning focus hook migrated legacy history: %v", err)
-	}
+	require.NoError(t, (&App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}).Run(ctx, []string{"plugin", "watch-history"}))
+	_, err = os.Stat(filepath.Join(stateDir, "history"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
 	socketPath := filepath.Join(socketDir, "herdr.sock")
 	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
 	watcherReady := make(chan struct{})
@@ -1353,7 +1026,7 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	select {
 	case <-watcherReady:
 	case <-time.After(2 * time.Second):
-		t.Fatal("first watcher did not subscribe")
+		require.FailNow(t, "first watcher did not subscribe")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -1362,15 +1035,9 @@ func TestPluginWatchHistoryReturnsWhenWatcherAlreadyRunning(t *testing.T) {
 	secondErr := a.Run(ctx, []string{"plugin", "watch-history"})
 	cancelFirst()
 	close(releaseServer)
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	if err := <-firstDone; !errors.Is(err, context.Canceled) {
-		t.Fatalf("first watcher error=%v, want context cancellation", err)
-	}
-	if secondErr != nil {
-		t.Fatalf("second watcher returned %v, want a successful no-op", secondErr)
-	}
+	require.NoError(t, <-serverDone)
+	require.ErrorIs(t, <-firstDone, context.Canceled)
+	require.NoError(t, secondErr)
 }
 
 func TestRetryHistoryMutationPreservesOrderAfterLockTimeout(t *testing.T) {
@@ -1409,34 +1076,22 @@ func TestRetryHistoryMutationPreservesOrderAfterLockTimeout(t *testing.T) {
 	select {
 	case <-blocked:
 	case <-ctx.Done():
-		t.Fatal("history mutation did not reach lock contention")
+		require.FailNow(t, "history mutation did not reach lock contention")
 	}
-	if len(got) != 0 {
-		t.Fatalf("later mutations overtook the contended mutation: %#v", got)
-	}
+	require.Empty(t, got)
 	close(release)
-	if err := <-done; err != nil {
-		t.Fatal(err)
-	}
-	if want := []string{"B", "C", "D"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("mutations=%#v want %#v", got, want)
-	}
+	require.NoError(t, <-done)
+	assert.Equal(t, []string{"B", "C", "D"}, got)
 }
 
 func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T) {
 	historyDir := filepath.Join(t.TempDir(), "history")
-	if err := state.SaveHistory(historyDir, state.History{Workspaces: []string{"A", "closed"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, state.SaveHistory(historyDir, state.History{Workspaces: []string{"A", "closed"}}))
 	//nolint:gosec // Test lock path is derived from t.TempDir().
 	lock, err := os.OpenFile(filepath.Join(historyDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = lock.Close() }()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_EX))
 	locked := true
 	defer func() {
 		if locked {
@@ -1445,15 +1100,11 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	}()
 
 	socketDir, err := os.MkdirTemp("/tmp", "herdr-sesh-watch-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
 	socketPath := filepath.Join(socketDir, "herdr.sock")
 	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
 	releaseServer := make(chan struct{})
@@ -1490,36 +1141,28 @@ func TestPluginWatchHistoryPreservesFocusOrderThroughLockContention(t *testing.T
 	select {
 	case <-lockTimedOut:
 	case <-ctx.Done():
-		t.Fatal("watcher did not retry the contended snapshot mutation")
+		require.FailNow(t, "watcher did not retry the contended snapshot mutation")
 	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))
 	locked = false
 
 	want := []string{"D", "C", "B", "A"}
 	for {
 		history, err := state.LoadHistory(historyDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if reflect.DeepEqual(history.Workspaces, want) {
 			break
 		}
 		select {
 		case <-ctx.Done():
-			t.Fatalf("history=%#v want %#v", history.Workspaces, want)
+			require.FailNow(t, fmt.Sprintf("history=%#v want %#v", history.Workspaces, want))
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
 	cancel()
 	close(releaseServer)
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	if err := <-watchDone; !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v want context cancellation", err)
-	}
+	require.NoError(t, <-serverDone)
+	require.ErrorIs(t, <-watchDone, context.Canceled)
 }
 
 func serveContendedHistoryStream(listener net.Listener, release <-chan struct{}) error {
@@ -1609,24 +1252,16 @@ func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {
 	logPath := filepath.Join(d, "herdr.log")
 	fakeHerdr := filepath.Join(d, "herdr")
 	//nolint:gosec // test creates a local executable fixture.
-	if err := os.WriteFile(fakeHerdr, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(fakeHerdr, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"), 0700))
 	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
 	t.Setenv("HERDR_FAKE_LOG", logPath)
 
 	a := &App{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"plugin", "open-picker"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"plugin", "open-picker"}))
 	//nolint:gosec // logPath is a test-owned temp file.
 	log, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := strings.TrimSpace(string(log)); got != "plugin pane open --plugin fullerzz.sesh --entrypoint picker --placement overlay" {
-		t.Fatalf("herdr args=%q", got)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "plugin pane open --plugin fullerzz.sesh --entrypoint picker --placement overlay", strings.TrimSpace(string(log)))
 }
 
 func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {
@@ -1635,13 +1270,9 @@ func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {
 
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), []string{"picker", "--json", "--config", cfgPath}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), []string{"picker", "--json", "--config", cfgPath}))
 	var sessions []model.Session
-	if err := json.Unmarshal(out.Bytes(), &sessions); err != nil {
-		t.Fatalf("decode picker JSON: %v\n%s", err, out.String())
-	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &sessions))
 	return sessions
 }
 
@@ -1652,13 +1283,9 @@ func runListJSON(t *testing.T, cfgPath, zoxideOutput string, extraArgs ...string
 	args := append([]string{"list", "--json", "--config", cfgPath}, extraArgs...)
 	var out bytes.Buffer
 	a := &App{Out: &out, Err: &bytes.Buffer{}}
-	if err := a.Run(context.Background(), args); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, a.Run(context.Background(), args))
 	var sessions []model.Session
-	if err := json.Unmarshal(out.Bytes(), &sessions); err != nil {
-		t.Fatalf("decode list JSON: %v\n%s", err, out.String())
-	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &sessions))
 	return sessions
 }
 
@@ -1666,13 +1293,9 @@ func configureHerdrScript(t *testing.T, script string) {
 	t.Helper()
 	fakeBin := t.TempDir()
 	//nolint:gosec // test creates local executable fixtures.
-	if err := os.WriteFile(filepath.Join(fakeBin, "herdr"), []byte(script), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "herdr"), []byte(script), 0700))
 	//nolint:gosec // test creates local executable fixtures.
-	if err := os.WriteFile(filepath.Join(fakeBin, "zoxide"), []byte("#!/bin/sh\n"), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "zoxide"), []byte("#!/bin/sh\n"), 0700))
 	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
@@ -1685,9 +1308,7 @@ func configureFakeSources(t *testing.T, zoxideOutput string) {
 		"zoxide": "#!/bin/sh\nprintf '%s' \"$FAKE_ZOXIDE_OUTPUT\"\n",
 	} {
 		//nolint:gosec // test creates local executable fixtures.
-		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte(script), 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(fakeBin, name), []byte(script), 0700))
 	}
 	t.Setenv("HERDR_BIN_PATH", filepath.Join(fakeBin, "herdr"))
 	t.Setenv("FAKE_ZOXIDE_OUTPUT", zoxideOutput)

--- a/internal/clone/clone_test.go
+++ b/internal/clone/clone_test.go
@@ -1,30 +1,26 @@
 package clone
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDestinationFromRepoURL(t *testing.T) {
 	got := Destination(Request{Repo: "git@host:org/project.git", CmdDir: "/tmp"})
-	if got != "/tmp/project" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "/tmp/project", got)
 }
 func TestDestinationOverride(t *testing.T) {
 	got := Destination(Request{Repo: "x", Dir: "/tmp/custom"})
-	if got != "/tmp/custom" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "/tmp/custom", got)
 }
 
 func TestDestinationRelativeDirUsesCmdDir(t *testing.T) {
 	got := Destination(Request{Repo: "x", CmdDir: "/tmp/work", Dir: "repo"})
-	if got != "/tmp/work/repo" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "/tmp/work/repo", got)
 }
 
 func TestDestinationRelativeDirWithoutCmdDir(t *testing.T) {
 	got := Destination(Request{Repo: "x", Dir: "repo"})
-	if got != "repo" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "repo", got)
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,23 +1,20 @@
 package config
 
 import (
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadMissingExplicitPathIncludesPath(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "missing.toml")
 	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("err = %v, want os.ErrNotExist", err)
-	}
-	if !strings.Contains(err.Error(), p) {
-		t.Fatalf("err = %v, want missing path %q", err, p)
-	}
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorContains(t, err, p)
 }
 
 func TestLoadExplicitSessionAndWindows(t *testing.T) {
@@ -36,18 +33,14 @@ name = "git"
 startup_script = "git status"
 `)
 	cfg, path, err := Load(LoadOptions{Warn: io.Discard, Path: cfgp, Home: "/home/zach"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if path != cfgp || cfg.DirLength != 2 || len(cfg.SessionConfigs) != 1 || cfg.SessionConfigs[0].Path != "~/projects/api" {
-		t.Fatalf("unexpected cfg %#v path %s", cfg, path)
-	}
-	if len(cfg.WindowConfigs) != 1 || cfg.WindowConfigs[0].Name != "git" {
-		t.Fatalf("missing window %#v", cfg.WindowConfigs)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NoError(t, err)
+	require.Equal(t, cfgp, path)
+	require.Equal(t, 2, cfg.DirLength)
+	require.Len(t, cfg.SessionConfigs, 1)
+	require.Equal(t, "~/projects/api", cfg.SessionConfigs[0].Path)
+	require.Len(t, cfg.WindowConfigs, 1)
+	require.Equal(t, "git", cfg.WindowConfigs[0].Name)
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestLoadStrictRejectsUnknown(t *testing.T) {
@@ -55,9 +48,7 @@ func TestLoadStrictRejectsUnknown(t *testing.T) {
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "strict_mode = true\nwat = 1\n")
 	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err == nil {
-		t.Fatal("expected strict error")
-	}
+	require.Error(t, err)
 }
 
 func TestLoadStrictRejectsUnsupportedSeshKeys(t *testing.T) {
@@ -73,9 +64,8 @@ func TestLoadStrictRejectsUnsupportedSeshKeys(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := filepath.Join(t.TempDir(), "sesh.toml")
 			mustWrite(t, p, "strict_mode = true\n"+body)
-			if _, _, err := Load(LoadOptions{Warn: io.Discard, Path: p}); err == nil {
-				t.Fatal("expected strict error")
-			}
+			_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+			require.Error(t, err)
 		})
 	}
 }
@@ -85,9 +75,8 @@ func TestLoadStrictRejectsUnsupportedSeshKeysInImports(t *testing.T) {
 	mustWrite(t, filepath.Join(d, "extra.toml"), "tmux_command = \"psmux\"\n")
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "strict_mode = true\nimport = [\"extra.toml\"]\n")
-	if _, _, err := Load(LoadOptions{Warn: io.Discard, Path: p}); err == nil {
-		t.Fatal("expected strict error from imported config")
-	}
+	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
+	require.Error(t, err)
 }
 
 func TestLoadImportOrder(t *testing.T) {
@@ -99,12 +88,10 @@ path="/extra"
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import=[\"extra.toml\"]\n[[session]]\nname=\"main\"\npath=\"/main\"\n")
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := []string{cfg.SessionConfigs[0].Name, cfg.SessionConfigs[1].Name}; got[0] != "extra" || got[1] != "main" {
-		t.Fatalf("bad order %#v", got)
-	}
+	require.NoError(t, err)
+	got := []string{cfg.SessionConfigs[0].Name, cfg.SessionConfigs[1].Name}
+	require.Equal(t, "extra", got[0])
+	assert.Equal(t, "main", got[1])
 }
 
 func TestLoadMergesNestedConfigTablesFieldByField(t *testing.T) {
@@ -127,21 +114,11 @@ startup_command = "make test"
 placeholder = "Search workspaces"
 `)
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DefaultSessionConfig.StartupCommand != "make test" {
-		t.Fatalf("startup command = %q", cfg.DefaultSessionConfig.StartupCommand)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != "printf extra {}" {
-		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
-	if cfg.TUI.Prompt != "Extra> " {
-		t.Fatalf("prompt = %q", cfg.TUI.Prompt)
-	}
-	if cfg.TUI.Placeholder != "Search workspaces" {
-		t.Fatalf("placeholder = %q", cfg.TUI.Placeholder)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "make test", cfg.DefaultSessionConfig.StartupCommand)
+	require.Equal(t, "printf extra {}", cfg.DefaultSessionConfig.PreviewCommand)
+	require.Equal(t, "Extra> ", cfg.TUI.Prompt)
+	assert.Equal(t, "Search workspaces", cfg.TUI.Placeholder)
 }
 
 func TestLoadExplicitEmptyPreviewCommandRestoresDefault(t *testing.T) {
@@ -156,12 +133,8 @@ preview_command = "printf extra {}"
 preview_command = ""
 `)
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestLoadExplicitEmptyTUITextOverridesImportedValues(t *testing.T) {
@@ -178,12 +151,9 @@ prompt = ""
 placeholder = ""
 `)
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.Prompt != "" || cfg.TUI.Placeholder != "" {
-		t.Fatalf("TUI text = prompt %q, placeholder %q", cfg.TUI.Prompt, cfg.TUI.Placeholder)
-	}
+	require.NoError(t, err)
+	require.Empty(t, cfg.TUI.Prompt)
+	assert.Empty(t, cfg.TUI.Placeholder)
 }
 
 func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
@@ -192,12 +162,8 @@ func TestLoadExplicitFalseShowIconsOverridesImportedValue(t *testing.T) {
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_icons = false\n")
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ShowIcons {
-		t.Fatal("show_icons = true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.ShowIcons, "show_icons = true, want false")
 }
 
 func TestLoadExplicitFalseHerdrThemeInheritOverridesImportedValue(t *testing.T) {
@@ -206,12 +172,8 @@ func TestLoadExplicitFalseHerdrThemeInheritOverridesImportedValue(t *testing.T) 
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nherdr_theme_inherit = false\n")
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.HerdrThemeInherit {
-		t.Fatal("herdr_theme_inherit = true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.HerdrThemeInherit, "herdr_theme_inherit = true, want false")
 }
 
 func TestLoadExplicitFalseReplaceWorktreeIconOverridesImportedValue(t *testing.T) {
@@ -220,12 +182,8 @@ func TestLoadExplicitFalseReplaceWorktreeIconOverridesImportedValue(t *testing.T
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nreplace_worktree_icon = false\n")
 	cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ReplaceWorktreeIcon {
-		t.Fatal("replace_worktree_icon=true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.ReplaceWorktreeIcon, "replace_worktree_icon=true, want false")
 }
 
 func TestLoadExplicitFalseShowLastWorkspacePathOverridesImportedValue(t *testing.T) {
@@ -234,12 +192,8 @@ func TestLoadExplicitFalseShowLastWorkspacePathOverridesImportedValue(t *testing
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_last_workspace_path = false\n")
 	cfg, _, err := Load(LoadOptions{Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ShowLastWorkspacePath {
-		t.Fatal("show_last_workspace_path = true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.ShowLastWorkspacePath, "show_last_workspace_path = true, want false")
 }
 
 func TestLoadExplicitFalseShowLastWorkspaceOverridesImportedValue(t *testing.T) {
@@ -248,31 +202,22 @@ func TestLoadExplicitFalseShowLastWorkspaceOverridesImportedValue(t *testing.T) 
 	p := filepath.Join(d, "sesh.toml")
 	mustWrite(t, p, "import = [\"extra.toml\"]\n[tui]\nshow_last_workspace = false\n")
 	cfg, _, err := Load(LoadOptions{Path: p})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ShowLastWorkspace {
-		t.Fatal("show_last_workspace = true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.ShowLastWorkspace, "show_last_workspace = true, want false")
 }
 
 func TestDefaultInheritsHerdrTheme(t *testing.T) {
-	if !Default().TUI.HerdrThemeInherit {
-		t.Fatal("herdr_theme_inherit default = false, want true")
-	}
+	assert.True(t, Default().TUI.HerdrThemeInherit, "herdr_theme_inherit default = false, want true")
 }
 
 func TestDefaultShowsLastWorkspacePath(t *testing.T) {
 	cfg := Default()
-	if !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath {
-		t.Fatalf("last workspace defaults = show %v, show path %v; want true", cfg.TUI.ShowLastWorkspace, cfg.TUI.ShowLastWorkspacePath)
-	}
+	require.True(t, cfg.TUI.ShowLastWorkspace)
+	assert.True(t, cfg.TUI.ShowLastWorkspacePath)
 }
 
 func TestDefaultReplacesWorktreeIcon(t *testing.T) {
-	if !Default().TUI.ReplaceWorktreeIcon {
-		t.Fatal("worktree icon replacement disabled by default")
-	}
+	assert.True(t, Default().TUI.ReplaceWorktreeIcon, "worktree icon replacement disabled by default")
 }
 
 func TestLoadTUIDefaultSort(t *testing.T) {
@@ -281,12 +226,8 @@ func TestLoadTUIDefaultSort(t *testing.T) {
 			p := filepath.Join(t.TempDir(), "sesh.toml")
 			mustWrite(t, p, "[tui]\ndefault_sort = \""+sortMode+"\"\n")
 			cfg, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if cfg.TUI.DefaultSort != sortMode {
-				t.Fatalf("default sort = %q, want %q", cfg.TUI.DefaultSort, sortMode)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, sortMode, cfg.TUI.DefaultSort)
 		})
 	}
 }
@@ -295,46 +236,30 @@ func TestLoadRejectsInvalidTUIDefaultSort(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "sesh.toml")
 	mustWrite(t, p, "[tui]\ndefault_sort = \"newest\"\n")
 	_, _, err := Load(LoadOptions{Warn: io.Discard, Path: p})
-	if err == nil {
-		t.Fatal("expected invalid default sort error")
-	}
+	require.Error(t, err)
 	for _, want := range []string{"tui.default_sort", "workspace", "recent", "agent"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q does not mention %q", err, want)
-		}
+		require.ErrorContains(t, err, want)
 	}
 }
 
 func TestDefaultPreviewCommandUsesEzaIcons(t *testing.T) {
 	cfg := Default()
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview command = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 	// Preview output is captured through sh, never a TTY, so eza's automatic
 	// color detection would disable ANSI colors without an explicit force.
-	if DefaultPreviewCommand != "eza --icons=always --color=always -la {}" {
-		t.Fatalf("default preview command = %q", DefaultPreviewCommand)
-	}
+	assert.Equal(t, "eza --icons=always --color=always -la {}", DefaultPreviewCommand)
 }
 
 func TestInitConfigDoesNotAdvertiseUnsupportedSeshSchema(t *testing.T) {
 	p, err := InitConfig(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	//nolint:gosec // p is returned from InitConfig using a test-owned temporary directory.
 	data, err := os.ReadFile(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(data), "sesh.schema.json") {
-		t.Fatalf("starter config advertises the full Sesh schema:\n%s", data)
-	}
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "sesh.schema.json")
 }
 
 func mustWrite(t *testing.T, p, s string) {
 	t.Helper()
-	if err := os.WriteFile(p, []byte(s), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(p, []byte(s), 0600))
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const migrateLegacyBody = `cache = true
@@ -46,25 +48,16 @@ func TestMigrateProducesEquivalentNativeConfig(t *testing.T) {
 	mustWrite(t, legacy, migrateLegacyBody)
 
 	gotLegacy, gotNative, err := Migrate(LoadOptions{Path: legacy}, "", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotLegacy != legacy || gotNative != filepath.Join(d, NativeFileName) {
-		t.Fatalf("paths = %q -> %q", gotLegacy, gotNative)
-	}
+	require.NoError(t, err)
+	require.Equal(t, legacy, gotLegacy)
+	require.Equal(t, filepath.Join(d, NativeFileName), gotNative)
 
 	legacyCfg, _, err := Load(LoadOptions{Path: legacy, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	nativeCfg, _, err := Load(LoadOptions{Path: gotNative, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	legacyCfg.ImportPaths = nil
-	if !configsEqual(legacyCfg, nativeCfg) {
-		t.Fatalf("migrated config differs:\nlegacy %#v\nnative %#v", legacyCfg, nativeCfg)
-	}
+	assert.Equal(t, legacyCfg, nativeCfg)
 }
 
 func TestMigrateFlattensImports(t *testing.T) {
@@ -74,87 +67,54 @@ func TestMigrateFlattensImports(t *testing.T) {
 	mustWrite(t, legacy, "import = [\"extra.toml\"]\n[[session]]\nname = \"main\"\npath = \"/main\"\n")
 
 	_, native, err := Migrate(LoadOptions{Path: legacy}, "", false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg, _, err := Load(LoadOptions{Path: native, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(cfg.SessionConfigs) != 2 || cfg.SessionConfigs[0].Name != "extra" || cfg.SessionConfigs[1].Name != "main" {
-		t.Fatalf("flattened workspaces = %#v", cfg.SessionConfigs)
-	}
+	require.NoError(t, err)
+	require.Len(t, cfg.SessionConfigs, 2)
+	require.Equal(t, "extra", cfg.SessionConfigs[0].Name)
+	assert.Equal(t, "main", cfg.SessionConfigs[1].Name)
 }
 
 func TestMigrateSharedSeshDirUsesFallback(t *testing.T) {
 	home := t.TempDir()
 	seshDir := filepath.Join(home, ".config", "sesh")
-	if err := os.MkdirAll(seshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(seshDir, 0700))
 	mustWrite(t, filepath.Join(seshDir, LegacyFileName), "cache = true\n")
 	fallback := filepath.Join(home, ".config", "herdr-sesh")
 
 	_, native, err := Migrate(LoadOptions{Home: home, Env: map[string]string{}}, fallback, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if native != filepath.Join(fallback, NativeFileName) {
-		t.Fatalf("native = %q, want inside %q", native, fallback)
-	}
-	if _, err := os.Stat(filepath.Join(seshDir, NativeFileName)); !os.IsNotExist(err) {
-		t.Fatal("wrote native file into undiscovered ~/.config/sesh")
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(fallback, NativeFileName), native)
+	_, err = os.Stat(filepath.Join(seshDir, NativeFileName))
+	require.ErrorIs(t, err, os.ErrNotExist, "wrote native file into undiscovered ~/.config/sesh")
 }
 
 func TestMigrateRelativeSharedSeshPathUsesFallback(t *testing.T) {
 	home, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	seshDir := filepath.Join(home, ".config", "sesh")
-	if err := os.MkdirAll(seshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(seshDir, 0700))
 	legacy := filepath.Join(seshDir, LegacyFileName)
 	mustWrite(t, legacy, "cache = true\n")
 	fallback := filepath.Join(home, ".config", "herdr-sesh")
 
 	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(home); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(home))
 	t.Cleanup(func() {
-		if err := os.Chdir(oldWD); err != nil {
-			t.Errorf("restore working directory: %v", err)
-		}
+		assert.NoError(t, os.Chdir(oldWD))
 	})
 
 	relativeLegacy := filepath.Join(".config", "sesh", LegacyFileName)
 	wantLegacy, err := filepath.Abs(relativeLegacy)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	gotLegacy, native, err := Migrate(LoadOptions{Path: relativeLegacy, Home: home}, fallback, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotLegacy != wantLegacy {
-		t.Fatalf("legacy = %q, want absolute path %q", gotLegacy, wantLegacy)
-	}
-	if native != filepath.Join(fallback, NativeFileName) {
-		t.Fatalf("native = %q, want discoverable path inside %q", native, fallback)
-	}
+	require.NoError(t, err)
+	require.Equal(t, wantLegacy, gotLegacy)
+	require.Equal(t, filepath.Join(fallback, NativeFileName), native)
 	resolved, err := ResolvePath(LoadOptions{Home: home, Env: map[string]string{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolved != native {
-		t.Fatalf("resolved = %q, want migrated config %q", resolved, native)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, native, resolved)
 }
 
 func migrateAndRead(t *testing.T, legacyBody string) (string, Config) {
@@ -163,49 +123,36 @@ func migrateAndRead(t *testing.T, legacyBody string) (string, Config) {
 	legacy := filepath.Join(d, LegacyFileName)
 	mustWrite(t, legacy, legacyBody)
 	_, native, err := Migrate(LoadOptions{Path: legacy}, "", false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	//nolint:gosec // native is a test-owned temporary path returned by Migrate.
 	data, err := os.ReadFile(native)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg, _, err := Load(LoadOptions{Path: native, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return string(data), cfg
 }
 
 func TestMigratePreservesAgentWorkspaceSort(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[tui]\ndefault_sort = \"agent\"\n")
-	if !strings.Contains(text, "workspace_sort") {
-		t.Fatalf("agent workspace sort missing from migrated config:\n%s", text)
-	}
-	if cfg.TUI.DefaultSort != "agent" {
-		t.Fatalf("workspace sort = %q, want agent", cfg.TUI.DefaultSort)
-	}
+	require.Contains(t, text, "workspace_sort")
+	assert.Equal(t, "agent", cfg.TUI.DefaultSort)
 }
 
 func TestMigrateEmitsShowIconsExplicitly(t *testing.T) {
 	t.Run("explicit true survives", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "[tui]\nshow_icons = true\n")
-		if !strings.Contains(text, "show_icons = true") || !cfg.TUI.ShowIcons {
-			t.Fatalf("show_icons=true lost:\n%s", text)
-		}
+		require.Contains(t, text, "show_icons = true")
+		assert.True(t, cfg.TUI.ShowIcons)
 	})
 	t.Run("explicit false survives as text", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "[tui]\nshow_icons = false\n")
-		if !strings.Contains(text, "show_icons = false") || cfg.TUI.ShowIcons {
-			t.Fatalf("explicit show_icons=false dropped from output:\n%s", text)
-		}
+		require.Contains(t, text, "show_icons = false")
+		assert.False(t, cfg.TUI.ShowIcons)
 	})
 	t.Run("absent enables icons", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "cache = true\n")
-		if !strings.Contains(text, "show_icons = true") || !cfg.TUI.ShowIcons {
-			t.Fatalf("absent show_icons did not enable icons:\n%s", text)
-		}
+		require.Contains(t, text, "show_icons = true")
+		assert.True(t, cfg.TUI.ShowIcons)
 	})
 	t.Run("explicit false in import survives", func(t *testing.T) {
 		d := t.TempDir()
@@ -213,67 +160,48 @@ func TestMigrateEmitsShowIconsExplicitly(t *testing.T) {
 		legacy := filepath.Join(d, LegacyFileName)
 		mustWrite(t, legacy, "import = [\"extra.toml\"]\n")
 		_, native, err := Migrate(LoadOptions{Path: legacy}, "", false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		cfg, _, err := Load(LoadOptions{Path: native, Warn: &bytes.Buffer{}})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if cfg.TUI.ShowIcons {
-			t.Fatal("imported explicit show_icons=false was overridden")
-		}
+		require.NoError(t, err)
+		assert.False(t, cfg.TUI.ShowIcons, "imported explicit show_icons=false was overridden")
 	})
 }
 
 func TestMigratePreservesDisabledHerdrThemeInheritance(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[tui]\nherdr_theme_inherit = false\n")
-	if !strings.Contains(text, "herdr_theme_inherit = false") {
-		t.Fatalf("disabled Herdr theme inheritance dropped from output:\n%s", text)
-	}
-	if cfg.TUI.HerdrThemeInherit {
-		t.Fatal("migrated herdr_theme_inherit = true, want false")
-	}
+	require.Contains(t, text, "herdr_theme_inherit = false")
+	assert.False(t, cfg.TUI.HerdrThemeInherit, "migrated herdr_theme_inherit = true, want false")
 }
 
 func TestMigratePreservesWorktreeIconReplacement(t *testing.T) {
 	t.Run("default enabled", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "cache = true\n")
-		if !strings.Contains(text, "replace_worktree_icon = true") || !cfg.TUI.ReplaceWorktreeIcon {
-			t.Fatalf("default worktree icon replacement lost:\n%s", text)
-		}
+		require.Contains(t, text, "replace_worktree_icon = true")
+		assert.True(t, cfg.TUI.ReplaceWorktreeIcon)
 	})
 	t.Run("explicit false", func(t *testing.T) {
 		text, cfg := migrateAndRead(t, "[tui]\nreplace_worktree_icon = false\n")
-		if !strings.Contains(text, "replace_worktree_icon = false") || cfg.TUI.ReplaceWorktreeIcon {
-			t.Fatalf("disabled worktree icon replacement lost:\n%s", text)
-		}
+		require.Contains(t, text, "replace_worktree_icon = false")
+		assert.False(t, cfg.TUI.ReplaceWorktreeIcon)
 	})
 }
 
 func TestMigratePreservesLastWorkspacePickerSettings(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[tui]\nshow_last_workspace = false\nshow_last_workspace_path = false\n")
-	if !strings.Contains(text, "show_last_workspace = false") || !strings.Contains(text, "show_last_workspace_path = false") {
-		t.Fatalf("last workspace settings dropped from output:\n%s", text)
-	}
-	if cfg.TUI.ShowLastWorkspace || cfg.TUI.ShowLastWorkspacePath {
-		t.Fatalf("migrated last workspace settings = %t, %t; want false, false", cfg.TUI.ShowLastWorkspace, cfg.TUI.ShowLastWorkspacePath)
-	}
+	require.Contains(t, text, "show_last_workspace = false")
+	require.Contains(t, text, "show_last_workspace_path = false")
+	require.False(t, cfg.TUI.ShowLastWorkspace)
+	assert.False(t, cfg.TUI.ShowLastWorkspacePath)
 }
 
 // The exact shape older releases generated via `config init`: no [tui] table
 // and the former colorless default preview baked in as an explicit value.
 func TestMigrateFormerGeneratedStarterShape(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[default_session]\npreview_command = \"eza --icons=always -la {}\"\n")
-	if !strings.Contains(text, "show_icons = true") || !cfg.TUI.ShowIcons {
-		t.Fatalf("icons not enabled for legacy file without show_icons:\n%s", text)
-	}
-	if strings.Contains(text, "preview") {
-		t.Fatalf("former default preview literal was kept as custom config:\n%s", text)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview = %q, want color-forced runtime default", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.Contains(t, text, "show_icons = true")
+	require.True(t, cfg.TUI.ShowIcons)
+	require.NotContains(t, text, "preview")
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestMigrateUpgradesFormerDefaultPreviewInWorkspacesAndRules(t *testing.T) {
@@ -286,40 +214,30 @@ preview_command = "eza --icons=always -la {}"
 pattern = "~/projects/**"
 preview_command = "eza --icons=always -la {}"
 `)
-	if got := cfg.SessionConfigs[0].PreviewCommand; got != DefaultPreviewCommand {
-		t.Fatalf("workspace preview = %q, want upgraded default", got)
-	}
-	if got := cfg.WildcardConfigs[0].PreviewCommand; got != DefaultPreviewCommand {
-		t.Fatalf("rule preview = %q, want upgraded default", got)
-	}
+	require.Equal(t, DefaultPreviewCommand, cfg.SessionConfigs[0].PreviewCommand)
+	assert.Equal(t, DefaultPreviewCommand, cfg.WildcardConfigs[0].PreviewCommand)
 }
 
 func TestMigrateLeavesDefaultPreviewToRuntime(t *testing.T) {
 	text, cfg := migrateAndRead(t, "cache = true\n")
-	if strings.Contains(text, "preview") {
-		t.Fatalf("unset preview was baked into migrated file:\n%s", text)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview = %q, want runtime default", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NotContains(t, text, "preview")
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestMigrateLeavesListAndNamingDefaultsToRuntime(t *testing.T) {
 	text, cfg := migrateAndRead(t, "cache = true\n")
-	if strings.Contains(text, "source_order") || strings.Contains(text, "path_components") {
-		t.Fatalf("unset list or naming defaults were baked into migrated file:\n%s", text)
-	}
+	require.NotContains(t, text, "source_order")
+	require.NotContains(t, text, "path_components")
 	defaults := Default()
-	if !cfg.Cache || !slices.Equal(cfg.SortOrder, defaults.SortOrder) || cfg.DirLength != defaults.DirLength {
-		t.Fatalf("migrated list config = cache %t, source order %v, path components %d", cfg.Cache, cfg.SortOrder, cfg.DirLength)
-	}
+	require.True(t, cfg.Cache)
+	require.True(t, slices.Equal(cfg.SortOrder, defaults.SortOrder))
+	assert.Equal(t, defaults.DirLength, cfg.DirLength)
 }
 
 func TestMigrateKeepsCustomPreviewVerbatim(t *testing.T) {
 	text, cfg := migrateAndRead(t, "[default_session]\npreview_command = \"printf custom {}\"\n")
-	if !strings.Contains(text, "printf custom {}") || cfg.DefaultSessionConfig.PreviewCommand != "printf custom {}" {
-		t.Fatalf("custom preview rewritten:\n%s", text)
-	}
+	require.Contains(t, text, "printf custom {}")
+	assert.Equal(t, "printf custom {}", cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestMigrateForceRejectsUnrelatedTarget(t *testing.T) {
@@ -329,22 +247,14 @@ func TestMigrateForceRejectsUnrelatedTarget(t *testing.T) {
 	mustWrite(t, legacy, "cache = true\n")
 	const unrelated = "not a herdr-sesh config\n"
 	//nolint:gosec // an existing non-private target verifies forced migration rejects it unchanged.
-	if err := os.WriteFile(target, []byte(unrelated), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(target, []byte(unrelated), 0644))
 
 	_, _, err := Migrate(LoadOptions{Path: legacy}, "", true)
-	if err == nil || !strings.Contains(err.Error(), "not a native config") {
-		t.Fatalf("err = %v", err)
-	}
+	require.ErrorContains(t, err, "not a native config")
 	//nolint:gosec // target is a test-owned temporary path.
 	got, readErr := os.ReadFile(target)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	if string(got) != unrelated {
-		t.Fatalf("unrelated target was overwritten with %q", got)
-	}
+	require.NoError(t, readErr)
+	assert.Equal(t, unrelated, string(got))
 }
 
 func TestMigrateForceReplacesNativeTargetWithPrivateMode(t *testing.T) {
@@ -353,44 +263,28 @@ func TestMigrateForceReplacesNativeTargetWithPrivateMode(t *testing.T) {
 	target := filepath.Join(d, NativeFileName)
 	mustWrite(t, legacy, "cache = true\n")
 	//nolint:gosec // an existing non-private target verifies migration replaces its mode with 0600.
-	if err := os.WriteFile(target, []byte("version = 1\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(target, []byte("version = 1\n"), 0644))
 
 	_, _, err := Migrate(LoadOptions{Path: legacy}, "", true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	info, err := os.Stat(target)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0600 {
-		t.Fatalf("mode = %v, want 0600", info.Mode().Perm())
-	}
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
 	cfg, _, err := Load(LoadOptions{Path: target, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.Cache {
-		t.Fatal("forced migration did not replace native target")
-	}
+	require.NoError(t, err)
+	assert.True(t, cfg.Cache, "forced migration did not replace native target")
 }
 
 func TestMigrateErrors(t *testing.T) {
 	t.Run("no config", func(t *testing.T) {
 		_, _, err := Migrate(LoadOptions{Home: t.TempDir(), Env: map[string]string{}}, "", false)
-		if err == nil || !strings.Contains(err.Error(), "no config file") {
-			t.Fatalf("err = %v", err)
-		}
+		require.ErrorContains(t, err, "no config file")
 	})
 	t.Run("already native", func(t *testing.T) {
 		p := filepath.Join(t.TempDir(), NativeFileName)
 		mustWrite(t, p, "version = 1\n")
 		_, _, err := Migrate(LoadOptions{Path: p}, "", false)
-		if err == nil || !strings.Contains(err.Error(), "already a native config") {
-			t.Fatalf("err = %v", err)
-		}
+		require.ErrorContains(t, err, "already a native config")
 	})
 	t.Run("target exists", func(t *testing.T) {
 		d := t.TempDir()
@@ -398,37 +292,26 @@ func TestMigrateErrors(t *testing.T) {
 		mustWrite(t, legacy, "cache = true\n")
 		mustWrite(t, filepath.Join(d, NativeFileName), "version = 1\n")
 		_, _, err := Migrate(LoadOptions{Path: legacy}, "", false)
-		if err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
-			t.Fatalf("err = %v", err)
-		}
+		require.ErrorContains(t, err, "refusing to overwrite")
 	})
 	t.Run("forced target cannot replace source", func(t *testing.T) {
 		p := filepath.Join(t.TempDir(), NativeFileName)
 		const body = "cache = true\n"
 		mustWrite(t, p, body)
 		_, _, err := Migrate(LoadOptions{Path: p}, "", true)
-		if err == nil || !strings.Contains(err.Error(), "same file") {
-			t.Fatalf("err = %v", err)
-		}
+		require.ErrorContains(t, err, "same file")
 		//nolint:gosec // p is a test-owned temporary path.
 		got, readErr := os.ReadFile(p)
-		if readErr != nil {
-			t.Fatal(readErr)
-		}
-		if string(got) != body {
-			t.Fatalf("source was changed to %q", got)
-		}
+		require.NoError(t, readErr)
+		assert.Equal(t, body, string(got))
 	})
 	t.Run("invalid legacy value fails native validation without writing", func(t *testing.T) {
 		d := t.TempDir()
 		legacy := filepath.Join(d, LegacyFileName)
 		mustWrite(t, legacy, "blacklist = [\"[\"]\n")
 		_, _, err := Migrate(LoadOptions{Path: legacy}, "", false)
-		if err == nil || !strings.Contains(err.Error(), "native validation") {
-			t.Fatalf("err = %v", err)
-		}
-		if _, err := os.Stat(filepath.Join(d, NativeFileName)); !os.IsNotExist(err) {
-			t.Fatal("wrote native file despite validation failure")
-		}
+		require.ErrorContains(t, err, "native validation")
+		_, err = os.Stat(filepath.Join(d, NativeFileName))
+		require.ErrorIs(t, err, os.ErrNotExist, "wrote native file despite validation failure")
 	})
 }

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -2,15 +2,14 @@ package config
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadNative(t *testing.T, body string) (Config, error) {
@@ -69,9 +68,7 @@ preview = "ls {}"
 disable_startup = false
 tabs = ["git"]
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	disable := true
 	want := Config{
 		Cache:          true,
@@ -99,40 +96,33 @@ tabs = ["git"]
 			Windows:        []string{"git"},
 		}},
 	}
-	if !configsEqual(cfg, want) {
-		t.Fatalf("decoded config mismatch:\ngot  %#v\nwant %#v", cfg, want)
-	}
+	assert.Equal(t, want, cfg)
 }
 
 func TestNativeMinimalFileKeepsDefaults(t *testing.T) {
 	cfg, err := loadNative(t, "version = 1\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	d := Default()
-	if cfg.DirLength != d.DirLength || cfg.TUI.DefaultSort != d.TUI.DefaultSort || !cfg.TUI.PrioritizeHome || !cfg.TUI.HerdrThemeInherit || !cfg.TUI.ShowLastWorkspace || !cfg.TUI.ShowLastWorkspacePath || !cfg.TUI.ReplaceWorktreeIcon || cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("defaults lost: %#v", cfg)
-	}
+	assert.Equal(t, d.DirLength, cfg.DirLength)
+	assert.Equal(t, d.TUI.DefaultSort, cfg.TUI.DefaultSort)
+	assert.True(t, cfg.TUI.PrioritizeHome, "prioritize_home")
+	assert.True(t, cfg.TUI.HerdrThemeInherit, "herdr_theme_inherit")
+	assert.True(t, cfg.TUI.ShowLastWorkspace, "show_last_workspace")
+	assert.True(t, cfg.TUI.ShowLastWorkspacePath, "show_last_workspace_path")
+	assert.True(t, cfg.TUI.ReplaceWorktreeIcon, "replace_worktree_icon")
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestNativePickerCanDisableHomePrioritization(t *testing.T) {
 	cfg, err := loadNative(t, "version = 1\n[picker]\nprioritize_home = false\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.PrioritizeHome {
-		t.Fatal("prioritize_home=true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.PrioritizeHome, "prioritize_home=true, want false")
 }
 
 func TestNativePickerAcceptsAgentWorkspaceSort(t *testing.T) {
 	cfg, err := loadNative(t, "version = 1\n[picker]\nworkspace_sort = \"agent\"\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.DefaultSort != "agent" {
-		t.Fatalf("workspace sort = %q, want agent", cfg.TUI.DefaultSort)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "agent", cfg.TUI.DefaultSort)
 }
 
 func TestNativePickerCanDisableHerdrThemeInheritance(t *testing.T) {
@@ -141,12 +131,8 @@ func TestNativePickerCanDisableHerdrThemeInheritance(t *testing.T) {
 [picker]
 herdr_theme_inherit = false
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.HerdrThemeInherit {
-		t.Fatal("herdr_theme_inherit = true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.HerdrThemeInherit, "herdr_theme_inherit = true, want false")
 }
 
 func TestNativePickerCanDisableWorktreeIconReplacement(t *testing.T) {
@@ -155,12 +141,8 @@ func TestNativePickerCanDisableWorktreeIconReplacement(t *testing.T) {
 [picker]
 replace_worktree_icon = false
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ReplaceWorktreeIcon {
-		t.Fatal("replace_worktree_icon=true, want false")
-	}
+	require.NoError(t, err)
+	assert.False(t, cfg.TUI.ReplaceWorktreeIcon, "replace_worktree_icon=true, want false")
 }
 
 func TestNativePickerCanDisablePreview(t *testing.T) {
@@ -169,20 +151,12 @@ func TestNativePickerCanDisablePreview(t *testing.T) {
 [picker]
 show_preview = false
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ShowPreview {
-		t.Fatal("show_preview=true, want false")
-	}
+	require.NoError(t, err)
+	require.False(t, cfg.TUI.ShowPreview, "show_preview=true, want false")
 
 	defaults, err := loadNative(t, "version = 1\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !defaults.TUI.ShowPreview {
-		t.Fatal("show_preview=false by default, want true")
-	}
+	require.NoError(t, err)
+	assert.True(t, defaults.TUI.ShowPreview, "show_preview=false by default, want true")
 }
 
 func TestNativePickerPreviewMode(t *testing.T) {
@@ -198,14 +172,11 @@ func TestNativePickerPreviewMode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := loadNative(t, "version = 1\n[picker]\n"+tc.setting+"\n")
 			if tc.want == "" {
-				if err == nil || !strings.Contains(err.Error(), "picker.preview_mode") {
-					t.Fatalf("expected preview_mode validation error, got %v", err)
-				}
+				assert.ErrorContains(t, err, "picker.preview_mode")
 				return
 			}
-			if err != nil || cfg.TUI.PreviewMode != tc.want {
-				t.Fatalf("mode=%q err=%v, want %q", cfg.TUI.PreviewMode, err, tc.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.TUI.PreviewMode)
 		})
 	}
 }
@@ -217,22 +188,15 @@ func TestNativePickerAcceptsLastWorkspaceSettings(t *testing.T) {
 show_last_workspace = false
 show_last_workspace_path = false
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TUI.ShowLastWorkspace || cfg.TUI.ShowLastWorkspacePath {
-		t.Fatalf("last workspace settings = %t, %t; want false, false", cfg.TUI.ShowLastWorkspace, cfg.TUI.ShowLastWorkspacePath)
-	}
+	require.NoError(t, err)
+	require.False(t, cfg.TUI.ShowLastWorkspace)
+	assert.False(t, cfg.TUI.ShowLastWorkspacePath)
 }
 
 func TestNativeEmptyPreviewFallsBackToDefault(t *testing.T) {
 	cfg, err := loadNative(t, "version = 1\n[workspace_defaults]\npreview = \"\"\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("preview = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 }
 
 func TestNativeFailures(t *testing.T) {
@@ -264,12 +228,7 @@ func TestNativeFailures(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, err := loadNative(t, tc.body)
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error %q does not mention %q", err, tc.want)
-			}
+			assert.ErrorContains(t, err, tc.want)
 		})
 	}
 }
@@ -347,30 +306,13 @@ tabs = ["git"]
 `)
 	var warn bytes.Buffer
 	legacyCfg, _, err := Load(LoadOptions{Path: legacyPath, Warn: &warn})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	nativeCfg, _, err := Load(LoadOptions{Path: nativePath, Warn: &warn})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// Normalize the one representational difference: legacy leaves ImportPaths
 	// nil and native never sets it.
 	legacyCfg.ImportPaths = nil
-	if !configsEqual(legacyCfg, nativeCfg) {
-		t.Fatalf("parity mismatch:\nlegacy %#v\nnative %#v", legacyCfg, nativeCfg)
-	}
-}
-
-func configsEqual(a, b Config) bool {
-	ad := a.SessionConfigs[0].DisableStartCommand
-	bd := b.SessionConfigs[0].DisableStartCommand
-	if (ad == nil) != (bd == nil) || (ad != nil && *ad != *bd) {
-		return false
-	}
-	a.SessionConfigs[0].DisableStartCommand = nil
-	b.SessionConfigs[0].DisableStartCommand = nil
-	return reflect.DeepEqual(a, b)
+	assert.Equal(t, legacyCfg, nativeCfg)
 }
 
 func TestDiscoveredNativeFileRequiresVersion(t *testing.T) {
@@ -381,49 +323,38 @@ func TestDiscoveredNativeFileRequiresVersion(t *testing.T) {
 		Env:  map[string]string{"HERDR_PLUGIN_CONFIG_DIR": dir},
 		Warn: &bytes.Buffer{},
 	})
-	if err == nil || !strings.Contains(err.Error(), "version") {
-		t.Fatalf("expected version error, got %v", err)
-	}
+	require.ErrorContains(t, err, "version")
 }
 
 func TestExplicitPathWithoutVersionLoadsAsLegacy(t *testing.T) {
 	p := filepath.Join(t.TempDir(), NativeFileName)
 	mustWrite(t, p, "cache = true\n")
 	cfg, _, err := Load(LoadOptions{Path: p, Warn: &bytes.Buffer{}})
-	if err != nil || !cfg.Cache {
-		t.Fatalf("cfg %#v err %v", cfg, err)
-	}
+	require.NoError(t, err)
+	assert.True(t, cfg.Cache)
 }
 
 func TestExplicitPathVersionKeySelectsNative(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "anything.toml")
 	mustWrite(t, p, "version = 1\nstrict_mode = true\n")
 	_, _, err := Load(LoadOptions{Path: p, Warn: &bytes.Buffer{}})
-	if err == nil || !strings.Contains(err.Error(), "strict_mode") {
-		t.Fatalf("expected native strict rejection, got %v", err)
-	}
+	require.ErrorContains(t, err, "strict_mode")
 }
 
 func TestLegacyLoadWarnsOnStderrWriter(t *testing.T) {
 	p := filepath.Join(t.TempDir(), LegacyFileName)
 	mustWrite(t, p, "cache = true\n")
 	var warn bytes.Buffer
-	if _, _, err := Load(LoadOptions{Path: p, Warn: &warn}); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(warn.String(), "deprecated") {
-		t.Fatalf("warning = %q", warn.String())
-	}
+	_, _, err := Load(LoadOptions{Path: p, Warn: &warn})
+	require.NoError(t, err)
+	assert.Contains(t, warn.String(), "deprecated")
 }
 
 func TestNativeFixtureLoads(t *testing.T) {
 	cfg, _, err := Load(LoadOptions{Path: filepath.Join("..", "..", "testdata", "herdr-sesh.toml"), Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(cfg.SessionConfigs) != 1 || cfg.SessionConfigs[0].Name != "sesh" {
-		t.Fatalf("fixture workspaces = %#v", cfg.SessionConfigs)
-	}
+	require.NoError(t, err)
+	require.Len(t, cfg.SessionConfigs, 1)
+	assert.Equal(t, "sesh", cfg.SessionConfigs[0].Name)
 }
 
 func TestDiscoveryOrderAndPrecedence(t *testing.T) {
@@ -435,9 +366,7 @@ func TestDiscoveryOrderAndPrecedence(t *testing.T) {
 		filepath.Join(home, ".config", "sesh"),
 	}
 	for _, d := range mkdirs {
-		if err := os.MkdirAll(d, 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(d, 0700))
 	}
 	write := func(rel string) string {
 		p := filepath.Join(home, rel)
@@ -459,12 +388,8 @@ func TestDiscoveryOrderAndPrecedence(t *testing.T) {
 	for i := len(order) - 1; i >= 0; i-- {
 		want := write(order[i])
 		got, err := ResolvePath(LoadOptions{Home: home, Env: map[string]string{"HERDR_PLUGIN_CONFIG_DIR": pluginDir}})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != want {
-			t.Fatalf("after creating %s: resolved %s, want %s", order[i], got, want)
-		}
+		require.NoError(t, err)
+		require.Equal(t, want, got)
 	}
 }
 
@@ -473,9 +398,7 @@ func TestMissingEnvConfigErrors(t *testing.T) {
 		Home: t.TempDir(),
 		Env:  map[string]string{"HERDR_SESH_CONFIG": "/nope/missing.toml"},
 	})
-	if err == nil {
-		t.Fatal("expected error for missing HERDR_SESH_CONFIG target")
-	}
+	require.Error(t, err)
 }
 
 func TestResolvePathPropagatesFilesystemErrors(t *testing.T) {
@@ -485,9 +408,7 @@ func TestResolvePathPropagatesFilesystemErrors(t *testing.T) {
 
 	t.Run("explicit path", func(t *testing.T) {
 		_, err := ResolvePath(LoadOptions{Path: filepath.Join(notDir, NativeFileName), Home: home, Env: map[string]string{}})
-		if !errors.Is(err, syscall.ENOTDIR) {
-			t.Fatalf("err = %v, want original filesystem error", err)
-		}
+		require.ErrorIs(t, err, syscall.ENOTDIR)
 	})
 
 	t.Run("environment path", func(t *testing.T) {
@@ -495,59 +416,38 @@ func TestResolvePathPropagatesFilesystemErrors(t *testing.T) {
 			Home: home,
 			Env:  map[string]string{"HERDR_SESH_CONFIG": filepath.Join(notDir, NativeFileName)},
 		})
-		if !errors.Is(err, syscall.ENOTDIR) {
-			t.Fatalf("err = %v, want original filesystem error", err)
-		}
+		require.ErrorIs(t, err, syscall.ENOTDIR)
 	})
 
 	t.Run("default discovery", func(t *testing.T) {
 		fallbackDir := filepath.Join(home, ".config", "herdr-sesh")
-		if err := os.MkdirAll(fallbackDir, 0700); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(fallbackDir, 0700))
 		mustWrite(t, filepath.Join(fallbackDir, NativeFileName), "version = 1\n")
 
 		_, err := ResolvePath(LoadOptions{
 			Home: home,
 			Env:  map[string]string{"HERDR_PLUGIN_CONFIG_DIR": notDir},
 		})
-		if !errors.Is(err, syscall.ENOTDIR) {
-			t.Fatalf("err = %v, want higher-priority filesystem error", err)
-		}
+		require.ErrorIs(t, err, syscall.ENOTDIR)
 	})
 }
 
 func TestInitConfigWritesNativeStarter(t *testing.T) {
 	dir := t.TempDir()
 	p, err := InitConfig(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if filepath.Base(p) != NativeFileName {
-		t.Fatalf("init path = %s", p)
-	}
+	require.NoError(t, err)
+	require.Equal(t, NativeFileName, filepath.Base(p))
 	cfg, _, err := Load(LoadOptions{Path: p, Warn: &bytes.Buffer{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DefaultSessionConfig.PreviewCommand != DefaultPreviewCommand {
-		t.Fatalf("starter preview = %q", cfg.DefaultSessionConfig.PreviewCommand)
-	}
+	require.NoError(t, err)
+	require.Equal(t, DefaultPreviewCommand, cfg.DefaultSessionConfig.PreviewCommand)
 	info, err := os.Stat(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0600 {
-		t.Fatalf("mode = %v", info.Mode().Perm())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }
 
 func TestInitConfigAtRejectsDirectory(t *testing.T) {
 	p := filepath.Join(t.TempDir(), NativeFileName)
-	if err := os.Mkdir(p, 0700); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := InitConfigAt(p); err == nil || !strings.Contains(err.Error(), "not a regular file") {
-		t.Fatalf("err = %v, want non-regular config path error", err)
-	}
+	require.NoError(t, os.Mkdir(p, 0700))
+	_, err := InitConfigAt(p)
+	require.ErrorContains(t, err, "not a regular file")
 }

--- a/internal/config/wildcard_test.go
+++ b/internal/config/wildcard_test.go
@@ -1,33 +1,27 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestWildcardOneLevelAndRecursive(t *testing.T) {
 	home := "/home/zach"
-	if !MatchWildcard("~/projects/*", "/home/zach/projects/api", home) {
-		t.Fatal("one-level should match")
-	}
-	if MatchWildcard("~/projects/*", "/home/zach/projects/team/api", home) {
-		t.Fatal("one-level should not match nested")
-	}
-	if !MatchWildcard("~/projects/**", "/home/zach/projects", home) {
-		t.Fatal("recursive should match base directory")
-	}
-	if !MatchWildcard("~/projects/**", "/home/zach/projects/team/api", home) {
-		t.Fatal("recursive should match nested")
-	}
+	require.True(t, MatchWildcard("~/projects/*", "/home/zach/projects/api", home), "one-level should match")
+	require.False(t, MatchWildcard("~/projects/*", "/home/zach/projects/team/api", home), "one-level should not match nested")
+	require.True(t, MatchWildcard("~/projects/**", "/home/zach/projects", home), "recursive should match base directory")
+	assert.True(t, MatchWildcard("~/projects/**", "/home/zach/projects/team/api", home), "recursive should match nested")
 }
 func TestFindWildcardFirstWins(t *testing.T) {
 	cfg := Config{WildcardConfigs: []WildcardConfig{{Pattern: "/tmp/**", StartupCommand: "first"}, {Pattern: "/tmp/app", StartupCommand: "second"}}}
 	w, ok := FindWildcard(cfg, "/tmp/app", "")
-	if !ok || w.StartupCommand != "first" {
-		t.Fatalf("bad wildcard %#v %v", w, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "first", w.StartupCommand)
 }
 func TestSubstitutePathShellQuotesSpaces(t *testing.T) {
 	got := SubstitutePath("cd {} && pwd", "/tmp/has space")
 	want := "cd '/tmp/has space' && pwd"
-	if got != want {
-		t.Fatalf("got %q want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -8,34 +8,27 @@ import (
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/sources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnectFocusesExistingWorkspace(t *testing.T) {
 	f := &herdr.FakeClient{}
 	_, err := Connect(context.Background(), f, []model.Session{{Name: "api", WorkspaceID: "ws1"}}, "api", Options{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(f.FocusedWorkspaces) != 1 || f.FocusedWorkspaces[0] != "ws1" {
-		t.Fatalf("focused: %#v", f.FocusedWorkspaces)
-	}
-	if len(f.CreatedWorkspaces) != 0 {
-		t.Fatalf("created unexpectedly: %#v", f.CreatedWorkspaces)
-	}
+	require.NoError(t, err)
+	require.Len(t, f.FocusedWorkspaces, 1)
+	require.Equal(t, "ws1", f.FocusedWorkspaces[0])
+	assert.Empty(t, f.CreatedWorkspaces)
 }
 
 func TestConnectCreatesWorkspaceForConfigSession(t *testing.T) {
 	f := &herdr.FakeClient{}
 	res, err := Connect(context.Background(), f, []model.Session{{Source: "config", Name: "api", Path: "/tmp/api"}}, "api", Options{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !res.Created || len(f.CreatedWorkspaces) != 1 {
-		t.Fatalf("result=%#v created=%#v", res, f.CreatedWorkspaces)
-	}
-	if f.CreatedWorkspaces[0].CWD != "/tmp/api" || f.CreatedWorkspaces[0].Label != "api" {
-		t.Fatalf("bad request: %#v", f.CreatedWorkspaces[0])
-	}
+	require.NoError(t, err)
+	require.True(t, res.Created)
+	require.Len(t, f.CreatedWorkspaces, 1)
+	require.Equal(t, "/tmp/api", f.CreatedWorkspaces[0].CWD)
+	assert.Equal(t, "api", f.CreatedWorkspaces[0].Label)
 }
 
 func TestConnectNoFocusScopesStartupCommandToCreatedWorkspace(t *testing.T) {
@@ -47,15 +40,12 @@ func TestConnectNoFocusScopesStartupCommandToCreatedWorkspace(t *testing.T) {
 		},
 	}
 	session := model.Session{Source: "config", Name: "api", Path: "/tmp/api", StartupCommand: "echo ready"}
-	if _, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{NoFocus: true}); err != nil {
-		t.Fatal(err)
-	}
-	if len(f.CreatedWorkspaces) != 1 || f.CreatedWorkspaces[0].Focus {
-		t.Fatalf("created workspaces: %#v", f.CreatedWorkspaces)
-	}
-	if len(f.PaneRuns) != 1 || f.PaneRuns[0] != "new-pane:echo ready" {
-		t.Fatalf("pane runs: %#v", f.PaneRuns)
-	}
+	_, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{NoFocus: true})
+	require.NoError(t, err)
+	require.Len(t, f.CreatedWorkspaces, 1)
+	require.False(t, f.CreatedWorkspaces[0].Focus)
+	require.Len(t, f.PaneRuns, 1)
+	assert.Equal(t, "new-pane:echo ready", f.PaneRuns[0])
 }
 
 func TestConnectFocusedScopesStartupCommandToCreatedWorkspace(t *testing.T) {
@@ -67,29 +57,21 @@ func TestConnectFocusedScopesStartupCommandToCreatedWorkspace(t *testing.T) {
 		},
 	}
 	session := model.Session{Source: "config", Name: "api", Path: "/tmp/api", StartupCommand: "echo ready"}
-	if _, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{}); err != nil {
-		t.Fatal(err)
-	}
-	if len(f.CreatedWorkspaces) != 1 || !f.CreatedWorkspaces[0].Focus {
-		t.Fatalf("created workspaces: %#v", f.CreatedWorkspaces)
-	}
-	if len(f.PaneRuns) != 1 || f.PaneRuns[0] != "new-pane:echo ready" {
-		t.Fatalf("pane runs: %#v", f.PaneRuns)
-	}
+	_, err := Connect(context.Background(), f, []model.Session{session}, "api", Options{})
+	require.NoError(t, err)
+	require.Len(t, f.CreatedWorkspaces, 1)
+	require.True(t, f.CreatedWorkspaces[0].Focus)
+	require.Len(t, f.PaneRuns, 1)
+	assert.Equal(t, "new-pane:echo ready", f.PaneRuns[0])
 }
 
 func TestConnectUsesExpandedConfigSessionPath(t *testing.T) {
 	cfg := config.Config{SessionConfigs: []config.SessionConfig{{Name: "api", Path: "~/projects/api"}}}
 	got, err := sources.ConfigSessions{Config: cfg, Home: "/home/zach"}.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	f := &herdr.FakeClient{}
 	_, err = Connect(context.Background(), f, got.Ordered(), "api", Options{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(f.CreatedWorkspaces) != 1 || f.CreatedWorkspaces[0].CWD != "/home/zach/projects/api" {
-		t.Fatalf("created workspaces: %#v", f.CreatedWorkspaces)
-	}
+	require.NoError(t, err)
+	require.Len(t, f.CreatedWorkspaces, 1)
+	assert.Equal(t, "/home/zach/projects/api", f.CreatedWorkspaces[0].CWD)
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type recRunner struct{ calls [][]string }
@@ -20,136 +21,118 @@ func TestCLIClientConstructsWorkspaceCreate(t *testing.T) {
 	rr := &recRunner{}
 	c := &CLIClient{Bin: "/bin/herdr", Runner: rr}
 	_, err := c.WorkspaceCreate(context.Background(), WorkspaceCreateRequest{CWD: "/tmp/api", Label: "api", Focus: true})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := [][]string{
 		{"/bin/herdr", "workspace", "create", "--cwd", "/tmp/api", "--label", "api"},
 		{"/bin/herdr", "workspace", "focus", "ws1"},
 	}
-	if !reflect.DeepEqual(rr.calls, want) {
-		t.Fatalf("got %#v want %#v", rr.calls, want)
-	}
+	assert.Equal(t, want, rr.calls)
 }
 
 func TestCLIClientConstructsWorkspaceCreateNoFocus(t *testing.T) {
 	rr := &recRunner{}
 	c := &CLIClient{Bin: "/bin/herdr", Runner: rr}
 	_, err := c.WorkspaceCreate(context.Background(), WorkspaceCreateRequest{CWD: "/tmp/api", Label: "api"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := [][]string{{"/bin/herdr", "workspace", "create", "--cwd", "/tmp/api", "--label", "api", "--no-focus"}}
-	if !reflect.DeepEqual(rr.calls, want) {
-		t.Fatalf("got %#v want %#v", rr.calls, want)
-	}
+	assert.Equal(t, want, rr.calls)
 }
 
 func TestCLIClientConstructsWorkspaceClose(t *testing.T) {
 	rr := &recRunner{}
 	c := &CLIClient{Bin: "/bin/herdr", Runner: rr}
-	if err := c.WorkspaceClose(context.Background(), "ws1"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.WorkspaceClose(context.Background(), "ws1"))
 	want := [][]string{{"/bin/herdr", "workspace", "close", "ws1"}}
-	if !reflect.DeepEqual(rr.calls, want) {
-		t.Fatalf("got %#v want %#v", rr.calls, want)
-	}
+	assert.Equal(t, want, rr.calls)
 }
 
 func TestCLIClientDecodesWorkspaceListEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"workspaces":[{"workspace_id":"w1","label":"api","agent_status":"working"}]}}`)}}
 	got, err := c.WorkspaceList(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" || got[0].AgentStatus != "working" {
-		t.Fatalf("workspaces=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "w1", got[0].ID)
+	require.Equal(t, "api", got[0].Label)
+	assert.Equal(t, "working", got[0].AgentStatus)
 }
 
 func TestCLIClientDecodesWorkspaceListWorktreeMetadata(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"workspaces":[{"workspace_id":"w-root","label":"project","worktree":{"checkout_path":"/repos/project","is_linked_worktree":false,"repo_key":"/repos/project/.git","repo_name":"project","repo_root":"/repos/project"}},{"workspace_id":"w-child","label":"feature","worktree":{"checkout_path":"/worktrees/feature","is_linked_worktree":true,"repo_key":"/repos/project/.git","repo_name":"project","repo_root":"/repos/project"}}]}}`)}}
 	got, err := c.WorkspaceList(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("workspaces=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 2)
 	root, child := got[0].Worktree, got[1].Worktree
-	if root == nil || root.IsLinkedWorktree || root.CheckoutPath != "/repos/project" || root.RepoKey != "/repos/project/.git" || root.RepoName != "project" || root.RepoRoot != "/repos/project" {
-		t.Fatalf("root worktree=%#v", root)
-	}
-	if child == nil || !child.IsLinkedWorktree || child.CheckoutPath != "/worktrees/feature" || child.RepoKey != root.RepoKey {
-		t.Fatalf("child worktree=%#v", child)
-	}
+	require.NotNil(t, root)
+	require.False(t, root.IsLinkedWorktree)
+	require.Equal(t, "/repos/project", root.CheckoutPath)
+	require.Equal(t, "/repos/project/.git", root.RepoKey)
+	require.Equal(t, "project", root.RepoName)
+	require.Equal(t, "/repos/project", root.RepoRoot)
+	require.NotNil(t, child)
+	require.True(t, child.IsLinkedWorktree)
+	require.Equal(t, "/worktrees/feature", child.CheckoutPath)
+	assert.Equal(t, root.RepoKey, child.RepoKey)
 }
 
 func TestCLIClientDecodesWorkspaceListArrayWithoutWorktreeMetadata(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`[{"id":"w1","label":"api","agent_status":"blocked"}]`)}}
 	got, err := c.WorkspaceList(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != "w1" || got[0].Label != "api" || got[0].AgentStatus != "blocked" || got[0].Worktree != nil {
-		t.Fatalf("workspaces=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "w1", got[0].ID)
+	require.Equal(t, "api", got[0].Label)
+	require.Equal(t, "blocked", got[0].AgentStatus)
+	require.Nil(t, got[0].Worktree)
 }
 
 func TestCLIClientDecodesWorkspaceCreateEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"root_pane":{"cwd":"/tmp/api","pane_id":"p1"},"workspace":{"workspace_id":"w1","label":"api"}}}`)}}
 	got, err := c.WorkspaceCreate(context.Background(), WorkspaceCreateRequest{CWD: "/tmp/api", Label: "api", Focus: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.ID != "w1" || got.Label != "api" || got.CWD != "/tmp/api" {
-		t.Fatalf("workspace=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "w1", got.ID)
+	require.Equal(t, "api", got.Label)
+	assert.Equal(t, "/tmp/api", got.CWD)
 }
 
 func TestCLIClientDecodesTabCreateEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"root_pane":{"cwd":"/tmp/api","pane_id":"p1"},"tab":{"tab_id":"w1:t2","workspace_id":"w1","label":"api"}}}`)}}
 	got, err := c.TabCreate(context.Background(), TabCreateRequest{WorkspaceID: "w1", CWD: "/tmp/api", Label: "api", Focus: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.ID != "w1:t2" || got.WorkspaceID != "w1" || got.CWD != "/tmp/api" || got.PaneID != "p1" {
-		t.Fatalf("tab=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "w1:t2", got.ID)
+	require.Equal(t, "w1", got.WorkspaceID)
+	require.Equal(t, "/tmp/api", got.CWD)
+	assert.Equal(t, "p1", got.PaneID)
 }
 
 func TestCLIClientDecodesTabListArray(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`[{"id":"w1:t1","workspace_id":"w1","label":"api"}]`)}}
 	got, err := c.TabList(context.Background(), "w1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != "w1:t1" || got[0].WorkspaceID != "w1" || got[0].Label != "api" {
-		t.Fatalf("tabs=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "w1:t1", got[0].ID)
+	require.Equal(t, "w1", got[0].WorkspaceID)
+	assert.Equal(t, "api", got[0].Label)
 }
 
 func TestCLIClientDecodesPaneListEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"panes":[{"pane_id":"p1","workspace_id":"w1","tab_id":"w1:t1","cwd":"/tmp/api","foreground_cwd":"/tmp/api/sub","focused":true}]}}`)}}
 	got, err := c.PaneList(context.Background(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != "p1" || got[0].WorkspaceID != "w1" || got[0].ForegroundCWD != "/tmp/api/sub" || !got[0].Focused {
-		t.Fatalf("panes=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "p1", got[0].ID)
+	require.Equal(t, "w1", got[0].WorkspaceID)
+	require.Equal(t, "/tmp/api/sub", got[0].ForegroundCWD)
+	assert.True(t, got[0].Focused)
 }
 
 func TestCLIClientDecodesPaneCurrentEnvelope(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte(`{"result":{"pane":{"pane_id":"p1","workspace_id":"w1","tab_id":"w1:t1","cwd":"/tmp/api"}}}`)}}
 	got, err := c.PaneCurrent(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.ID != "p1" || got.WorkspaceID != "w1" || got.TabID != "w1:t1" || got.CWD != "/tmp/api" {
-		t.Fatalf("pane=%#v", got)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "p1", got.ID)
+	require.Equal(t, "w1", got.WorkspaceID)
+	require.Equal(t, "w1:t1", got.TabID)
+	assert.Equal(t, "/tmp/api", got.CWD)
 }
 
 func TestCLIClientPaneFocusedOmitsCallerPane(t *testing.T) {
@@ -163,30 +146,21 @@ else
 fi
 `
 	//nolint:gosec // test creates a local executable fixture.
-	if err := os.WriteFile(bin, []byte(script), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0700))
 	t.Setenv("HERDR_PANE_ID", "stale-pane")
 	c := &CLIClient{Bin: bin, Runner: ExecRunner{}}
 
 	caller, err := c.PaneCurrent(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	focused, err := c.PaneFocused(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if caller.WorkspaceID != "caller" || focused.WorkspaceID != "focused" {
-		t.Fatalf("caller=%q focused=%q", caller.WorkspaceID, focused.WorkspaceID)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "caller", caller.WorkspaceID)
+	assert.Equal(t, "focused", focused.WorkspaceID)
 }
 func TestFakeClientRecordsPaneRun(t *testing.T) {
 	f := &FakeClient{}
 	_ = f.PaneRun(context.Background(), "p1", "npm test")
-	if f.PaneRuns[0] != "p1:npm test" {
-		t.Fatal(f.PaneRuns)
-	}
+	assert.Equal(t, "p1:npm test", f.PaneRuns[0])
 }
 
 type fixedRunner struct {
@@ -202,21 +176,13 @@ func (r fixedRunner) Run(context.Context, string, ...string) ([]byte, []byte, er
 func TestCLIClientReturnsDecodeErrors(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stdout: []byte("not json")}}
 	_, err := c.WorkspaceList(context.Background())
-	if err == nil {
-		t.Fatal("expected decode error")
-	}
-	if !strings.Contains(err.Error(), "decode herdr workspace list JSON") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err)
+	require.ErrorContains(t, err, "decode herdr workspace list JSON")
 }
 
 func TestCLIClientIncludesStderrOnCommandFailure(t *testing.T) {
 	c := &CLIClient{Bin: "/bin/herdr", Runner: fixedRunner{stderr: []byte("boom\n"), err: errors.New("exit status 1")}}
 	_, err := c.WorkspaceList(context.Background())
-	if err == nil {
-		t.Fatal("expected command error")
-	}
-	if !strings.Contains(err.Error(), "boom") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
 }

--- a/internal/herdr/events_test.go
+++ b/internal/herdr/events_test.go
@@ -8,10 +8,11 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWatchWorkspaceEventsReconcilesDelayedProtocol20Replay(t *testing.T) {
@@ -84,16 +85,11 @@ func TestWatchWorkspaceEventsReconcilesDelayedProtocol20Replay(t *testing.T) {
 		},
 	)
 	_ = listener.Close()
-	if !reconnect || err == nil {
-		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
+	require.True(t, reconnect)
+	require.Error(t, err)
+	require.NoError(t, <-serverDone)
 	want := []string{"current", "previous", "older"}
-	if !reflect.DeepEqual(history, want) {
-		t.Fatalf("history=%#v want %#v", history, want)
-	}
+	assert.Equal(t, want, history)
 }
 
 func TestWatchWorkspaceEventsPreservesInterruptedProtocol20Replay(t *testing.T) {
@@ -145,16 +141,11 @@ func TestWatchWorkspaceEventsPreservesInterruptedProtocol20Replay(t *testing.T) 
 		},
 	)
 	_ = listener.Close()
-	if !reconnect || err == nil {
-		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
+	require.True(t, reconnect)
+	require.Error(t, err)
+	require.NoError(t, <-serverDone)
 	want := []string{"current", "previous", "older"}
-	if !reflect.DeepEqual(history, want) {
-		t.Fatalf("history=%#v want %#v", history, want)
-	}
+	assert.Equal(t, want, history)
 }
 
 func TestWatchWorkspaceEventsRejectsPreSubscriptionProtocol(t *testing.T) {
@@ -190,12 +181,8 @@ func TestWatchWorkspaceEventsRejectsPreSubscriptionProtocol(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	err := WatchWorkspaceEvents(ctx, socketPath, func(string) error { return nil }, func(string) error { return nil })
-	if err == nil || !strings.Contains(err.Error(), "requires Herdr protocol 20") {
-		t.Fatalf("watch error=%v, want protocol 20 requirement", err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
+	require.ErrorContains(t, err, "requires Herdr protocol 20")
+	require.NoError(t, <-serverDone)
 }
 
 func TestWatchWorkspaceEventsBuffersProtocol21EventsDuringProtocolProbe(t *testing.T) {
@@ -282,15 +269,10 @@ func TestWatchWorkspaceEventsBuffersProtocol21EventsDuringProtocolProbe(t *testi
 			return nil
 		},
 	)
-	if !reconnect || err == nil {
-		t.Fatalf("watch result=(%v, %v), want reconnect after closed stream", reconnect, err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	if want := []string{"C", "B", "A"}; !reflect.DeepEqual(history, want) {
-		t.Fatalf("history=%#v want %#v", history, want)
-	}
+	require.True(t, reconnect)
+	require.Error(t, err)
+	require.NoError(t, <-serverDone)
+	assert.Equal(t, []string{"C", "B", "A"}, history)
 }
 
 func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
@@ -338,15 +320,9 @@ func TestWatchWorkspaceEventsNoHistoryKeepsSnapshotWindowEvent(t *testing.T) {
 		},
 		func(string) error { return nil },
 	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
-	if want := []string{"snapshot", "during-snapshot"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("focuses=%#v want %#v", got, want)
-	}
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, <-serverDone)
+	assert.Equal(t, []string{"snapshot", "during-snapshot"}, got)
 }
 
 func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
@@ -414,30 +390,20 @@ func TestWatchWorkspaceEventsReconnectsAfterUnexpectedEOF(t *testing.T) {
 			return nil
 		},
 	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("watch error=%v, want context cancellation", err)
-	}
-	if err := <-serverDone; err != nil {
-		t.Fatal(err)
-	}
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, <-serverDone)
 	want := []string{"focus:after-reconnect", "close:after-reconnect"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("mutations=%#v want %#v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func listenTestSocket(t *testing.T) (net.Listener, string) {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "herdr-sesh-events-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	socketPath := filepath.Join(dir, "herdr.sock")
 	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 	return listener, socketPath
 }

--- a/internal/herdr/pane_preview_test.go
+++ b/internal/herdr/pane_preview_test.go
@@ -3,8 +3,10 @@ package herdr
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type panePreviewRunner struct {
@@ -32,13 +34,10 @@ func TestWorkspacePaneReadTargetsBackgroundWorkspaceActiveTab(t *testing.T) {
 	}}}`}
 	c := &CLIClient{Bin: "herdr", Runner: r}
 	text, err := c.WorkspacePaneRead(context.Background(), "w2")
-	if err != nil || text != "\x1b[32mactive pane\x1b[0m\n" {
-		t.Fatalf("text=%q err=%v", text, err)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "\x1b[32mactive pane\x1b[0m\n", text)
 	want := [][]string{{"api", "snapshot"}, {"pane", "read", "w2:p3", "--source", "visible", "--format", "ansi"}}
-	if !reflect.DeepEqual(r.calls, want) {
-		t.Fatalf("calls=%v want=%v", r.calls, want)
-	}
+	assert.Equal(t, want, r.calls)
 }
 
 func TestWorkspacePaneReadRejectsMissingTargetsAndErrors(t *testing.T) {
@@ -55,16 +54,13 @@ func TestWorkspacePaneReadRejectsMissingTargetsAndErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &panePreviewRunner{snapshot: tc.snapshot, err: tc.err}
 			c := &CLIClient{Bin: "herdr", Runner: r}
-			if _, err := c.WorkspacePaneRead(context.Background(), tc.id); err == nil {
-				t.Fatal("expected error")
-			}
+			_, err := c.WorkspacePaneRead(context.Background(), tc.id)
+			require.Error(t, err)
 			var wantCalls [][]string
 			if tc.id != "" {
 				wantCalls = [][]string{{"api", "snapshot"}}
 			}
-			if !reflect.DeepEqual(r.calls, wantCalls) {
-				t.Fatalf("calls=%v, want %v", r.calls, wantCalls)
-			}
+			assert.Equal(t, wantCalls, r.calls)
 		})
 	}
 }

--- a/internal/model/session_test.go
+++ b/internal/model/session_test.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSessionJSONOmitsInternalPickerFields(t *testing.T) {
@@ -18,23 +20,16 @@ func TestSessionJSONOmitsInternalPickerFields(t *testing.T) {
 		Worktree: WorktreeRelation{Linked: true, ParentWorkspaceID: "w-parent", ParentWorkspaceName: "parent"},
 	}
 	b, err := json.Marshal(s)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got := string(b)
-	if !strings.Contains(got, `"source":"config"`) || !strings.Contains(got, `"name":"api"`) {
-		t.Fatalf("json missing public fields: %s", got)
-	}
-	if strings.Contains(got, "WindowConfigs") || strings.Contains(got, "window_configs") {
-		t.Fatalf("json leaked internal window configs: %s", got)
-	}
-	if strings.Contains(got, "AgentStatus") || strings.Contains(got, "agent_status") {
-		t.Fatalf("json leaked internal agent status: %s", got)
-	}
+	require.Contains(t, got, `"source":"config"`)
+	require.Contains(t, got, `"name":"api"`)
+	require.NotContains(t, got, "WindowConfigs")
+	require.NotContains(t, got, "window_configs")
+	require.NotContains(t, got, "AgentStatus")
+	require.NotContains(t, got, "agent_status")
 	for _, internal := range []string{"Worktree", "worktree", "w-parent", "parent"} {
-		if strings.Contains(got, internal) {
-			t.Fatalf("json leaked internal worktree relation %q: %s", internal, got)
-		}
+		require.NotContains(t, got, internal)
 	}
 }
 
@@ -42,18 +37,10 @@ func TestKeyIsStableAndSourceScoped(t *testing.T) {
 	a := Session{Source: "config", Name: "api", Path: "/tmp/api"}
 	b := Session{Source: "config", Name: "api", Path: "/tmp/api"}
 	c := Session{Source: "zoxide", Name: "api", Path: "/tmp/api"}
-	if Key(a) != Key(b) {
-		t.Fatalf("expected stable key, got %q and %q", Key(a), Key(b))
-	}
-	if Key(a) == Key(c) {
-		t.Fatalf("expected source-scoped key, got %q", Key(a))
-	}
+	require.Equal(t, Key(b), Key(a))
+	require.NotEqual(t, Key(c), Key(a))
 	b.AgentStatus = "working"
-	if Key(a) != Key(b) {
-		t.Fatalf("expected status-independent key, got %q and %q", Key(a), Key(b))
-	}
+	require.Equal(t, Key(b), Key(a))
 	b.Worktree = WorktreeRelation{Linked: true, ParentWorkspaceID: "w-parent", ParentWorkspaceName: "parent"}
-	if Key(a) != Key(b) {
-		t.Fatalf("expected worktree-independent key, got %q and %q", Key(a), Key(b))
-	}
+	assert.Equal(t, Key(b), Key(a))
 }

--- a/internal/namer/namer_test.go
+++ b/internal/namer/namer_test.go
@@ -6,6 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNameFromGitRemote(t *testing.T) {
@@ -13,33 +16,24 @@ func TestNameFromGitRemote(t *testing.T) {
 	run(t, d, "git", "init")
 	run(t, d, "git", "remote", "add", "origin", "git@github.com:fullerzz/herdr-plugin-sesh.git")
 	got := Namer{}.Name(context.Background(), d, 1)
-	if got != "herdr-plugin-sesh" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "herdr-plugin-sesh", got)
 }
 func TestNameFromDirectoryLength(t *testing.T) {
 	got := Namer{}.Name(context.Background(), "/tmp/parent/child", 2)
-	if got != "parent/child" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "parent/child", got)
 }
 func TestNameFromRepoWithoutRemote(t *testing.T) {
 	d := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(d, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(d, 0700))
 	run(t, d, "git", "init")
 	got := Namer{}.Name(context.Background(), d, 1)
-	if got != "repo" {
-		t.Fatalf("got %q", got)
-	}
+	assert.Equal(t, "repo", got)
 }
 func run(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	//nolint:gosec // tests execute fixed git commands.
 	c := exec.Command(args[0], args[1:]...)
 	c.Dir = dir
-	if out, err := c.CombinedOutput(); err != nil {
-		t.Fatalf("%v: %v %s", args, err, out)
-	}
+	out, err := c.CombinedOutput()
+	require.NoErrorf(t, err, "%v: %s", args, out)
 }

--- a/internal/picker/fzf_test.go
+++ b/internal/picker/fzf_test.go
@@ -9,49 +9,37 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunFZFSelectsSessionByHiddenIndex(t *testing.T) {
 	fzf := filepath.Join(t.TempDir(), "fzf")
-	if err := os.WriteFile(fzf, []byte("#!/bin/sh\ncat >/dev/null\nprintf '1\\tzoxide\\t"+zoxideSourceIcon+" zoxide\\tweb\\t/tmp/web\\tweb\\n'\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(fzf, []byte("#!/bin/sh\ncat >/dev/null\nprintf '1\\tzoxide\\t"+zoxideSourceIcon+" zoxide\\tweb\\t/tmp/web\\tweb\\n'\n"), 0600))
 	//nolint:gosec // the fake fzf binary must be executable for this test.
-	if err := os.Chmod(fzf, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Chmod(fzf, 0700))
 	selected, ok, err := RunFZF(context.Background(), []model.Session{
 		{Source: "config", Name: "api", Path: "/tmp/api"},
 		{Source: "zoxide", Name: "web", Path: "/tmp/web"},
 	}, Options{FZFCommand: fzf})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || selected.Name != "web" {
-		t.Fatalf("selected=%#v ok=%v", selected, ok)
-	}
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "web", selected.Name)
 }
 
 func TestFZFInputKeepsIndexHiddenAndAddsSeparatorAwareSearch(t *testing.T) {
 	got := fzfInput([]model.Session{{Source: "config", Name: "api-service", Path: "/tmp/api.service"}}, true)
-	if !strings.HasPrefix(got, "0\tconfig\t\x1b[1;38;5;214m"+configSourceIcon+" config\x1b[0m\tapi-service\t/tmp/api.service\t") {
-		t.Fatalf("input = %q", got)
-	}
-	if !strings.Contains(got, "api service") || !strings.Contains(got, "tmp api service") {
-		t.Fatalf("missing normalized search field: %q", got)
-	}
+	require.True(t, strings.HasPrefix(got, "0\tconfig\t\x1b[1;38;5;214m"+configSourceIcon+" config\x1b[0m\tapi-service\t/tmp/api.service\t"))
+	require.Contains(t, got, "api service")
+	assert.Contains(t, got, "tmp api service")
 }
 
 func TestFZFInputAddsHomeAliasSearchToken(t *testing.T) {
 	t.Setenv("HOME", "/Users/zach")
 	got := fzfInput([]model.Session{{Source: "herdr", Name: "zach", Path: "/Users/zach"}}, false)
-	if !strings.HasSuffix(got, "\thome\n") {
-		t.Fatalf("missing home alias search token: %q", got)
-	}
+	require.True(t, strings.HasSuffix(got, "\thome\n"))
 	args := strings.Join(fzfArgs(Options{}), "\n")
-	if !strings.Contains(args, "--nth=3..6") {
-		t.Fatalf("home alias search field is not searchable:\n%s", args)
-	}
+	assert.Contains(t, args, "--nth=3..6")
 }
 
 func TestFZFInputUsesSourceCategoryColors(t *testing.T) {
@@ -67,42 +55,28 @@ func TestFZFInputUsesSourceCategoryColors(t *testing.T) {
 		"\x1b[1;38;5;114m" + zoxideSourceIcon + " zoxide\x1b[0m",
 		"\x1b[1;38;5;176m[dir]\x1b[0m",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("input missing %q:\n%q", want, got)
-		}
+		require.Contains(t, got, want)
 	}
 }
 
 func TestFZFArgsPreviewAllItemsWithBat(t *testing.T) {
 	args := strings.Join(fzfArgs(Options{}), "\n")
 	for _, want := range []string{"--ansi", "--with-nth=3,4,5", "--preview=", "export PATH", "source={2}", "label={4}", "item_path={5}", "command -v bat", "/opt/homebrew/bin/bat", "--file-name \"$item_path\""} {
-		if !strings.Contains(args, want) {
-			t.Fatalf("args missing %q:\n%s", want, args)
-		}
+		require.Contains(t, args, want)
 	}
-	if strings.Contains(args, "\npath=") {
-		t.Fatalf("preview should not assign zsh's special path variable:\n%s", args)
-	}
-	if strings.Contains(args, "{2} != herdr") {
-		t.Fatalf("preview should not be limited to herdr rows:\n%s", args)
-	}
+	require.NotContains(t, args, "\npath=")
+	assert.NotContains(t, args, "{2} != herdr")
 }
 
 func TestFZFPreviewCommandFindsSystemToolsWithMinimalPath(t *testing.T) {
 	fakeBin := t.TempDir()
 	bat := filepath.Join(fakeBin, "bat")
-	if err := os.WriteFile(bat, []byte("#!/bin/sh\ncat\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bat, []byte("#!/bin/sh\ncat\n"), 0600))
 	//nolint:gosec // the fake bat binary must be executable for this test.
-	if err := os.Chmod(bat, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Chmod(bat, 0700))
 
 	project := t.TempDir()
-	if err := os.WriteFile(filepath.Join(project, "note.txt"), []byte("preview\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(project, "note.txt"), []byte("preview\n"), 0600))
 	script := strings.NewReplacer(
 		"{2}", "zoxide",
 		"{4}", "project",
@@ -112,16 +86,11 @@ func TestFZFPreviewCommandFindsSystemToolsWithMinimalPath(t *testing.T) {
 		t.Helper()
 		cmd.Env = []string{"PATH=" + fakeBin, "HOME=" + t.TempDir()}
 		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("preview command failed: %v\n%s", err, out)
-		}
+		require.NoError(t, err)
 		got := string(out)
-		if strings.Contains(got, "not found") {
-			t.Fatalf("preview command could not find system tools:\n%s", got)
-		}
-		if !strings.Contains(got, "session: project") || !strings.Contains(got, "note.txt") {
-			t.Fatalf("preview output missing expected content:\n%s", got)
-		}
+		require.NotContains(t, got, "not found")
+		require.Contains(t, got, "session: project")
+		require.Contains(t, got, "note.txt")
 	}
 	previewShellCommand := func(shell string) *exec.Cmd {
 		//nolint:gosec // The shell and script are fixed by this regression test.
@@ -144,8 +113,7 @@ func TestFZFPreviewCommandFindsSystemToolsWithMinimalPath(t *testing.T) {
 
 func TestFZFSelectionIndexRejectsInvalidOutput(t *testing.T) {
 	for _, out := range []string{"", "abc\tconfig\tapi", "5\tconfig\tapi"} {
-		if idx, ok := fzfSelectionIndex(out, 2); ok {
-			t.Fatalf("idx=%d ok=true for %q", idx, out)
-		}
+		idx, ok := fzfSelectionIndex(out, 2)
+		require.Falsef(t, ok, "idx=%d for %q", idx, out)
 	}
 }

--- a/internal/picker/fzf_test.go
+++ b/internal/picker/fzf_test.go
@@ -55,14 +55,14 @@ func TestFZFInputUsesSourceCategoryColors(t *testing.T) {
 		"\x1b[1;38;5;114m" + zoxideSourceIcon + " zoxide\x1b[0m",
 		"\x1b[1;38;5;176m[dir]\x1b[0m",
 	} {
-		require.Contains(t, got, want)
+		assert.Contains(t, got, want)
 	}
 }
 
 func TestFZFArgsPreviewAllItemsWithBat(t *testing.T) {
 	args := strings.Join(fzfArgs(Options{}), "\n")
 	for _, want := range []string{"--ansi", "--with-nth=3,4,5", "--preview=", "export PATH", "source={2}", "label={4}", "item_path={5}", "command -v bat", "/opt/homebrew/bin/bat", "--file-name \"$item_path\""} {
-		require.Contains(t, args, want)
+		assert.Contains(t, args, want)
 	}
 	require.NotContains(t, args, "\npath=")
 	assert.NotContains(t, args, "{2} != herdr")
@@ -114,6 +114,6 @@ func TestFZFPreviewCommandFindsSystemToolsWithMinimalPath(t *testing.T) {
 func TestFZFSelectionIndexRejectsInvalidOutput(t *testing.T) {
 	for _, out := range []string{"", "abc\tconfig\tapi", "5\tconfig\tapi"} {
 		idx, ok := fzfSelectionIndex(out, 2)
-		require.Falsef(t, ok, "idx=%d for %q", idx, out)
+		assert.Falsef(t, ok, "idx=%d for %q", idx, out)
 	}
 }

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -4,32 +4,32 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterAndCurrent(t *testing.T) {
 	m := New([]model.Session{{Name: "api"}, {Name: "web"}})
 	m.Filter("api")
 	cur, ok := m.Current()
-	if !ok || cur.Name != "api" {
-		t.Fatalf("cur=%#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "api", cur.Name)
 }
 func TestFilterDoesNotMutateSourceItems(t *testing.T) {
 	m := New([]model.Session{{Name: "api"}, {Name: "web"}})
 	m.Filter("web")
 	m.Filter("")
-	if len(m.Filtered) != 2 || m.Filtered[0].Name != "api" || m.Filtered[1].Name != "web" {
-		t.Fatalf("filtered=%#v all=%#v", m.Filtered, m.All)
-	}
+	require.Len(t, m.Filtered, 2)
+	require.Equal(t, "api", m.Filtered[0].Name)
+	assert.Equal(t, "web", m.Filtered[1].Name)
 }
 func TestFilterResetsSelectionWhenQueryChanges(t *testing.T) {
 	m := New([]model.Session{{Name: "api"}, {Name: "api-worker"}, {Name: "web"}})
 	m.Move(1)
 	m.Filter("api")
 	cur, ok := m.Current()
-	if !ok || cur.Name != "api" {
-		t.Fatalf("cur=%#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "api", cur.Name)
 }
 func TestFilterRanksNameMatchesBeforePathMatches(t *testing.T) {
 	m := New([]model.Session{
@@ -43,13 +43,9 @@ func TestFilterRanksNameMatchesBeforePathMatches(t *testing.T) {
 	m.Filter("api")
 
 	want := []string{"api-service", "api-both", "api-web", "", "worker"}
-	if len(m.Filtered) != len(want) {
-		t.Fatalf("filtered=%#v", m.Filtered)
-	}
+	require.Len(t, m.Filtered, len(want))
 	for i, name := range want {
-		if m.Filtered[i].Name != name {
-			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
-		}
+		require.Equal(t, name, m.Filtered[i].Name)
 	}
 }
 func TestFilterKeepsNameMatchAheadOfPathOnlyWorktreeParent(t *testing.T) {
@@ -61,13 +57,9 @@ func TestFilterKeepsNameMatchAheadOfPathOnlyWorktreeParent(t *testing.T) {
 	m.Filter("api")
 
 	want := []string{"api-fix", "backend"}
-	if len(m.Filtered) != len(want) {
-		t.Fatalf("filtered=%#v", m.Filtered)
-	}
+	require.Len(t, m.Filtered, len(want))
 	for i, name := range want {
-		if m.Filtered[i].Name != name {
-			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
-		}
+		require.Equal(t, name, m.Filtered[i].Name)
 	}
 }
 func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
@@ -78,9 +70,8 @@ func TestFilterSelectsHomeDirectoryWhenQueryIsHome(t *testing.T) {
 	})
 	m.Filter("home")
 	cur, ok := m.Current()
-	if !ok || cur.Name != "~" {
-		t.Fatalf("cur=%#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "~", cur.Name)
 }
 
 func TestZeroValueModelPrioritizesHome(t *testing.T) {
@@ -93,9 +84,8 @@ func TestZeroValueModelPrioritizesHome(t *testing.T) {
 	m.Filter("home")
 
 	cur, ok := m.Current()
-	if !ok || cur.Name != "~" {
-		t.Fatalf("cur=%#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "~", cur.Name)
 }
 
 func TestFilterRanksActualHomePathBeforeMisleadingHomeName(t *testing.T) {
@@ -109,13 +99,9 @@ func TestFilterRanksActualHomePathBeforeMisleadingHomeName(t *testing.T) {
 	m.Filter("home")
 
 	want := []string{"/Users/zachfuller", "/tmp/manager", "/tmp/home-archive"}
-	if len(m.Filtered) != len(want) {
-		t.Fatalf("filtered=%#v", m.Filtered)
-	}
+	require.Len(t, m.Filtered, len(want))
 	for i, path := range want {
-		if m.Filtered[i].Path != path {
-			t.Fatalf("filtered[%d].Path=%q, want %q", i, m.Filtered[i].Path, path)
-		}
+		require.Equal(t, path, m.Filtered[i].Path)
 	}
 }
 
@@ -133,19 +119,13 @@ func TestFilterCanDisableHomePrioritization(t *testing.T) {
 	m.Filter("HOME")
 
 	want := []string{"home-tools", "home-manager", "path-before", "home-root", "path-after"}
-	if len(m.Filtered) != len(want) {
-		t.Fatalf("filtered=%#v", m.Filtered)
-	}
+	require.Len(t, m.Filtered, len(want))
 	for i, name := range want {
-		if m.Filtered[i].Name != name {
-			t.Fatalf("filtered[%d].Name=%q, want %q", i, m.Filtered[i].Name, name)
-		}
+		require.Equal(t, name, m.Filtered[i].Name)
 	}
 }
 func TestSeparatorAwareMatch(t *testing.T) {
-	if !Match("my-api.service", "api service", true) {
-		t.Fatal("expected separator aware match")
-	}
+	assert.True(t, Match("my-api.service", "api service", true), "expected separator aware match")
 }
 
 func TestSeparatorAwareMatchNormalizesQuerySeparators(t *testing.T) {
@@ -160,9 +140,7 @@ func TestSeparatorAwareMatchNormalizesQuerySeparators(t *testing.T) {
 		{"underscore query against a dashed candidate", "my-api-service", "api_service"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if !Match(tc.hay, tc.query, true) {
-				t.Fatalf("Match(%q, %q, true) = false, want true", tc.hay, tc.query)
-			}
+			assert.True(t, Match(tc.hay, tc.query, true))
 		})
 	}
 }
@@ -181,17 +159,11 @@ func TestSeparatorAwareMatchIsAdditive(t *testing.T) {
 		{"my-api.service", "service api", false},
 		{"my-api.service", "", true},
 	} {
-		if got := Match(tc.hay, tc.query, true); got != tc.want {
-			t.Fatalf("Match(%q, %q, true) = %v, want %v", tc.hay, tc.query, got, tc.want)
-		}
+		require.Equal(t, tc.want, Match(tc.hay, tc.query, true))
 	}
 }
 
 func TestSeparatorUnawareMatchLeavesQueryLiteral(t *testing.T) {
-	if !Match("my-api.service", "api.service", false) {
-		t.Fatal("expected literal match when separator awareness is off")
-	}
-	if Match("my-api.service", "api service", false) {
-		t.Fatal("did not expect separator normalization when it is off")
-	}
+	require.True(t, Match("my-api.service", "api.service", false), "expected literal match when separator awareness is off")
+	assert.False(t, Match("my-api.service", "api service", false), "did not expect separator normalization when it is off")
 }

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -159,7 +159,7 @@ func TestSeparatorAwareMatchIsAdditive(t *testing.T) {
 		{"my-api.service", "service api", false},
 		{"my-api.service", "", true},
 	} {
-		require.Equal(t, tc.want, Match(tc.hay, tc.query, true))
+		assert.Equalf(t, tc.want, Match(tc.hay, tc.query, true), "Match(%q, %q, true)", tc.hay, tc.query)
 	}
 }
 

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -2,8 +2,10 @@ package picker
 
 import (
 	"context"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -22,57 +24,46 @@ func TestPanePreviewToggleRefreshAndSelection(t *testing.T) {
 	initialContext, initialID, initialKey := m.previewContext, m.previewRequestID, m.previewKey
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if !m.panePreview || initialContext.Err() == nil || cmd == nil {
-		t.Fatal("toggle must cancel the old preview and start pane mode")
-	}
+	require.True(t, m.panePreview)
+	require.Error(t, initialContext.Err())
+	require.NotNil(t, cmd)
 	updated, tick := m.Update(cmd())
 	m = updated.(teaModel)
-	if m.preview != "pane w1" || tick == nil || !strings.Contains(ansi.Strip(m.previewTitle()), "PANE [ctrl+o]") {
-		t.Fatalf("preview=%q tick=%v title=%q", m.preview, tick, m.previewTitle())
-	}
+	require.Equal(t, "pane w1", m.preview)
+	require.NotNil(t, tick)
+	require.Contains(t, ansi.Strip(m.previewTitle()), "PANE [ctrl+o]")
 	// A completed read schedules one refresh; refreshing preserves the visible text.
 	refreshID := m.previewRequestID
 	refreshTick := tick().(panePreviewTickMsg)
-	if refreshTick.requestID != refreshID {
-		t.Fatal("refresh tick did not retain the completed request ID")
-	}
+	require.Equal(t, refreshID, refreshTick.requestID)
 	updated, cmd = m.Update(refreshTick)
 	m = updated.(teaModel)
-	if cmd == nil || m.preview != "pane w1" {
-		t.Fatal("refresh should retain pane contents")
-	}
+	require.NotNil(t, cmd)
+	require.Equal(t, "pane w1", m.preview)
 	staleResult := cmd()
 	refreshContext := m.previewContext
 	m.list.Move(1)
 	m, cmd = m.refreshPreview()
-	if refreshContext.Err() == nil {
-		t.Fatal("selection change must cancel refresh")
-	}
-	if m.preview != "Loading preview..." {
-		t.Fatal("selection change must replace the previous pane snapshot with a loading message")
-	}
+	require.Error(t, refreshContext.Err())
+	require.Equal(t, "Loading preview...", m.preview)
 	updated, _ = m.Update(cmd())
 	m = updated.(teaModel)
 	for _, stale := range []tea.Msg{staleResult, previewMsg{key: initialKey, requestID: initialID, text: "stale command"}, panePreviewTickMsg{requestID: refreshID}} {
 		updated, cmd = m.Update(stale)
 		m = updated.(teaModel)
-		if m.preview != "pane w2" || cmd != nil {
-			t.Fatal("stale preview changed selection or scheduled work")
-		}
+		require.Equal(t, "pane w2", m.preview)
+		require.Nil(t, cmd)
 	}
 	paneID := m.previewRequestID
 	updated, cmd = m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	updated, _ = m.Update(cmd())
 	m = updated.(teaModel)
-	if m.panePreview || m.preview != "configured preview" {
-		t.Fatalf("toggle back: %q", m.preview)
-	}
+	require.False(t, m.panePreview)
+	require.Equal(t, "configured preview", m.preview)
 	updated, cmd = m.Update(panePreviewTickMsg{requestID: paneID})
 	m = updated.(teaModel)
-	if cmd != nil {
-		t.Fatal("pane timer survived mode switch")
-	}
+	require.Nil(t, cmd)
 	m = m.cancelActivePreview()
 }
 
@@ -81,8 +72,9 @@ func TestPanePreviewHiddenAndEmptyPicker(t *testing.T) {
 		m := newTeaModel(nil, opts)
 		updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 		m = updated.(teaModel)
-		if cmd != nil || opts.HidePreview && m.panePreview {
-			t.Fatal("unexpected pane preview work")
+		require.Nil(t, cmd)
+		if opts.HidePreview {
+			assert.False(t, m.panePreview)
 		}
 	}
 }
@@ -101,9 +93,8 @@ func TestCtrlVPastesWithoutChangingPreviewMode(t *testing.T) {
 			m.panePreview = tc.pane
 			updated, cmd := m.Update(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
 			m = updated.(teaModel)
-			if cmd == nil || m.panePreview != tc.pane {
-				t.Fatal("Ctrl+V must request clipboard paste without changing the preview")
-			}
+			require.NotNil(t, cmd)
+			require.Equal(t, tc.pane, m.panePreview)
 			m = m.cancelActivePreview()
 		})
 	}
@@ -133,17 +124,14 @@ func TestInitialPreviewMode(t *testing.T) {
 			}
 			m := newTeaModel([]model.Session{{Source: "herdr", WorkspaceID: "w1"}}, Options{PreviewMode: tc.mode, HidePreview: tc.hidden})
 			executeTeaCommand(m.Init())
-			if rendered != tc.want {
-				t.Fatalf("initial renderer = %q, want %q", rendered, tc.want)
-			}
+			require.Equal(t, tc.want, rendered)
 			if !tc.hidden {
 				rendered = ""
 				updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 				m = updated.(teaModel)
 				executeTeaCommand(cmd)
-				if rendered == "" || rendered == tc.want {
-					t.Fatalf("Ctrl+O did not change renderer: %q", rendered)
-				}
+				require.NotEmpty(t, rendered)
+				require.NotEqual(t, tc.want, rendered)
 			}
 			_ = m.cancelActivePreview()
 		})

--- a/internal/picker/tea_benchmark_test.go
+++ b/internal/picker/tea_benchmark_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
 
@@ -30,16 +31,12 @@ func BenchmarkFilterSessions(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			picker := New(benchmarkSessions(tt.count))
 			picker.Filter(tt.query)
-			if got := len(picker.Filtered); got != tt.want {
-				b.Fatalf("filtered=%d, want %d", got, tt.want)
-			}
+			require.Len(b, picker.Filtered, tt.want)
 			b.ReportAllocs()
 			for b.Loop() {
 				picker.Filter(tt.query)
 			}
-			if got := len(picker.Filtered); got != tt.want {
-				b.Fatalf("filtered=%d, want %d", got, tt.want)
-			}
+			require.Len(b, picker.Filtered, tt.want)
 		})
 	}
 }
@@ -90,8 +87,9 @@ func BenchmarkPreviewNavigationBurst(b *testing.B) {
 			picker.list.Selected = i
 			next, command := picker.refreshPreview()
 			picker = next
+			// Keep assertion overhead off the measured success path.
 			if command == nil {
-				b.Fatalf("preview command %d is nil", i)
+				require.NotNil(b, command, "preview command %d", i)
 			}
 			go func(command tea.Cmd) {
 				_ = command()

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -14,10 +14,12 @@ import (
 
 	"charm.land/bubbles/v2/cursor"
 	"charm.land/bubbles/v2/spinner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
-
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 )
 
@@ -39,9 +41,7 @@ func TestTeaModelHomePrioritizationOption(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTeaModel(nil, tc.opts)
-			if m.list.DisableHomePrioritization != tc.wantDisabled {
-				t.Fatalf("DisableHomePrioritization=%t, want %t", m.list.DisableHomePrioritization, tc.wantDisabled)
-			}
+			assert.Equal(t, tc.wantDisabled, m.list.DisableHomePrioritization)
 		})
 	}
 }
@@ -53,9 +53,7 @@ func TestTeaModelDragsPreviewDivider(t *testing.T) {
 	m.list.Selected = 1
 	m.preview = strings.Repeat("preview ", 30)
 	previewID := m.previewRequestID
-	if m.View().MouseMode != tea.MouseModeCellMotion {
-		t.Fatal("picker must request mouse drag events")
-	}
+	require.Equal(t, tea.MouseModeCellMotion, m.View().MouseMode)
 	for _, step := range []struct {
 		name string
 		msg  tea.Msg
@@ -74,17 +72,15 @@ func TestTeaModelDragsPreviewDivider(t *testing.T) {
 		t.Run(step.name, func(t *testing.T) {
 			updated, cmd := m.Update(step.msg)
 			m = updated.(teaModel)
-			if cmd != nil || m.previewRequestID != previewID || m.list.Selected != 1 || m.input.Value() != "" {
-				t.Fatal("resizing changed picker selection/input or requested a new preview")
-			}
+			require.Nil(t, cmd)
+			require.Equal(t, previewID, m.previewRequestID)
+			require.Equal(t, 1, m.list.Selected)
+			require.Empty(t, m.input.Value())
 			lines := strings.Split(ansi.Strip(m.View().Content), "\n")
 			for y := 5; y < 5+previewTitleRows+m.previewBodyLines(); y++ {
-				if cell := ansi.Cut(lines[y], step.x, step.x+1); cell != "│" {
-					t.Fatalf("divider at (%d,%d) = %q", step.x, y, cell)
-				}
-				if width := lipgloss.Width(lines[y]); width != m.width {
-					t.Fatalf("rendered width = %d, want %d", width, m.width)
-				}
+				require.Equal(t, "│", ansi.Cut(lines[y], step.x, step.x+1))
+				width := lipgloss.Width(lines[y])
+				require.Equal(t, m.width, width)
 			}
 		})
 	}
@@ -112,8 +108,8 @@ func TestTeaModelIgnoresMouseOutsidePreviewDivider(t *testing.T) {
 			m := newTeaModel(nil, Options{HidePreview: tc.hidden})
 			m.width, m.height = tc.width, 28
 			before := m.View()
-			if (tc.hidden || tc.width < previewSplitWidth) && before.MouseMode != tea.MouseModeNone {
-				t.Fatal("mouse reporting enabled without a divider")
+			if tc.hidden || tc.width < previewSplitWidth {
+				assert.Equal(t, tea.MouseModeNone, before.MouseMode, "mouse reporting enabled without a divider")
 			}
 			updated, _ := m.Update(tc.click)
 			m = updated.(teaModel)
@@ -123,9 +119,7 @@ func TestTeaModelIgnoresMouseOutsidePreviewDivider(t *testing.T) {
 			}
 			updated, _ = m.Update(tea.MouseMotionMsg{X: 54, Y: 6, Button: tea.MouseLeft})
 			m = updated.(teaModel)
-			if got := m.View().Content; got != before.Content {
-				t.Fatal("mouse events outside an active divider drag changed the view")
-			}
+			assert.Equal(t, before.Content, m.View().Content)
 		})
 	}
 }
@@ -138,14 +132,13 @@ func TestTeaModelFiltersMovesAndChooses(t *testing.T) {
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'a', Text: "api service"})
 	m = updated.(teaModel)
 	cur, ok := m.list.Current()
-	if !ok || cur.Name != "api-service" {
-		t.Fatalf("current = %#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	require.Equal(t, "api-service", cur.Name)
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(teaModel)
-	if cmd == nil || !m.chosen || m.choice.Name != "api-service" {
-		t.Fatalf("chosen=%v choice=%#v cmd=%v", m.chosen, m.choice, cmd)
-	}
+	require.NotNil(t, cmd)
+	require.True(t, m.chosen)
+	assert.Equal(t, "api-service", m.choice.Name)
 }
 
 func TestTeaModelMovesSelection(t *testing.T) {
@@ -155,9 +148,8 @@ func TestTeaModelMovesSelection(t *testing.T) {
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 	cur, ok := m.list.Current()
-	if !ok || cur.Name != "web" {
-		t.Fatalf("current = %#v ok=%v", cur, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "web", cur.Name)
 }
 
 func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
@@ -167,21 +159,20 @@ func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
 	m = updated.(teaModel)
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if current, ok := m.list.Current(); !ok || current.Name != "web" {
-		t.Fatalf("current = %#v ok=%v, want web", current, ok)
-	}
+	current, ok := m.list.Current()
+	require.True(t, ok)
+	assert.Equal(t, "web", current.Name)
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if current, ok := m.list.Current(); !ok || current.Name != "api" {
-		t.Fatalf("current = %#v ok=%v, want api", current, ok)
-	}
+	current, ok = m.list.Current()
+	require.True(t, ok)
+	assert.Equal(t, "api", current.Name)
 	updated, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
-	if !strings.Contains(view, "enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit") || !strings.Contains(view, "LAST WORKSPACE · None recorded") {
-		t.Fatalf("view missing complete navigation help or last workspace:\n%s", view)
-	}
+	require.Contains(t, view, "enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit")
+	assert.Contains(t, view, "LAST WORKSPACE · None recorded")
 }
 
 func TestTeaModelCtrlKDeletesAfterFilterCursor(t *testing.T) {
@@ -192,9 +183,7 @@ func TestTeaModelCtrlKDeletesAfterFilterCursor(t *testing.T) {
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 
-	if got := m.input.Value(); got != "api" {
-		t.Fatalf("input=%q, want %q", got, "api")
-	}
+	assert.Equal(t, "api", m.input.Value())
 }
 
 func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
@@ -212,31 +201,22 @@ func TestTeaModelCtrlXClosesSelectedHerdrWorkspace(t *testing.T) {
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if cmd == nil {
-		t.Fatal("ctrl+x did not return a close command")
-	}
+	require.NotNil(t, cmd)
 	updated, enterCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(teaModel)
-	if enterCmd != nil || m.chosen {
-		t.Fatalf("closing workspace remained selectable: cmd=%v chosen=%v", enterCmd, m.chosen)
-	}
+	require.Nil(t, enterCmd)
+	require.False(t, m.chosen)
 	m.list.Move(1)
 	m, _ = m.refreshPreview()
 	updated, _ = m.Update(cmd())
 	m = updated.(teaModel)
 
-	if closed != "w1" {
-		t.Fatalf("closed workspace=%q, want w1", closed)
-	}
-	if got, want := sessionNames(m.list.All), []string{"api-selected", "api-other"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("remaining sessions=%v want %v", got, want)
-	}
-	if current, ok := m.list.Current(); !ok || current.Name != "api-selected" {
-		t.Fatalf("current=%#v ok=%v, want api-selected", current, ok)
-	}
-	if current, _ := m.list.Current(); m.previewKey != model.Key(current) {
-		t.Fatalf("preview key=%q, want selected session %q", m.previewKey, model.Key(current))
-	}
+	require.Equal(t, "w1", closed)
+	require.Equal(t, []string{"api-selected", "api-other"}, sessionNames(m.list.All))
+	current, ok := m.list.Current()
+	require.True(t, ok)
+	assert.Equal(t, "api-selected", current.Name)
+	assert.Equal(t, model.Key(current), m.previewKey)
 }
 
 func TestTeaModelCtrlXUpdatesLastWorkspace(t *testing.T) {
@@ -267,12 +247,8 @@ func TestTeaModelCtrlXUpdatesLastWorkspace(t *testing.T) {
 	updated, _ = m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if m.lastWorkspaceID != "w2" {
-		t.Fatalf("last workspace=%q, want w2", m.lastWorkspaceID)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · older") {
-		t.Fatalf("view missing updated last workspace:\n%s", view)
-	}
+	require.Equal(t, "w2", m.lastWorkspaceID)
+	assert.Contains(t, ansi.Strip(m.View().Content), "LAST WORKSPACE · older")
 }
 
 func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
@@ -300,9 +276,9 @@ func TestTeaModelDoesNotQuitWhileWorkspaceCloseIsPending(t *testing.T) {
 			updated, cmd := m.Update(tt.key)
 			m = updated.(teaModel)
 
-			if cmd != nil || m.chosen || m.closingWorkspaceID != "w1" {
-				t.Fatalf("pending close quit picker: cmd=%v chosen=%v closing=%q", cmd, m.chosen, m.closingWorkspaceID)
-			}
+			require.Nil(t, cmd)
+			require.False(t, m.chosen)
+			assert.Equal(t, "w1", m.closingWorkspaceID)
 		})
 	}
 }
@@ -337,13 +313,10 @@ func TestTeaModelCtrlCCancelsWorkspaceCloseAndQuitsAfterResult(t *testing.T) {
 
 			updated, quitCmd := m.Update(closeCmd())
 			_ = updated.(teaModel)
-			if quitCmd == nil {
-				t.Fatal("picker did not quit after cancelled close returned")
-			}
+			require.NotNil(t, quitCmd)
 			msg := quitCmd()
-			if _, ok := msg.(tea.QuitMsg); !ok {
-				t.Fatalf("command returned %T, want tea.QuitMsg", msg)
-			}
+			_, ok := msg.(tea.QuitMsg)
+			assert.True(t, ok)
 		})
 	}
 }
@@ -368,12 +341,10 @@ func TestTeaModelCtrlXRestoresDeduplicatedSessionAfterClose(t *testing.T) {
 	updated, _ = m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"api", "web"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("sessions=%v want %v", got, want)
-	}
-	if current, ok := m.list.Current(); !ok || current.Name != "web" {
-		t.Fatalf("current=%#v ok=%v, want web", current, ok)
-	}
+	require.Equal(t, []string{"api", "web"}, sessionNames(m.list.All))
+	current, ok := m.list.Current()
+	require.True(t, ok)
+	assert.Equal(t, "web", current.Name)
 }
 
 func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
@@ -394,17 +365,11 @@ func TestTeaModelCtrlXRetainsActiveWorkspacesWhenReloadFails(t *testing.T) {
 	updated, _ = m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"web"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("sessions=%v want %v", got, want)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "Workspace closed, but sessions could not be refreshed: workspace list failed") {
-		t.Fatalf("view missing reload failure:\n%s", view)
-	}
+	require.Equal(t, []string{"web"}, sessionNames(m.list.All))
+	require.Contains(t, ansi.Strip(m.View().Content), "Workspace closed, but sessions could not be refreshed: workspace list failed")
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
-		t.Fatalf("view did not refresh last workspace after reload failure:\n%s", view)
-	}
+	assert.Contains(t, ansi.Strip(m.View().Content), "LAST WORKSPACE · Unavailable")
 }
 
 func TestTeaModelCtrlXClearsClosedParentWhenReloadFails(t *testing.T) {
@@ -433,13 +398,14 @@ func TestTeaModelCtrlXClearsClosedParentWhenReloadFails(t *testing.T) {
 	m = updated.(teaModel)
 
 	child, ok := m.list.Current()
-	if !ok || !child.Worktree.Linked || child.Worktree.ParentWorkspaceID != "" || child.Worktree.ParentWorkspaceName != "" {
-		t.Fatalf("child=%#v ok=%v", child, ok)
-	}
+	require.True(t, ok)
+	require.True(t, child.Worktree.Linked)
+	require.Empty(t, child.Worktree.ParentWorkspaceID)
+	require.Empty(t, child.Worktree.ParentWorkspaceName)
 	rowText := ansi.Strip(row(child, false, 80, false, ""))
-	if !strings.Contains(rowText, "[↳ herdr]") || strings.Contains(rowText, "worktree of parent") || strings.Contains(rowText, "linked worktree") {
-		t.Fatalf("child row kept stale parent description or lost worktree badge: %q", rowText)
-	}
+	require.Contains(t, rowText, "[↳ herdr]")
+	require.NotContains(t, rowText, "worktree of parent")
+	assert.NotContains(t, rowText, "linked worktree")
 }
 
 func TestTeaModelCtrlXRefreshesHerdrMetadataWhenSessionReloadFails(t *testing.T) {
@@ -465,14 +431,10 @@ func TestTeaModelCtrlXRefreshesHerdrMetadataWhenSessionReloadFails(t *testing.T)
 	updated, _ = m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"old label"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("sessions=%v want retained rows %v", got, want)
-	}
+	require.Equal(t, []string{"old label"}, sessionNames(m.list.All))
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · new label") {
-		t.Fatalf("view kept stale Herdr metadata:\n%s", view)
-	}
+	assert.Contains(t, ansi.Strip(m.View().Content), "LAST WORKSPACE · new label")
 }
 
 func TestTeaModelCtrlXGroupsReloadedWorktreeFamily(t *testing.T) {
@@ -491,9 +453,7 @@ func TestTeaModelCtrlXGroupsReloadedWorktreeFamily(t *testing.T) {
 	updated, _ = m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"parent", "child"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("reloaded order=%v want %v", got, want)
-	}
+	assert.Equal(t, []string{"parent", "child"}, sessionNames(m.list.All))
 }
 
 func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
@@ -509,20 +469,14 @@ func TestTeaModelCtrlXKeepsWorkspaceWhenCloseFails(t *testing.T) {
 	m.list.Move(1)
 	m, _ = m.refreshPreview()
 	stalePreview := previewMsg{key: m.previewKey, text: "stale preview"}
-	updated, previewCmd := m.Update(cmd())
+	updated, _ = m.Update(cmd())
 	m = updated.(teaModel)
-	if m.preview == "Closing workspace..." {
-		t.Fatalf("failed close left stale preview: cmd=%v", previewCmd)
-	}
+	require.NotEqual(t, "Closing workspace...", m.preview)
 	updated, _ = m.Update(stalePreview)
 	m = updated.(teaModel)
 
-	if len(m.list.All) != 2 {
-		t.Fatalf("workspace removed after close failure: %#v", m.list.All)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "close failed") {
-		t.Fatalf("view missing close failure after selection and preview changed:\n%s", view)
-	}
+	require.Len(t, m.list.All, 2)
+	assert.Contains(t, ansi.Strip(m.View().Content), "close failed")
 }
 
 func TestTeaModelCtrlXRefreshesPreviewWhenCloseFails(t *testing.T) {
@@ -535,9 +489,8 @@ func TestTeaModelCtrlXRefreshesPreviewWhenCloseFails(t *testing.T) {
 	updated, previewCmd := m.Update(closeCmd())
 	m = updated.(teaModel)
 
-	if previewCmd == nil || m.preview == "Closing workspace..." {
-		t.Fatalf("failed close did not refresh preview: preview=%q cmd=%v", m.preview, previewCmd)
-	}
+	require.NotNil(t, previewCmd)
+	assert.NotEqual(t, "Closing workspace...", m.preview)
 }
 
 func TestTeaModelCtrlXIgnoresNonHerdrSession(t *testing.T) {
@@ -551,9 +504,8 @@ func TestTeaModelCtrlXIgnoresNonHerdrSession(t *testing.T) {
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
 	_ = updated.(teaModel)
-	if cmd != nil || called {
-		t.Fatalf("non-Herdr ctrl+x returned cmd=%v called=%v", cmd, called)
-	}
+	require.Nil(t, cmd)
+	assert.False(t, called)
 }
 
 func TestTeaModelDownTransfersCursorFromFilterToList(t *testing.T) {
@@ -561,41 +513,31 @@ func TestTeaModelDownTransfersCursorFromFilterToList(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "work"})
 	m = updated.(teaModel)
-	if view := ansi.Strip(m.listView(40, 2)); strings.Contains(view, "┃") {
-		t.Fatalf("list cursor visible while filter is focused:\n%s", view)
-	}
+	require.NotContains(t, ansi.Strip(m.listView(40, 2)), "┃")
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
-	if m.input.Focused() {
-		t.Fatal("filter remained focused after moving into the list")
-	}
-	if m.list.Selected != 0 {
-		t.Fatalf("selected row=%d, want first filtered row", m.list.Selected)
-	}
+	require.False(t, m.input.Focused(), "filter remained focused after moving into the list")
+	require.Equal(t, 0, m.list.Selected)
 	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
 	startColumn := visualColumn(lines[3], "┃")
 	wantStartColumn := horizontalPadding + lipgloss.Width(defaultPrompt+"work")
-	if startColumn != wantStartColumn {
-		t.Fatalf("transfer cursor column=%d, want typed-text endpoint %d:\n%s", startColumn, wantStartColumn, strings.Join(lines, "\n"))
-	}
+	require.Equal(t, wantStartColumn, startColumn)
 
 	updated, _ = m.Update(smearTickMsg{})
 	m = updated.(teaModel)
 	lines = strings.Split(ansi.Strip(m.View().Content), "\n")
 	nextColumn := visualColumn(lines[4], "┃")
-	if nextColumn < horizontalPadding || nextColumn >= startColumn {
-		t.Fatalf("transfer cursor did not move down-left: start=%d next=%d\n%s", startColumn, nextColumn, strings.Join(lines, "\n"))
-	}
+	require.GreaterOrEqual(t, nextColumn, horizontalPadding)
+	require.Less(t, nextColumn, startColumn)
 
 	for range 10 {
 		updated, _ = m.Update(smearTickMsg{})
 		m = updated.(teaModel)
 	}
 	view := ansi.Strip(m.View().Content)
-	if strings.Count(view, "┃") != 1 || !strings.Contains(ansi.Strip(m.listView(40, 2)), "┃") {
-		t.Fatalf("cursor did not settle as the single list rail:\n%s", view)
-	}
+	require.Equal(t, 1, strings.Count(view, "┃"))
+	assert.Contains(t, ansi.Strip(m.listView(40, 2)), "┃")
 }
 
 func TestTeaModelUpTransfersCursorFromListToFilter(t *testing.T) {
@@ -612,30 +554,23 @@ func TestTeaModelUpTransfersCursorFromListToFilter(t *testing.T) {
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	m = updated.(teaModel)
-	if m.input.Focused() {
-		t.Fatal("filter refocused before the reverse smear completed")
-	}
+	require.False(t, m.input.Focused(), "filter refocused before the reverse smear completed")
 	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
 	startColumn := visualColumn(lines[listFirstRowIndex], "┃")
-	if startColumn != horizontalPadding {
-		t.Fatalf("reverse cursor column=%d, want list rail %d:\n%s", startColumn, horizontalPadding, strings.Join(lines, "\n"))
-	}
+	require.Equal(t, horizontalPadding, startColumn)
 
 	updated, _ = m.Update(smearTickMsg{})
 	m = updated.(teaModel)
 	lines = strings.Split(ansi.Strip(m.View().Content), "\n")
 	nextColumn := visualColumn(lines[listFirstRowIndex-1], "┃")
-	if nextColumn <= startColumn {
-		t.Fatalf("reverse cursor did not move up-right: start=%d next=%d\n%s", startColumn, nextColumn, strings.Join(lines, "\n"))
-	}
+	require.Greater(t, nextColumn, startColumn)
 
 	for range 10 {
 		updated, _ = m.Update(smearTickMsg{})
 		m = updated.(teaModel)
 	}
-	if !m.input.Focused() || strings.Contains(ansi.Strip(m.listView(40, 2)), "┃") {
-		t.Fatalf("cursor did not settle in the filter:\n%s", ansi.Strip(m.View().Content))
-	}
+	require.True(t, m.input.Focused())
+	assert.NotContains(t, ansi.Strip(m.listView(40, 2)), "┃")
 }
 
 func TestTeaModelRightTransfersCursorFromListToFilter(t *testing.T) {
@@ -652,16 +587,14 @@ func TestTeaModelRightTransfersCursorFromListToFilter(t *testing.T) {
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	m = updated.(teaModel)
-	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
-		t.Fatalf("right arrow skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
-	}
+	require.False(t, m.input.Focused())
+	require.True(t, m.focusSmearActive)
+	require.Equal(t, -1, m.focusSmearDirection)
 
 	updated, _ = m.Update(smearTickMsg{})
 	m = updated.(teaModel)
 	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
-	if column := visualColumn(lines[listFirstRowIndex-1], "┃"); column <= horizontalPadding {
-		t.Fatalf("right-arrow cursor did not smear up-right: column=%d\n%s", column, strings.Join(lines, "\n"))
-	}
+	assert.Greater(t, visualColumn(lines[listFirstRowIndex-1], "┃"), horizontalPadding)
 }
 
 func TestTeaModelTypingTransfersCursorFromListToFilter(t *testing.T) {
@@ -673,19 +606,16 @@ func TestTeaModelTypingTransfersCursorFromListToFilter(t *testing.T) {
 
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "w"})
 	m = updated.(teaModel)
-	if m.input.Value() != "w" || m.list.Query != "w" {
-		t.Fatalf("typed key was not applied during transfer: input=%q query=%q", m.input.Value(), m.list.Query)
-	}
-	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
-		t.Fatalf("typing skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
-	}
+	require.Equal(t, "w", m.input.Value())
+	require.Equal(t, "w", m.list.Query)
+	require.False(t, m.input.Focused())
+	require.True(t, m.focusSmearActive)
+	require.Equal(t, -1, m.focusSmearDirection)
 
 	updated, _ = m.Update(smearTickMsg{})
 	m = updated.(teaModel)
 	lines := strings.Split(ansi.Strip(m.View().Content), "\n")
-	if column := visualColumn(lines[listFirstRowIndex], "┃"); column <= horizontalPadding {
-		t.Fatalf("typed cursor did not smear up-right: column=%d\n%s", column, strings.Join(lines, "\n"))
-	}
+	assert.Greater(t, visualColumn(lines[listFirstRowIndex], "┃"), horizontalPadding)
 }
 
 func TestTeaModelPasteTransfersCursorFromListToFilter(t *testing.T) {
@@ -696,12 +626,11 @@ func TestTeaModelPasteTransfersCursorFromListToFilter(t *testing.T) {
 
 	updated, _ := m.Update(tea.PasteMsg{Content: "workspace"})
 	m = updated.(teaModel)
-	if m.input.Value() != "workspace" || m.list.Query != "workspace" {
-		t.Fatalf("pasted text was not applied during transfer: input=%q query=%q", m.input.Value(), m.list.Query)
-	}
-	if m.input.Focused() || !m.focusSmearActive || m.focusSmearDirection != -1 {
-		t.Fatalf("paste skipped reverse smear: inputFocused=%v active=%v direction=%d", m.input.Focused(), m.focusSmearActive, m.focusSmearDirection)
-	}
+	require.Equal(t, "workspace", m.input.Value())
+	require.Equal(t, "workspace", m.list.Query)
+	require.False(t, m.input.Focused())
+	require.True(t, m.focusSmearActive)
+	assert.Equal(t, -1, m.focusSmearDirection)
 }
 
 func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
@@ -721,9 +650,7 @@ func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
 	m = updated.(teaModel)
 	distance := m.focusSmearSteps
 	wantDistance := listFirstRowIndex + m.list.Selected - filterLineIndex
-	if distance != wantDistance {
-		t.Fatalf("transfer distance=%d, want selected-row distance %d", distance, wantDistance)
-	}
+	require.Equal(t, wantDistance, distance)
 	previousStep := m.focusSmearStep
 	ticks := 0
 	largestAdvance := 0
@@ -735,9 +662,8 @@ func TestTeaModelAcceleratesLongFocusTransfers(t *testing.T) {
 		previousStep = m.focusSmearStep
 	}
 
-	if ticks >= distance || largestAdvance <= 1 {
-		t.Fatalf("long transfer did not accelerate: distance=%d ticks=%d largestAdvance=%d", distance, ticks, largestAdvance)
-	}
+	require.Less(t, ticks, distance)
+	assert.Greater(t, largestAdvance, 1)
 }
 
 func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
@@ -759,9 +685,7 @@ func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
 	for frame := range 3 {
 		lines := strings.Split(ansi.Strip(m.View().Content), "\n")
 		column := visualColumn(lines[listFirstRowIndex-frame], "█")
-		if column < 0 {
-			t.Fatalf("frame %d missing Gooey cursor:\n%s", frame, strings.Join(lines, "\n"))
-		}
+		require.GreaterOrEqual(t, column, 0)
 		columns = append(columns, column)
 		if frame < 2 {
 			updated, _ = m.Update(smearTickMsg{})
@@ -771,9 +695,7 @@ func TestTeaModelGooeyReverseTransferEasesOut(t *testing.T) {
 
 	firstMove := columns[1] - columns[0]
 	secondMove := columns[2] - columns[1]
-	if firstMove <= secondMove {
-		t.Fatalf("reverse Gooey movement accelerated into the input: columns=%v moves=%d,%d", columns, firstMove, secondMove)
-	}
+	assert.Greater(t, firstMove, secondMove)
 }
 
 func TestTeaModelSmearPresets(t *testing.T) {
@@ -804,18 +726,14 @@ func TestTeaModelSmearPresets(t *testing.T) {
 			}
 			transfer := ansi.Strip(m.View().Content)
 			for _, glyph := range append([]string{tt.head}, tt.transferTrail...) {
-				if !strings.Contains(transfer, glyph) {
-					t.Fatalf("%s transfer missing %q:\n%s", tt.name, glyph, transfer)
-				}
+				require.Contains(t, transfer, glyph)
 			}
 
 			for range 10 {
 				updated, _ = m.Update(smearTickMsg{})
 				m = updated.(teaModel)
 			}
-			if view := ansi.Strip(m.listView(40, 6)); !strings.Contains(view, tt.head) {
-				t.Fatalf("%s settled cursor missing %q:\n%s", tt.name, tt.head, view)
-			}
+			require.Contains(t, ansi.Strip(m.listView(40, 6)), tt.head)
 			for range len(items) - 1 {
 				updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 				m = updated.(teaModel)
@@ -827,9 +745,7 @@ func TestTeaModelSmearPresets(t *testing.T) {
 					trailCells++
 				}
 			}
-			if trailCells != tt.rowTrailCells {
-				t.Fatalf("%s row trail cells=%d, want %d:\n%s", tt.name, trailCells, tt.rowTrailCells, rowView)
-			}
+			assert.Equal(t, tt.rowTrailCells, trailCells)
 		})
 	}
 }
@@ -846,9 +762,7 @@ func TestTeaModelSmearsRapidSelectionMoves(t *testing.T) {
 
 	lines := strings.Split(strings.TrimSuffix(ansi.Strip(m.listView(40, 3)), "\n"), "\n")
 	for i, want := range []string{"╷ ", "│ ", "┃ "} {
-		if !strings.HasPrefix(lines[i], want) {
-			t.Fatalf("row %d = %q, want rail %q\n%s", i, lines[i], want, strings.Join(lines, "\n"))
-		}
+		require.True(t, strings.HasPrefix(lines[i], want))
 	}
 }
 
@@ -863,15 +777,11 @@ func TestTeaModelSmearRetracts(t *testing.T) {
 	m.input.Blur()
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
-	if !strings.HasPrefix(ansi.Strip(m.listView(40, 2)), "╷ ") {
-		t.Fatalf("moving selection did not start the smear:\n%s", ansi.Strip(m.listView(40, 2)))
-	}
+	require.True(t, strings.HasPrefix(ansi.Strip(m.listView(40, 2)), "╷ "))
 
 	msg := cmd()
 	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("move command = %T, want preview and animation batch", msg)
-	}
+	require.True(t, ok)
 	tickHandled := false
 	for _, child := range batch {
 		msg := child()
@@ -882,12 +792,8 @@ func TestTeaModelSmearRetracts(t *testing.T) {
 		m = updated.(teaModel)
 		tickHandled = true
 	}
-	if !tickHandled {
-		t.Fatal("move batch did not contain an animation tick")
-	}
-	if view := ansi.Strip(m.listView(40, 2)); strings.HasPrefix(view, "╷ ") {
-		t.Fatalf("smear remained after settling:\n%s", view)
-	}
+	require.True(t, tickHandled, "move batch did not contain an animation tick")
+	assert.False(t, strings.HasPrefix(ansi.Strip(m.listView(40, 2)), "╷ "))
 }
 
 func TestTeaModelCapsSmearSettleTime(t *testing.T) {
@@ -905,9 +811,7 @@ func TestTeaModelCapsSmearSettleTime(t *testing.T) {
 	}
 
 	for ticks := 1; m.smearActive; ticks++ {
-		if ticks > 3 {
-			t.Fatalf("smear still active after %d settle ticks", ticks-1)
-		}
+		require.LessOrEqual(t, ticks, 3)
 		updated, _ := m.Update(smearTickMsg{})
 		m = updated.(teaModel)
 	}
@@ -930,9 +834,8 @@ func TestTeaModelQueryChangeClearsSmear(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.listView(40, 4))
-	if strings.Contains(view, "╵ ") || strings.Contains(view, "│ ") {
-		t.Fatalf("query change left a smear on reordered rows:\n%s", view)
-	}
+	require.NotContains(t, view, "╵ ")
+	assert.NotContains(t, view, "│ ")
 }
 
 func TestTeaModelReducedMotionSkipsSmear(t *testing.T) {
@@ -944,25 +847,19 @@ func TestTeaModelReducedMotionSkipsSmear(t *testing.T) {
 	m = updated.(teaModel)
 
 	current, ok := m.list.Current()
-	if !ok || current.Name != "web" {
-		t.Fatalf("current = %#v ok=%v", current, ok)
-	}
+	require.True(t, ok)
+	require.Equal(t, "web", current.Name)
 	view := ansi.Strip(m.listView(40, 2))
-	if strings.Contains(view, "╷ ") || strings.Contains(view, "│ ") {
-		t.Fatalf("reduced motion rendered a smear:\n%s", view)
-	}
+	require.NotContains(t, view, "╷ ")
+	assert.NotContains(t, view, "│ ")
 }
 
 func TestTeaModelForwardsTextInputNonKeyMessages(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
 	updated, cmd := m.Update(cursor.Blink())
 	m = updated.(teaModel)
-	if cmd == nil {
-		t.Fatal("expected textinput to handle non-key cursor message")
-	}
-	if m.list.Query != m.input.Value() {
-		t.Fatalf("query=%q input=%q", m.list.Query, m.input.Value())
-	}
+	require.NotNil(t, cmd)
+	assert.Equal(t, m.input.Value(), m.list.Query)
 }
 
 func TestTeaModelViewRendersStyledShell(t *testing.T) {
@@ -989,16 +886,11 @@ func TestTeaModelViewRendersStyledShell(t *testing.T) {
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
 	for _, want := range []string{"herdr / sesh", "3 workspaces", "Find> ", "Search sessions", "LAST WORKSPACE · workspace-api  /tmp/workspace-api", "WORKSPACES", "PREVIEW [ctrl+o] · workspace-api", herdrSourceIcon + " herdr", zoxideSourceIcon + " zoxide", configSourceIcon + " config", "api", "preview content", "enter select"} {
-		if !strings.Contains(view, want) {
-			t.Fatalf("view missing %q:\n%s", want, view)
-		}
+		require.Contains(t, view, want)
 	}
-	if strings.Contains(view, "+-") || strings.Contains(view, "| ") {
-		t.Fatalf("view still contains ASCII box chrome:\n%s", view)
-	}
-	if got, want := maxLineWidth(view), 160; got != want {
-		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
-	}
+	require.NotContains(t, view, "+-")
+	require.NotContains(t, view, "| ")
+	assert.Equal(t, 160, maxLineWidth(view))
 }
 
 func TestTeaModelViewGroupsAndDescribesWorktreeFamily(t *testing.T) {
@@ -1045,18 +937,12 @@ func TestTeaModelViewGroupsAndDescribesWorktreeFamily(t *testing.T) {
 			lastChildLine = i
 		}
 	}
-	if parentLine < 0 || firstChildLine != parentLine+1 || lastChildLine != firstChildLine+1 {
-		t.Fatalf("worktree family is not parent-first with tree branches:\n%s", view)
-	}
-	if !strings.Contains(view, "PREVIEW [ctrl+o] · feature · worktree of project") {
-		t.Fatalf("view missing worktree preview context:\n%s", view)
-	}
-	if got, want := maxLineWidth(view), 160; got != want {
-		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
-	}
-	if got, want := lipgloss.Height(view), 28; got != want {
-		t.Fatalf("view height=%d, want %d:\n%s", got, want, view)
-	}
+	require.GreaterOrEqual(t, parentLine, 0)
+	require.Equal(t, parentLine+1, firstChildLine)
+	require.Equal(t, firstChildLine+1, lastChildLine)
+	require.Contains(t, view, "PREVIEW [ctrl+o] · feature · worktree of project")
+	require.Equal(t, 160, maxLineWidth(view))
+	assert.Equal(t, 28, lipgloss.Height(view))
 }
 
 func TestWorktreeTreePrefixRequiresContiguousVisibleFamily(t *testing.T) {
@@ -1066,9 +952,7 @@ func TestWorktreeTreePrefixRequiresContiguousVisibleFamily(t *testing.T) {
 		{Source: "herdr", Name: "child", WorkspaceID: "w-child", Worktree: model.WorktreeRelation{Linked: true, ParentWorkspaceID: "w-parent"}},
 	}
 
-	if got := worktreeTreePrefix(items, 2); got != "" {
-		t.Fatalf("tree prefix=%q for non-contiguous family, want none", got)
-	}
+	assert.Empty(t, worktreeTreePrefix(items, 2))
 }
 
 func TestListViewKeepsWorktreeBranchWhenParentIsOffScreen(t *testing.T) {
@@ -1079,9 +963,7 @@ func TestListViewKeepsWorktreeBranchWhenParentIsOffScreen(t *testing.T) {
 	m.list.Selected = 1
 
 	view := ansi.Strip(m.listView(80, 1))
-	if !strings.Contains(view, "└─ child") {
-		t.Fatalf("off-screen parent hid the child relationship: %q", view)
-	}
+	assert.Contains(t, view, "└─ child")
 }
 
 func TestTeaModelLastWorkspaceFallsBackToRecordedID(t *testing.T) {
@@ -1090,9 +972,7 @@ func TestTeaModelLastWorkspaceFallsBackToRecordedID(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
-	if !strings.Contains(view, "LAST WORKSPACE · unavailable-workspace") {
-		t.Fatalf("view missing recorded workspace ID:\n%s", view)
-	}
+	assert.Contains(t, view, "LAST WORKSPACE · unavailable-workspace")
 }
 
 func TestTeaModelLastWorkspaceUsesRawHerdrMetadata(t *testing.T) {
@@ -1104,9 +984,7 @@ func TestTeaModelLastWorkspaceUsesRawHerdrMetadata(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
-	if !strings.Contains(view, "LAST WORKSPACE · api  /live/api") {
-		t.Fatalf("view did not use raw Herdr workspace metadata:\n%s", view)
-	}
+	assert.Contains(t, view, "LAST WORKSPACE · api  /live/api")
 }
 
 func TestTeaModelCanHideLastWorkspacePath(t *testing.T) {
@@ -1119,9 +997,8 @@ func TestTeaModelCanHideLastWorkspacePath(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
-	if !strings.Contains(view, "LAST WORKSPACE · api") || strings.Contains(view, "/live/api") {
-		t.Fatalf("view did not hide last workspace path:\n%s", view)
-	}
+	require.Contains(t, view, "LAST WORKSPACE · api")
+	assert.NotContains(t, view, "/live/api")
 }
 
 func TestTeaModelCanHideLastWorkspace(t *testing.T) {
@@ -1134,9 +1011,9 @@ func TestTeaModelCanHideLastWorkspace(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
-	if strings.Contains(view, "LAST WORKSPACE") || strings.Contains(view, "last: api") || strings.Contains(view, "/live/api") {
-		t.Fatalf("view did not hide last workspace feature:\n%s", view)
-	}
+	require.NotContains(t, view, "LAST WORKSPACE")
+	require.NotContains(t, view, "last: api")
+	assert.NotContains(t, view, "/live/api")
 }
 
 func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
@@ -1147,16 +1024,12 @@ func TestTeaModelLastWorkspaceSharesFooterWithKeybinds(t *testing.T) {
 	view := ansi.Strip(m.View().Content)
 	for _, line := range strings.Split(view, "\n") {
 		if strings.Contains(line, "LAST WORKSPACE") {
-			if !strings.Contains(line, "enter select") {
-				t.Fatalf("last workspace is not on keybind row: %q", line)
-			}
-			if want := "LAST WORKSPACE · ws-api"; !strings.HasSuffix(strings.TrimSpace(line), want) {
-				t.Fatalf("last workspace is not right-aligned: %q", line)
-			}
+			require.Contains(t, line, "enter select")
+			require.True(t, strings.HasSuffix(strings.TrimSpace(line), "LAST WORKSPACE · ws-api"))
 			return
 		}
 	}
-	t.Fatalf("view missing last workspace footer:\n%s", view)
+	require.FailNow(t, fmt.Sprintf("view missing last workspace footer:\n%s", view))
 }
 
 func TestFooterLinePrioritizesKeybindHelpAtNarrowWidths(t *testing.T) {
@@ -1167,11 +1040,9 @@ func TestFooterLinePrioritizesKeybindHelpAtNarrowWidths(t *testing.T) {
 	help := helpStyle.Render("enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit")
 	for _, width := range []int{10, 20, 40, 80, 120} {
 		line := m.footerLine(help, width)
-		if got := lipgloss.Width(line); got != width {
-			t.Fatalf("width %d: footer width=%d:\n%q", width, got, line)
-		}
-		if plain := ansi.Strip(line); width >= lipgloss.Width(help) && !strings.Contains(plain, "esc exit") {
-			t.Fatalf("width %d: keybind help truncated: %q", width, plain)
+		require.Equal(t, width, lipgloss.Width(line))
+		if width >= lipgloss.Width(help) {
+			assert.Contains(t, ansi.Strip(line), "esc exit")
 		}
 	}
 }
@@ -1183,21 +1054,18 @@ func TestFooterLineCompactsLastWorkspaceBeforeDroppingIt(t *testing.T) {
 	})
 	help := helpStyle.Render("enter select · ctrl+j/k · ctrl+r workspace · ctrl+x close · esc exit")
 	line := ansi.Strip(m.footerLine(help, 80))
-	if !strings.Contains(line, "last: api") || strings.Contains(line, "LAST WORKSPACE") {
-		t.Fatalf("footer did not compact last workspace: %q", line)
-	}
-	if !strings.Contains(line, "esc exit") {
-		t.Fatalf("compact footer truncated keybind help: %q", line)
-	}
+	require.Contains(t, line, "last: api")
+	require.NotContains(t, line, "LAST WORKSPACE")
+	assert.Contains(t, line, "esc exit")
 }
 
 func TestFooterLineGivesCloseErrorWholeRow(t *testing.T) {
 	m := newTeaModel(nil, Options{LastWorkspaceID: "ws-api"})
 	m.closeError = "Failed to close workspace: herdr workspace close w1: boom"
 	line := ansi.Strip(m.footerLine(emptyStyle.Render(m.closeError), 80))
-	if !strings.Contains(line, "close w1: boom") || strings.Contains(line, "LAST WORKSPACE") || strings.Contains(line, "last:") {
-		t.Fatalf("close error did not get the whole footer row: %q", line)
-	}
+	require.Contains(t, line, "close w1: boom")
+	require.NotContains(t, line, "LAST WORKSPACE")
+	assert.NotContains(t, line, "last:")
 }
 
 func TestTeaModelLastWorkspaceUnavailable(t *testing.T) {
@@ -1205,9 +1073,7 @@ func TestTeaModelLastWorkspaceUnavailable(t *testing.T) {
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
 	m = updated.(teaModel)
 
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "LAST WORKSPACE · Unavailable") {
-		t.Fatalf("view missing unavailable state:\n%s", view)
-	}
+	assert.Contains(t, ansi.Strip(m.View().Content), "LAST WORKSPACE · Unavailable")
 }
 
 func TestTeaModelUnnamedLastWorkspaceDoesNotRepeatCompactedPath(t *testing.T) {
@@ -1220,22 +1086,16 @@ func TestTeaModelUnnamedLastWorkspaceDoesNotRepeatCompactedPath(t *testing.T) {
 	m = updated.(teaModel)
 
 	view := ansi.Strip(m.View().Content)
-	if strings.Count(view, "~/api") != 1 {
-		t.Fatalf("view repeated compacted workspace path:\n%s", view)
-	}
+	assert.Equal(t, 1, strings.Count(view, "~/api"))
 }
 
 func TestTeaModelShowIconsControlsSourceIcons(t *testing.T) {
 	items := []model.Session{{Source: "herdr", Name: "api"}}
 	withoutIcons := ansi.Strip(newTeaModel(items, Options{}).View().Content)
-	if strings.Contains(withoutIcons, herdrSourceIcon) {
-		t.Fatalf("view unexpectedly contains source icon:\n%s", withoutIcons)
-	}
+	require.NotContains(t, withoutIcons, herdrSourceIcon)
 
 	withIcons := ansi.Strip(newTeaModel(items, Options{ShowIcons: true}).View().Content)
-	if !strings.Contains(withIcons, herdrSourceIcon+" herdr") {
-		t.Fatalf("view missing source icon:\n%s", withIcons)
-	}
+	assert.Contains(t, withIcons, herdrSourceIcon+" herdr")
 }
 
 func TestRowUsesSourceCategoryColors(t *testing.T) {
@@ -1250,9 +1110,7 @@ func TestRowUsesSourceCategoryColors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		got := row(model.Session{Source: tt.source, Name: tt.source}, false, 80, true, "")
-		if !strings.Contains(got, tt.color) {
-			t.Fatalf("row for source %q missing color %s:\n%q", tt.source, tt.color, got)
-		}
+		require.Contains(t, got, tt.color)
 	}
 }
 
@@ -1260,17 +1118,16 @@ func TestChildWorktreeUsesPurpleTypeBadge(t *testing.T) {
 	s := model.Session{Source: "herdr", Name: "feature", Worktree: model.WorktreeRelation{Linked: true}}
 
 	withoutIcons := row(s, false, 80, false, "")
-	if plain := ansi.Strip(withoutIcons); !strings.Contains(plain, "[↳ herdr]") || strings.Contains(plain, "↳ feature") {
-		t.Fatalf("child type badge without icons=%q", plain)
-	}
-	if !strings.Contains(withoutIcons, "38;2;187;154;247") || strings.Contains(withoutIcons, "38;2;125;207;255") {
-		t.Fatalf("child type badge is not exclusively purple:\n%q", withoutIcons)
-	}
+	plain := ansi.Strip(withoutIcons)
+	require.Contains(t, plain, "[↳ herdr]")
+	require.NotContains(t, plain, "↳ feature")
+	require.Contains(t, withoutIcons, "38;2;187;154;247")
+	require.NotContains(t, withoutIcons, "38;2;125;207;255")
 
 	withIcons := ansi.Strip(row(s, false, 80, true, ""))
-	if !strings.Contains(withIcons, "↳ herdr") || strings.Contains(withIcons, herdrSourceIcon) || strings.Contains(withIcons, "↳ feature") {
-		t.Fatalf("child type badge with icons=%q", withIcons)
-	}
+	require.Contains(t, withIcons, "↳ herdr")
+	require.NotContains(t, withIcons, herdrSourceIcon)
+	assert.NotContains(t, withIcons, "↳ feature")
 }
 
 func TestChildWorktreeIconReplacementCanBeDisabled(t *testing.T) {
@@ -1281,18 +1138,15 @@ func TestChildWorktreeIconReplacementCanBeDisabled(t *testing.T) {
 	m := newTeaModel(items, Options{ShowIcons: true, DisableWorktreeIconReplacement: true})
 	withIcons := m.listView(80, 2)
 	plain := ansi.Strip(withIcons)
-	if !strings.Contains(plain, herdrSourceIcon+" herdr") || !strings.Contains(plain, "└─ feature") || strings.Contains(plain, "↳") {
-		t.Fatalf("child row with replacement disabled=%q", plain)
-	}
-	if !strings.Contains(withIcons, "38;2;187;154;247") {
-		t.Fatalf("child type lost purple styling:\n%q", withIcons)
-	}
+	require.Contains(t, plain, herdrSourceIcon+" herdr")
+	require.Contains(t, plain, "└─ feature")
+	require.NotContains(t, plain, "↳")
+	require.Contains(t, withIcons, "38;2;187;154;247")
 
 	m = newTeaModel(items, Options{DisableWorktreeIconReplacement: true})
 	withoutIcons := ansi.Strip(m.listView(80, 2))
-	if !strings.Contains(withoutIcons, "[herdr]") || strings.Contains(withoutIcons, "↳") {
-		t.Fatalf("child row without source icons=%q", withoutIcons)
-	}
+	require.Contains(t, withoutIcons, "[herdr]")
+	assert.NotContains(t, withoutIcons, "↳")
 }
 
 func TestRowUsesAgentStatusIndicators(t *testing.T) {
@@ -1308,15 +1162,12 @@ func TestRowUsesAgentStatusIndicators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		got := row(model.Session{Source: "herdr", Name: "api", AgentStatus: tt.status}, false, 80, true, "")
-		if !strings.Contains(ansi.Strip(got), tt.glyph) || !strings.Contains(got, tt.color) {
-			t.Fatalf("row for status %q missing glyph/color:\n%q", tt.status, got)
-		}
+		require.Contains(t, ansi.Strip(got), tt.glyph)
+		require.Contains(t, got, tt.color)
 	}
 	for _, status := range []string{"", "unknown", "future"} {
 		got := ansi.Strip(row(model.Session{Source: "herdr", Name: "api", AgentStatus: status}, false, 80, true, ""))
-		if strings.ContainsAny(got, "⢄◉✓●") {
-			t.Fatalf("row for status %q unexpectedly contains indicator: %q", status, got)
-		}
+		require.False(t, strings.ContainsAny(got, "⢄◉✓●"))
 	}
 }
 
@@ -1328,23 +1179,17 @@ func TestTeaModelAnimatesWorkingAgentStatusIndicator(t *testing.T) {
 	m = updated.(teaModel)
 	after := ansi.Strip(m.listView(80, 1))
 
-	if !strings.Contains(before, "⢄") || !strings.Contains(after, "⢂") {
-		t.Fatalf("working indicator did not advance jump frame:\nbefore: %q\nafter:  %q", before, after)
-	}
-	if cmd == nil {
-		t.Fatal("working indicator did not schedule its next jump frame")
-	}
+	require.Contains(t, before, "⢄")
+	require.Contains(t, after, "⢂")
+	require.NotNil(t, cmd)
 }
 
 func TestTeaModelStartsAgentStatusSpinner(t *testing.T) {
 	m := newTeaModel(nil, Options{RefreshAgentStatuses: func() (map[string]string, error) { return nil, nil }})
 	batch, ok := m.Init()().(tea.BatchMsg)
-	if !ok || len(batch) == 0 {
-		t.Fatalf("init command = %#v, want batch", batch)
-	}
-	if msg := batch[len(batch)-1](); reflect.TypeOf(msg) != reflect.TypeOf(spinner.TickMsg{}) {
-		t.Fatalf("last init message = %T, want spinner.TickMsg", msg)
-	}
+	require.True(t, ok)
+	require.NotEmpty(t, batch)
+	assert.Equal(t, reflect.TypeOf(spinner.TickMsg{}), reflect.TypeOf(batch[len(batch)-1]()))
 }
 
 func TestRowCompactsHomeAndNeverWraps(t *testing.T) {
@@ -1356,19 +1201,15 @@ func TestRowCompactsHomeAndNeverWraps(t *testing.T) {
 		AgentStatus: "working",
 	}
 	wide := ansi.Strip(strings.TrimSuffix(row(s, true, 76, true, ""), "\n"))
-	if strings.Contains(wide, "\n") || lipgloss.Width(wide) != 76 {
-		t.Fatalf("wide row width=%d or wrapped:\n%q", lipgloss.Width(wide), wide)
-	}
-	if !strings.Contains(wide, "~/Code/Go/") || strings.Contains(wide, "/Users/picker") {
-		t.Fatalf("wide row did not compact home path: %q", wide)
-	}
+	require.NotContains(t, wide, "\n")
+	require.Equal(t, 76, lipgloss.Width(wide))
+	require.Contains(t, wide, "~/Code/Go/")
+	require.NotContains(t, wide, "/Users/picker")
 	narrow := ansi.Strip(strings.TrimSuffix(row(s, false, 48, true, ""), "\n"))
-	if strings.Contains(narrow, "~/") || strings.Contains(narrow, "/Users/picker") {
-		t.Fatalf("narrow row should omit its path: %q", narrow)
-	}
-	if strings.Contains(narrow, "\n") || lipgloss.Width(narrow) != 48 {
-		t.Fatalf("narrow row width=%d or wrapped: %q", lipgloss.Width(narrow), narrow)
-	}
+	require.NotContains(t, narrow, "~/")
+	require.NotContains(t, narrow, "/Users/picker")
+	require.NotContains(t, narrow, "\n")
+	assert.Equal(t, 48, lipgloss.Width(narrow))
 }
 
 func TestRowShowsWorktreePathWithoutParentDescription(t *testing.T) {
@@ -1387,31 +1228,22 @@ func TestRowShowsWorktreePathWithoutParentDescription(t *testing.T) {
 	wide := row(s, true, 100, true, "")
 	widePlain := ansi.Strip(strings.TrimSuffix(wide, "\n"))
 	for _, want := range []string{"┃", "◉", "↳ herdr", "feature", "/tmp/project-feature"} {
-		if !strings.Contains(widePlain, want) {
-			t.Fatalf("wide worktree row missing %q:\n%q", want, wide)
-		}
+		require.Contains(t, widePlain, want)
 	}
-	if strings.Contains(widePlain, "worktree of") {
-		t.Fatalf("wide child row obscures its path with parent description:\n%q", widePlain)
-	}
-	if strings.Contains(widePlain, herdrSourceIcon) {
-		t.Fatalf("wide child row kept Herdr icon alongside worktree arrow:\n%q", widePlain)
-	}
-	if lipgloss.Width(widePlain) != 100 || strings.Contains(widePlain, "\n") {
-		t.Fatalf("wide row width=%d or wrapped:\n%q", lipgloss.Width(widePlain), widePlain)
-	}
+	require.NotContains(t, widePlain, "worktree of")
+	require.NotContains(t, widePlain, herdrSourceIcon)
+	require.Equal(t, 100, lipgloss.Width(widePlain))
+	require.NotContains(t, widePlain, "\n")
 
 	narrow := row(s, false, 48, false, "")
 	narrowPlain := ansi.Strip(strings.TrimSuffix(narrow, "\n"))
-	if !strings.Contains(narrowPlain, "[↳ herdr]") || !strings.Contains(narrowPlain, "feature") || strings.Contains(narrowPlain, "↳ feature") {
-		t.Fatalf("narrow worktree row missing child type badge: %q", narrowPlain)
-	}
-	if strings.Contains(narrowPlain, "worktree of") || strings.Contains(narrowPlain, "/tmp/project-feature") {
-		t.Fatalf("narrow worktree row kept secondary context: %q", narrowPlain)
-	}
-	if lipgloss.Width(narrowPlain) != 48 || strings.Contains(narrowPlain, "\n") {
-		t.Fatalf("narrow row width=%d or wrapped: %q", lipgloss.Width(narrowPlain), narrowPlain)
-	}
+	require.Contains(t, narrowPlain, "[↳ herdr]")
+	require.Contains(t, narrowPlain, "feature")
+	require.NotContains(t, narrowPlain, "↳ feature")
+	require.NotContains(t, narrowPlain, "worktree of")
+	require.NotContains(t, narrowPlain, "/tmp/project-feature")
+	require.Equal(t, 48, lipgloss.Width(narrowPlain))
+	assert.NotContains(t, narrowPlain, "\n")
 }
 
 func TestRowPreservesWorktreeMarkerAtCompactBoundary(t *testing.T) {
@@ -1424,12 +1256,9 @@ func TestRowPreservesWorktreeMarkerAtCompactBoundary(t *testing.T) {
 	for _, showIcons := range []bool{false, true} {
 		for _, width := range []int{1, 4, 5, 6, 10, 14, 15, 16} {
 			got := ansi.Strip(strings.TrimSuffix(row(s, true, width, showIcons, ""), "\n"))
-			if !strings.Contains(got, "↳") {
-				t.Fatalf("icons=%v width=%d missing marker: %q", showIcons, width, got)
-			}
-			if lipgloss.Width(got) != width || strings.Contains(got, "\n") {
-				t.Fatalf("icons=%v width=%d got width=%d or wrapped: %q", showIcons, width, lipgloss.Width(got), got)
-			}
+			require.Contains(t, got, "↳")
+			require.Equal(t, width, lipgloss.Width(got))
+			require.NotContains(t, got, "\n")
 		}
 	}
 }
@@ -1440,16 +1269,17 @@ func TestRowUsesBadgeWithoutDescriptionWhenWorktreeParentIsUnresolved(t *testing
 		Name:     "feature",
 		Worktree: model.WorktreeRelation{Linked: true},
 	}, false, 80, false, ""))
-	if !strings.Contains(got, "[↳ herdr]") || !strings.Contains(got, "feature") || strings.Contains(got, "linked worktree") || strings.Contains(got, "worktree of") || strings.Contains(got, "↳ feature") {
-		t.Fatalf("unresolved worktree row=%q", got)
-	}
+	require.Contains(t, got, "[↳ herdr]")
+	require.Contains(t, got, "feature")
+	require.NotContains(t, got, "linked worktree")
+	require.NotContains(t, got, "worktree of")
+	assert.NotContains(t, got, "↳ feature")
 }
 
 func TestRowDoesNotMarkNormalWorkspace(t *testing.T) {
 	got := ansi.Strip(row(model.Session{Source: "herdr", Name: "project", Path: "/tmp/project"}, false, 80, false, ""))
-	if strings.Contains(got, "↳") || strings.Contains(got, "worktree") {
-		t.Fatalf("normal workspace row has worktree indicator: %q", got)
-	}
+	require.NotContains(t, got, "↳")
+	assert.NotContains(t, got, "worktree")
 }
 
 func TestPreviewTitleShowsUnresolvedLinkedWorktree(t *testing.T) {
@@ -1460,9 +1290,8 @@ func TestPreviewTitleShowsUnresolvedLinkedWorktree(t *testing.T) {
 	}}, Options{})
 
 	got := ansi.Strip(m.previewTitle())
-	if !strings.Contains(got, "PREVIEW [ctrl+o] · feature · linked worktree") || strings.Contains(got, "worktree of") {
-		t.Fatalf("preview title=%q", got)
-	}
+	require.Contains(t, got, "PREVIEW [ctrl+o] · feature · linked worktree")
+	assert.NotContains(t, got, "worktree of")
 }
 
 func TestPreviewTitleShowsWorktreeParentBeforeAgentStatus(t *testing.T) {
@@ -1483,18 +1312,14 @@ func TestPreviewTitleShowsWorktreeParentBeforeAgentStatus(t *testing.T) {
 	m.list.Selected = 1
 
 	got := ansi.Strip(m.previewTitle())
-	if !strings.Contains(got, "PREVIEW [ctrl+o] · feature · worktree of parent · working") {
-		t.Fatalf("preview title=%q", got)
-	}
+	assert.Contains(t, got, "PREVIEW [ctrl+o] · feature · worktree of parent · working")
 }
 
 func TestTeaModelPreviewUsesConfiguredCommand(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api", Path: "/tmp/api"}}, Options{DefaultPreviewCommand: "printf preview:%s {}"})
 	msg := previewCommand(m.previewContext, m.previewKey, m.previewRequestID, m.list.Filtered[m.list.Selected], m.defaultPreviewCommand, false)()
 	preview := msg.(previewMsg)
-	if got := strings.TrimSpace(preview.text); got != "preview:/tmp/api" {
-		t.Fatalf("preview=%q", preview.text)
-	}
+	assert.Equal(t, "preview:/tmp/api", strings.TrimSpace(preview.text))
 }
 
 func TestTeaModelHidePreviewDoesNotRunInitialPreview(t *testing.T) {
@@ -1505,9 +1330,8 @@ func TestTeaModelHidePreviewDoesNotRunInitialPreview(t *testing.T) {
 	})
 
 	executeTeaCommand(m.Init())
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("preview command ran while hidden: %v", err)
-	}
+	_, err := os.Stat(marker)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestTeaModelHidePreviewDoesNotRefreshAfterSelection(t *testing.T) {
@@ -1522,9 +1346,8 @@ func TestTeaModelHidePreviewDoesNotRefreshAfterSelection(t *testing.T) {
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
 	executeTeaCommand(cmd)
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("preview command refreshed while hidden: %v", err)
-	}
+	_, err := os.Stat(marker)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func executeTeaCommand(cmd tea.Cmd) {
@@ -1549,13 +1372,12 @@ func TestTeaModelRefreshesPreviewWhenSelectionChanges(t *testing.T) {
 	m = updated.(teaModel)
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m = updated.(teaModel)
-	if cmd == nil || !strings.Contains(m.preview, "Loading preview") {
-		t.Fatalf("cmd=%v preview=%q", cmd, m.preview)
-	}
+	require.NotNil(t, cmd)
+	require.Contains(t, m.preview, "Loading preview")
 	current, ok := m.list.Current()
-	if !ok || current.Name != "web" || m.previewKey != model.Key(current) {
-		t.Fatalf("current=%#v ok=%v previewKey=%q", current, ok, m.previewKey)
-	}
+	require.True(t, ok)
+	require.Equal(t, "web", current.Name)
+	assert.Equal(t, model.Key(current), m.previewKey)
 }
 
 func TestTeaModelCancelsSupersededPreview(t *testing.T) {
@@ -1592,9 +1414,9 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 	select {
 	case <-firstStarted:
 	case err := <-previewErr:
-		t.Fatal(err)
+		require.FailNow(t, fmt.Sprint(err))
 	case <-time.After(time.Second):
-		t.Fatal("first preview did not start")
+		require.FailNow(t, "first preview did not start")
 	}
 
 	m.list.Move(1)
@@ -1604,22 +1426,20 @@ func TestTeaModelCancelsSupersededPreview(t *testing.T) {
 	select {
 	case <-secondStarted:
 	case err := <-previewErr:
-		t.Fatal(err)
+		require.FailNow(t, fmt.Sprint(err))
 	case <-time.After(time.Second):
-		t.Fatal("replacement preview did not start")
+		require.FailNow(t, "replacement preview did not start")
 	}
 	select {
 	case <-firstCanceled:
 	case <-time.After(time.Second):
-		t.Fatal("superseded preview did not observe cancellation")
+		require.FailNow(t, "superseded preview did not observe cancellation")
 	}
 
 	close(releaseSecond)
 	updated, _ := m.Update(<-secondResult)
 	m = updated.(teaModel)
-	if m.preview != "web preview" {
-		t.Fatalf("preview=%q, want replacement result", m.preview)
-	}
+	require.Equal(t, "web preview", m.preview)
 	<-firstResult
 }
 
@@ -1640,9 +1460,7 @@ func TestTeaModelRejectsObsoleteSameKeyPreview(t *testing.T) {
 
 	updated, _ := m.Update(firstCmd())
 	m = updated.(teaModel)
-	if m.preview != "Loading preview..." {
-		t.Fatalf("preview=%q, want active request loading text", m.preview)
-	}
+	assert.Equal(t, "Loading preview...", m.preview)
 }
 
 func TestTeaModelCancelsPreviewOnQuitOrNoPreview(t *testing.T) {
@@ -1684,14 +1502,14 @@ func TestTeaModelCancelsPreviewOnQuitOrNoPreview(t *testing.T) {
 			select {
 			case <-started:
 			case <-time.After(time.Second):
-				t.Fatal("preview did not start")
+				require.FailNow(t, "preview did not start")
 			}
 
 			_, _ = tt.advance(m)
 			select {
 			case <-canceled:
 			case <-time.After(time.Second):
-				t.Fatal("preview did not observe cancellation")
+				require.FailNow(t, "preview did not observe cancellation")
 			}
 		})
 	}
@@ -1730,7 +1548,7 @@ func TestTeaModelCancelsRestartedPreviewWhenQuittingPendingClose(t *testing.T) {
 	select {
 	case <-closeStarted:
 	case <-time.After(time.Second):
-		t.Fatal("workspace close did not start")
+		require.FailNow(t, "workspace close did not start")
 	}
 
 	updated, moveCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
@@ -1739,25 +1557,24 @@ func TestTeaModelCancelsRestartedPreviewWhenQuittingPendingClose(t *testing.T) {
 	select {
 	case <-previewStarted:
 	case <-time.After(time.Second):
-		t.Fatal("navigation did not restart preview during close")
+		require.FailNow(t, "navigation did not restart preview during close")
 	}
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	m = updated.(teaModel)
 	updated, quitCmd := m.Update(<-closeResult)
 	m = updated.(teaModel)
-	if quitCmd == nil {
-		t.Fatal("pending close did not quit after cancellation")
-	}
+	require.NotNil(t, quitCmd)
 	if quitMsg := quitCmd(); quitMsg == nil {
-		t.Fatal("quit command returned nil")
-	} else if _, ok := quitMsg.(tea.QuitMsg); !ok {
-		t.Fatalf("quit command returned %T", quitMsg)
+		require.FailNow(t, "quit command returned nil")
+	} else {
+		_, ok := quitMsg.(tea.QuitMsg)
+		require.True(t, ok)
 	}
 	select {
 	case <-previewCanceled:
 	case <-time.After(time.Second):
-		t.Fatal("restarted preview did not observe cancellation before quit")
+		require.FailNow(t, "restarted preview did not observe cancellation before quit")
 	}
 }
 
@@ -1772,22 +1589,16 @@ func TestTeaModelRefreshesAgentStatuses(t *testing.T) {
 
 	updated, cmd := m.Update(statusRefreshTickMsg{})
 	m = updated.(teaModel)
-	if cmd == nil {
-		t.Fatal("status refresh tick did not fetch statuses")
-	}
+	require.NotNil(t, cmd)
 
 	updated, next := m.Update(cmd())
 	m = updated.(teaModel)
 	current, ok := m.list.Current()
-	if !ok || current.AgentStatus != "blocked" {
-		t.Fatalf("current=%#v ok=%v", current, ok)
-	}
-	if m.list.Query != "api" || len(m.list.Filtered) != 1 {
-		t.Fatalf("query=%q filtered=%#v", m.list.Query, m.list.Filtered)
-	}
-	if next == nil {
-		t.Fatal("status refresh did not schedule the next tick")
-	}
+	require.True(t, ok)
+	require.Equal(t, "blocked", current.AgentStatus)
+	require.Equal(t, "api", m.list.Query)
+	require.Len(t, m.list.Filtered, 1)
+	require.NotNil(t, next)
 }
 
 func TestTeaModelAgentSortRefreshPreservesSelectionAndPreview(t *testing.T) {
@@ -1799,9 +1610,8 @@ func TestTeaModelAgentSortRefreshPreservesSelectionAndPreview(t *testing.T) {
 	m.list.Filter("api")
 	m.list.Selected = 1
 	selected, ok := m.list.Current()
-	if !ok || selected.WorkspaceID != "w1" {
-		t.Fatalf("selected=%#v ok=%v", selected, ok)
-	}
+	require.True(t, ok)
+	require.Equal(t, "w1", selected.WorkspaceID)
 	selectedKey := model.Key(selected)
 	m.previewKey = selectedKey
 	previewRequestID := m.previewRequestID
@@ -1815,28 +1625,17 @@ func TestTeaModelAgentSortRefreshPreservesSelectionAndPreview(t *testing.T) {
 	}})
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"api-two", "api-three", "api-one"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("all order=%v want %v", got, want)
-	}
-	if got, want := sessionNames(m.list.Filtered), []string{"api-two", "api-three", "api-one"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("filtered order=%v want %v", got, want)
-	}
+	require.Equal(t, []string{"api-two", "api-three", "api-one"}, sessionNames(m.list.All))
+	require.Equal(t, []string{"api-two", "api-three", "api-one"}, sessionNames(m.list.Filtered))
 	current, ok := m.list.Current()
-	if !ok || model.Key(current) != selectedKey {
-		t.Fatalf("current=%#v ok=%v, want key %q", current, ok, selectedKey)
-	}
-	if m.list.Query != "api" {
-		t.Fatalf("query=%q, want api", m.list.Query)
-	}
-	if m.previewKey != selectedKey || m.previewRequestID != previewRequestID {
-		t.Fatalf("preview changed: key=%q request=%d, want key=%q request=%d", m.previewKey, m.previewRequestID, selectedKey, previewRequestID)
-	}
-	if m.smearActive || m.focusSmearActive {
-		t.Fatal("status reorder kept stale smear animation")
-	}
-	if next == nil {
-		t.Fatal("status refresh did not schedule the next tick")
-	}
+	require.True(t, ok)
+	require.Equal(t, selectedKey, model.Key(current))
+	require.Equal(t, "api", m.list.Query)
+	require.Equal(t, selectedKey, m.previewKey)
+	require.Equal(t, previewRequestID, m.previewRequestID)
+	require.False(t, m.smearActive)
+	require.False(t, m.focusSmearActive)
+	require.NotNil(t, next)
 }
 
 func TestTeaModelAgentSortRefreshDemotesMissingStatus(t *testing.T) {
@@ -1848,12 +1647,8 @@ func TestTeaModelAgentSortRefreshDemotesMissingStatus(t *testing.T) {
 	updated, _ := m.Update(agentStatusesMsg{statuses: map[string]string{"w2": "idle"}})
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"idle", "blocked"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent order=%v want %v", got, want)
-	}
-	if got := m.list.All[1].AgentStatus; got != "" {
-		t.Fatalf("missing workspace status=%q, want empty", got)
-	}
+	require.Equal(t, []string{"idle", "blocked"}, sessionNames(m.list.All))
+	assert.Empty(t, m.list.All[1].AgentStatus)
 }
 
 func TestTeaModelAgentSortRefreshErrorKeepsState(t *testing.T) {
@@ -1870,22 +1665,15 @@ func TestTeaModelAgentSortRefreshErrorKeepsState(t *testing.T) {
 	updated, next := m.Update(agentStatusesMsg{statuses: map[string]string{"w1": "idle", "w2": "blocked"}, err: errors.New("offline")})
 	m = updated.(teaModel)
 
-	if got, want := sessionNames(m.list.All), []string{"blocked", "idle"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent order=%v want %v", got, want)
-	}
-	if m.list.All[0].AgentStatus != "blocked" || m.list.All[1].AgentStatus != "idle" {
-		t.Fatalf("statuses changed after error: %#v", m.list.All)
-	}
+	require.Equal(t, []string{"blocked", "idle"}, sessionNames(m.list.All))
+	require.Equal(t, "blocked", m.list.All[0].AgentStatus)
+	require.Equal(t, "idle", m.list.All[1].AgentStatus)
 	current, ok := m.list.Current()
-	if !ok || model.Key(current) != selectedKey {
-		t.Fatalf("current=%#v ok=%v, want key %q", current, ok, selectedKey)
-	}
-	if m.previewKey != selectedKey || m.previewRequestID != previewRequestID {
-		t.Fatal("preview changed after refresh error")
-	}
-	if next == nil {
-		t.Fatal("refresh error did not schedule the next tick")
-	}
+	require.True(t, ok)
+	require.Equal(t, selectedKey, model.Key(current))
+	require.Equal(t, selectedKey, m.previewKey)
+	require.Equal(t, previewRequestID, m.previewRequestID)
+	require.NotNil(t, next)
 }
 
 func TestTeaModelAgentStatusRefreshKeepsNonAgentSortOrder(t *testing.T) {
@@ -1905,16 +1693,12 @@ func TestTeaModelAgentStatusRefreshKeepsNonAgentSortOrder(t *testing.T) {
 			updated, _ := m.Update(agentStatusesMsg{statuses: map[string]string{"w1": "idle", "w2": "blocked"}})
 			m = updated.(teaModel)
 
-			if got := sessionNames(m.list.All); !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("order=%v want %v", got, tc.want)
-			}
+			require.Equal(t, tc.want, sessionNames(m.list.All))
 			statuses := map[string]string{}
 			for _, item := range m.list.All {
 				statuses[item.WorkspaceID] = item.AgentStatus
 			}
-			if !reflect.DeepEqual(statuses, map[string]string{"w1": "idle", "w2": "blocked"}) {
-				t.Fatalf("statuses=%v", statuses)
-			}
+			assert.Equal(t, map[string]string{"w1": "idle", "w2": "blocked"}, statuses)
 		})
 	}
 }
@@ -1925,18 +1709,10 @@ func TestPreviewViewUsesConstantHeight(t *testing.T) {
 	short := m.previewView(40, 4)
 	m.preview = strings.Repeat("wrapped preview content ", 20)
 	long := m.previewView(40, 4)
-	if lipgloss.Height(short) != lipgloss.Height(long) {
-		t.Fatalf("preview heights changed: short=%d long=%d\nshort:\n%s\nlong:\n%s", lipgloss.Height(short), lipgloss.Height(long), short, long)
-	}
-	if got, want := lipgloss.Height(short), 4+previewTitleRows; got != want {
-		t.Fatalf("preview height=%d, want %d\n%s", got, want, short)
-	}
-	if !strings.Contains(long, "...") {
-		t.Fatalf("long preview missing truncation marker:\n%s", long)
-	}
-	if strings.Contains(ansi.Strip(long), "+-") {
-		t.Fatalf("preview still contains box chrome:\n%s", long)
-	}
+	require.Equal(t, lipgloss.Height(long), lipgloss.Height(short))
+	require.Equal(t, 4+previewTitleRows, lipgloss.Height(short))
+	require.Contains(t, long, "...")
+	assert.NotContains(t, ansi.Strip(long), "+-")
 }
 
 func TestTeaModelUsesAvailableWindowHeight(t *testing.T) {
@@ -1947,42 +1723,25 @@ func TestTeaModelUsesAvailableWindowHeight(t *testing.T) {
 	m := newTeaModel(items, Options{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(teaModel)
-	if got := m.previewBodyLines(); got <= defaultVisibleRows {
-		t.Fatalf("preview body lines=%d, want more than fallback %d", got, defaultVisibleRows)
-	}
+	require.Greater(t, m.previewBodyLines(), defaultVisibleRows)
 	view := ansi.Strip(m.View().Content)
-	if got, want := lipgloss.Height(view), 40; got != want {
-		t.Fatalf("view height=%d, want %d", got, want)
-	}
+	require.Equal(t, 40, lipgloss.Height(view))
 	lines := strings.Split(view, "\n")
-	if lines[0] != "" {
-		t.Fatalf("expected top padding row, got %q\n%s", lines[0], view)
-	}
-	if header := lines[1]; !strings.Contains(header, "herdr / sesh") {
-		t.Fatalf("expected navigator header after padding, got %q\n%s", header, view)
-	}
-	if got, want := maxLineWidth(view), 120; got != want {
-		t.Fatalf("view width=%d, want %d:\n%s", got, want, view)
-	}
-	if last := lines[len(lines)-1]; strings.TrimSpace(last) != "" {
-		t.Fatalf("expected bottom breathing room, got %q\n%s", last, view)
-	}
+	require.Empty(t, lines[0])
+	require.Contains(t, lines[1], "herdr / sesh")
+	require.Equal(t, 120, maxLineWidth(view))
+	assert.Empty(t, strings.TrimSpace(lines[len(lines)-1]))
 }
 
 func TestSelectedRowUsesRailAndPreservesSourceColor(t *testing.T) {
 	got := row(model.Session{Source: "herdr", Name: "herdr-plugin-sesh", Path: "/tmp/herdr-plugin-sesh", AgentStatus: "working"}, true, 80, true, "")
 	plain := ansi.Strip(got)
-	if !strings.Contains(plain, "┃") {
-		t.Fatalf("selected row missing navigation rail:\n%q", got)
-	}
+	require.Contains(t, plain, "┃")
 	for _, want := range []string{"38;2;125;207;255", "38;2;224;175;104", herdrSourceIcon + " herdr", "herdr-plugin-sesh", "/tmp/herdr-plugin-sesh"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("selected row missing %q:\n%q", want, got)
-		}
+		require.Contains(t, got, want)
 	}
-	if strings.Contains(got, "48;2;") || strings.Contains(got, "48;5;") {
-		t.Fatalf("selected row should not use a background fill:\n%q", got)
-	}
+	require.NotContains(t, got, "48;2;")
+	assert.NotContains(t, got, "48;5;")
 }
 
 func TestListViewHighlightsCaseInsensitiveQueryMatches(t *testing.T) {
@@ -1995,9 +1754,7 @@ func TestListViewHighlightsCaseInsensitiveQueryMatches(t *testing.T) {
 
 	got := m.listView(80, 1)
 	want := lipgloss.NewStyle().Foreground(violetColor).Bold(true).Render("API")
-	if matches := strings.Count(got, want); matches != 2 {
-		t.Fatalf("highlighted matches=%d, want 2:\n%q", matches, got)
-	}
+	assert.Equal(t, 2, strings.Count(got, want))
 }
 
 func TestListViewPreservesUnicodeWhenHighlightingFoldedMatch(t *testing.T) {
@@ -2006,12 +1763,8 @@ func TestListViewPreservesUnicodeWhenHighlightingFoldedMatch(t *testing.T) {
 
 	got := m.listView(80, 1)
 	want := matchStyle.Render("Ⱥ")
-	if !utf8.ValidString(got) {
-		t.Fatalf("highlighted row is invalid UTF-8: %q", got)
-	}
-	if matches := strings.Count(got, want); matches != 2 {
-		t.Fatalf("highlighted matches=%d, want 2:\n%q", matches, got)
-	}
+	require.True(t, utf8.ValidString(got))
+	assert.Equal(t, 2, strings.Count(got, want))
 }
 
 func TestTeaModelStacksPreviewAtNarrowWidth(t *testing.T) {
@@ -2020,15 +1773,10 @@ func TestTeaModelStacksPreviewAtNarrowWidth(t *testing.T) {
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 70, Height: 28})
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
-	if got, want := lipgloss.Height(view), 28; got != want {
-		t.Fatalf("view height=%d, want %d:\n%s", got, want, view)
-	}
-	if !strings.Contains(view, "WORKSPACES") || !strings.Contains(view, "PREVIEW [ctrl+o] · api · blocked") {
-		t.Fatalf("narrow view missing stacked sections:\n%s", view)
-	}
-	if strings.Contains(view, "│") {
-		t.Fatalf("narrow view should not contain a vertical pane divider:\n%s", view)
-	}
+	require.Equal(t, 28, lipgloss.Height(view))
+	require.Contains(t, view, "WORKSPACES")
+	require.Contains(t, view, "PREVIEW [ctrl+o] · api · blocked")
+	assert.NotContains(t, view, "│")
 }
 
 func TestTeaModelHidePreviewUsesAllAvailableSpace(t *testing.T) {
@@ -2047,20 +1795,15 @@ func TestTeaModelHidePreviewUsesAllAvailableSpace(t *testing.T) {
 			m = updated.(teaModel)
 			view := ansi.Strip(m.View().Content)
 
-			if strings.Contains(view, "PREVIEW") || strings.Contains(view, "│") {
-				t.Fatalf("hidden preview still rendered at width %d:\n%s", width, view)
+			require.NotContains(t, view, "PREVIEW")
+			require.NotContains(t, view, "│")
+			require.Equal(t, 28, lipgloss.Height(view))
+			require.Equal(t, width, maxLineWidth(view))
+			if width == 70 {
+				assert.Contains(t, view, "workspace-17")
 			}
-			if got := lipgloss.Height(view); got != 28 {
-				t.Fatalf("view height=%d, want 28:\n%s", got, view)
-			}
-			if got := maxLineWidth(view); got != width {
-				t.Fatalf("view width=%d, want %d:\n%s", got, width, view)
-			}
-			if width == 70 && !strings.Contains(view, "workspace-17") {
-				t.Fatalf("narrow list did not reclaim preview rows:\n%s", view)
-			}
-			if width == 120 && !strings.Contains(view, items[0].Path) {
-				t.Fatalf("wide list did not give reclaimed width to the path column:\n%s", view)
+			if width == 120 {
+				assert.Contains(t, view, items[0].Path)
 			}
 		})
 	}
@@ -2072,9 +1815,7 @@ func TestTeaModelHidePreviewFitsShortNarrowTerminal(t *testing.T) {
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)
 
-	if got := lipgloss.Height(view); got != 14 {
-		t.Fatalf("view height=%d, want 14:\n%s", got, view)
-	}
+	assert.Equal(t, 14, lipgloss.Height(view))
 }
 
 func TestTeaModelHidePreviewShowsWorkspaceCloseProgressInFooter(t *testing.T) {
@@ -2091,14 +1832,10 @@ func TestTeaModelHidePreviewShowsWorkspaceCloseProgressInFooter(t *testing.T) {
 		}
 	})
 
-	if footer := renderedFooter(m); !strings.Contains(footer, "Closing workspace...") {
-		t.Fatalf("closing footer=%q", footer)
-	}
+	require.Contains(t, renderedFooter(m), "Closing workspace...")
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	m = updated.(teaModel)
-	if footer := renderedFooter(m); !strings.Contains(footer, "Cancelling workspace close...") {
-		t.Fatalf("cancelling footer=%q", footer)
-	}
+	assert.Contains(t, renderedFooter(m), "Cancelling workspace close...")
 }
 
 func renderedFooter(m teaModel) string {
@@ -2110,17 +1847,13 @@ func TestTeaModelSplitsPreviewAtTerminalThreshold(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "api"}}, Options{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: previewSplitWidth, Height: 28})
 	m = updated.(teaModel)
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "│") {
-		t.Fatalf("preview should split at width %d:\n%s", previewSplitWidth, view)
-	}
+	assert.Contains(t, ansi.Strip(m.View().Content), "│")
 }
 
 func TestTeaModelHeaderShowsFilteredCountWhenAllRowsMatch(t *testing.T) {
 	m := newTeaModel([]model.Session{{Name: "workspace-api"}, {Name: "workspace-web"}}, Options{})
 	m.list.Filter("workspace")
-	if got := ansi.Strip(m.header(80)); !strings.Contains(got, "2/2 workspaces") {
-		t.Fatalf("filtered header=%q, want total-aware count", got)
-	}
+	assert.Contains(t, ansi.Strip(m.header(80)), "2/2 workspaces")
 }
 
 func TestTeaModelCyclesHerdrWorkspaceSortModes(t *testing.T) {
@@ -2132,36 +1865,22 @@ func TestTeaModelCyclesHerdrWorkspaceSortModes(t *testing.T) {
 		{Source: "herdr", Name: "third", WorkspaceID: "w3", AgentStatus: "idle"},
 	}
 	m := newTeaModel(items, Options{RecentWorkspaceIDs: []string{"w3", "w1"}})
-	if got, want := sessionNames(m.list.All), []string{"configured", "first", "recent-directory", "second", "third"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("workspace order=%v want %v", got, want)
-	}
+	require.Equal(t, []string{"configured", "first", "recent-directory", "second", "third"}, sessionNames(m.list.All))
 
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"configured", "third", "recent-directory", "first", "second"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("recent order=%v want %v", got, want)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r recent") {
-		t.Fatalf("view missing recent sort mode:\n%s", view)
-	}
+	require.Equal(t, []string{"configured", "third", "recent-directory", "first", "second"}, sessionNames(m.list.All))
+	require.Contains(t, ansi.Strip(m.View().Content), "ctrl+r recent")
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"configured", "second", "recent-directory", "first", "third"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent order=%v want %v", got, want)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r agent") {
-		t.Fatalf("view missing agent sort mode:\n%s", view)
-	}
+	require.Equal(t, []string{"configured", "second", "recent-directory", "first", "third"}, sessionNames(m.list.All))
+	require.Contains(t, ansi.Strip(m.View().Content), "ctrl+r agent")
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"configured", "first", "recent-directory", "second", "third"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("restored workspace order=%v want %v", got, want)
-	}
-	if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r workspace") {
-		t.Fatalf("view missing workspace sort mode:\n%s", view)
-	}
+	require.Equal(t, []string{"configured", "first", "recent-directory", "second", "third"}, sessionNames(m.list.All))
+	assert.Contains(t, ansi.Strip(m.View().Content), "ctrl+r workspace")
 }
 
 func TestTeaModelStartsWithConfiguredWorkspaceSort(t *testing.T) {
@@ -2184,16 +1903,12 @@ func TestTeaModelStartsWithConfiguredWorkspaceSort(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTeaModel(items, Options{RecentWorkspaceIDs: []string{"w2", "w1", "w3"}, WorkspaceSort: tc.mode})
-			if got := sessionNames(m.list.All); !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("initial order=%v want %v", got, tc.want)
-			}
+			require.Equal(t, tc.want, sessionNames(m.list.All))
 			wantMode := tc.mode
 			if wantMode == "" || wantMode == "future" {
 				wantMode = "workspace"
 			}
-			if view := ansi.Strip(m.View().Content); !strings.Contains(view, "ctrl+r "+wantMode) {
-				t.Fatalf("view missing %s sort mode:\n%s", wantMode, view)
-			}
+			assert.Contains(t, ansi.Strip(m.View().Content), "ctrl+r "+wantMode)
 		})
 	}
 }
@@ -2215,9 +1930,7 @@ func TestTeaModelAgentSortRanksStatusesAndPreservesSourceSlots(t *testing.T) {
 	m := newTeaModel(items, Options{WorkspaceSort: "agent"})
 
 	want := []string{"configured", "blocked", "directory", "done", "working-a", "working-b", "idle", "unknown", "agentless", "future"}
-	if got := sessionNames(m.list.All); !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent order=%v want %v", got, want)
-	}
+	assert.Equal(t, want, sessionNames(m.list.All))
 }
 
 func TestTeaModelAgentSortPromotesWorktreeFamilyByBestMember(t *testing.T) {
@@ -2232,9 +1945,7 @@ func TestTeaModelAgentSortPromotesWorktreeFamilyByBestMember(t *testing.T) {
 	m := newTeaModel(items, Options{WorkspaceSort: "agent"})
 
 	want := []string{"parent", "child-blocked", "child-idle", "other", "unresolved"}
-	if got := sessionNames(m.list.All); !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent family order=%v want %v", got, want)
-	}
+	assert.Equal(t, want, sessionNames(m.list.All))
 }
 
 func TestSortHerdrWorkspacesGroupsChildrenBelowParent(t *testing.T) {
@@ -2249,9 +1960,7 @@ func TestSortHerdrWorkspacesGroupsChildrenBelowParent(t *testing.T) {
 
 	sortHerdrWorkspaces(items, []string{"w-child-b", "w-unrelated", "w-parent", "w-child-a"})
 
-	if got, want := sessionNames(items), []string{"configured", "parent", "directory", "child-b", "child-a", "unrelated"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("grouped order=%v want %v", got, want)
-	}
+	assert.Equal(t, []string{"configured", "parent", "directory", "child-b", "child-a", "unrelated"}, sessionNames(items))
 }
 
 func TestSortHerdrWorkspacesRanksFamilyByMostRecentMember(t *testing.T) {
@@ -2264,9 +1973,7 @@ func TestSortHerdrWorkspacesRanksFamilyByMostRecentMember(t *testing.T) {
 
 	sortHerdrWorkspaces(items, []string{"w-child-b", "w-unrelated", "w-parent"})
 
-	if got, want := sessionNames(items), []string{"parent", "child-b", "child-a", "unrelated"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("recent grouped order=%v want %v", got, want)
-	}
+	assert.Equal(t, []string{"parent", "child-b", "child-a", "unrelated"}, sessionNames(items))
 }
 
 func TestSortHerdrWorkspacesLeavesUnresolvedChildIndependent(t *testing.T) {
@@ -2277,9 +1984,7 @@ func TestSortHerdrWorkspacesLeavesUnresolvedChildIndependent(t *testing.T) {
 
 	sortHerdrWorkspaces(items, []string{"w-other", "w-child"})
 
-	if got, want := sessionNames(items), []string{"other", "unresolved"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("unresolved order=%v want %v", got, want)
-	}
+	assert.Equal(t, []string{"other", "unresolved"}, sessionNames(items))
 }
 
 func TestTeaModelGroupsWorktreeFamilyWithoutMutatingInput(t *testing.T) {
@@ -2290,12 +1995,8 @@ func TestTeaModelGroupsWorktreeFamilyWithoutMutatingInput(t *testing.T) {
 
 	m := newTeaModel(items, Options{})
 
-	if got, want := sessionNames(m.list.All), []string{"parent", "child"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("model order=%v want %v", got, want)
-	}
-	if got, want := sessionNames(items), []string{"child", "parent"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("input mutated: got %v want %v", got, want)
-	}
+	require.Equal(t, []string{"parent", "child"}, sessionNames(m.list.All))
+	assert.Equal(t, []string{"child", "parent"}, sessionNames(items))
 }
 
 func TestTeaModelKeepsWorktreeFamilyAcrossSortModes(t *testing.T) {
@@ -2305,27 +2006,19 @@ func TestTeaModelKeepsWorktreeFamilyAcrossSortModes(t *testing.T) {
 		{Source: "herdr", Name: "other", WorkspaceID: "w-other", AgentStatus: "done"},
 	}
 	m := newTeaModel(items, Options{RecentWorkspaceIDs: []string{"w-other", "w-child"}})
-	if got, want := sessionNames(m.list.All), []string{"parent", "child", "other"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("workspace order=%v want %v", got, want)
-	}
+	require.Equal(t, []string{"parent", "child", "other"}, sessionNames(m.list.All))
 
 	updated, _ := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"other", "parent", "child"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("recent order=%v want %v", got, want)
-	}
+	require.Equal(t, []string{"other", "parent", "child"}, sessionNames(m.list.All))
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"parent", "child", "other"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("agent order=%v want %v", got, want)
-	}
+	require.Equal(t, []string{"parent", "child", "other"}, sessionNames(m.list.All))
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
-	if got, want := sessionNames(m.list.All), []string{"parent", "child", "other"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("restored workspace order=%v want %v", got, want)
-	}
+	assert.Equal(t, []string{"parent", "child", "other"}, sessionNames(m.list.All))
 }
 
 func TestTeaModelFilterDoesNotInjectWorktreeParent(t *testing.T) {
@@ -2336,12 +2029,14 @@ func TestTeaModelFilterDoesNotInjectWorktreeParent(t *testing.T) {
 
 	m.list.Filter("feature")
 
-	if got, want := sessionNames(m.list.Filtered), []string{"feature"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("filtered sessions=%v want %v", got, want)
-	}
-	if rowText := ansi.Strip(m.listView(80, 1)); !strings.Contains(rowText, "[↳ herdr]") || !strings.Contains(rowText, "feature") || !strings.Contains(rowText, "/tmp/feature") || strings.Contains(rowText, "worktree of parent") || strings.Contains(rowText, "├─") || strings.Contains(rowText, "└─") {
-		t.Fatalf("filtered child lost standalone path or kept parent-only context: %q", rowText)
-	}
+	require.Equal(t, []string{"feature"}, sessionNames(m.list.Filtered))
+	rowText := ansi.Strip(m.listView(80, 1))
+	require.Contains(t, rowText, "[↳ herdr]")
+	require.Contains(t, rowText, "feature")
+	require.Contains(t, rowText, "/tmp/feature")
+	require.NotContains(t, rowText, "worktree of parent")
+	require.NotContains(t, rowText, "├─")
+	assert.NotContains(t, rowText, "└─")
 }
 
 func TestTeaModelSearchRailDoesNotTruncateAtWindowEdge(t *testing.T) {
@@ -2349,8 +2044,8 @@ func TestTeaModelSearchRailDoesNotTruncateAtWindowEdge(t *testing.T) {
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 28})
 	m = updated.(teaModel)
 	for _, line := range strings.Split(ansi.Strip(m.View().Content), "\n") {
-		if strings.Contains(line, defaultPrompt) && strings.Contains(line, "…") {
-			t.Fatalf("search rail was truncated at the window edge: %q", line)
+		if strings.Contains(line, defaultPrompt) {
+			assert.NotContains(t, line, "…")
 		}
 	}
 }
@@ -2363,18 +2058,16 @@ func TestListViewUsesDirectionalOverflowMarkers(t *testing.T) {
 	m := newTeaModel(items, Options{})
 	m.list.Selected = 10
 	view := ansi.Strip(m.listView(60, 6))
-	if !strings.Contains(view, "↑ 7 more") || !strings.Contains(view, "↓ 9 more") || strings.Contains(view, "...") {
-		t.Fatalf("list view missing directional overflow markers:\n%s", view)
-	}
+	require.Contains(t, view, "↑ 7 more")
+	require.Contains(t, view, "↓ 9 more")
+	assert.NotContains(t, view, "...")
 }
 
 func TestListViewKeepsSelectionVisibleWithTwoRows(t *testing.T) {
 	items := []model.Session{{Name: "workspace-0"}, {Name: "workspace-1"}, {Name: "workspace-2"}, {Name: "workspace-3"}, {Name: "workspace-4"}}
 	m := newTeaModel(items, Options{})
 	m.list.Selected = 2
-	if view := ansi.Strip(m.listView(60, 2)); !strings.Contains(view, "workspace-2") {
-		t.Fatalf("two-row list hid the selected workspace:\n%s", view)
-	}
+	assert.Contains(t, ansi.Strip(m.listView(60, 2)), "workspace-2")
 }
 
 func maxLineWidth(s string) int {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -109,7 +109,7 @@ func TestTeaModelIgnoresMouseOutsidePreviewDivider(t *testing.T) {
 			m.width, m.height = tc.width, 28
 			before := m.View()
 			if tc.hidden || tc.width < previewSplitWidth {
-				assert.Equal(t, tea.MouseModeNone, before.MouseMode, "mouse reporting enabled without a divider")
+				require.Equal(t, tea.MouseModeNone, before.MouseMode, "mouse reporting enabled without a divider")
 			}
 			updated, _ := m.Update(tc.click)
 			m = updated.(teaModel)
@@ -161,13 +161,13 @@ func TestTeaModelCtrlJKMovesSelection(t *testing.T) {
 	m = updated.(teaModel)
 	current, ok := m.list.Current()
 	require.True(t, ok)
-	assert.Equal(t, "web", current.Name)
+	require.Equal(t, "web", current.Name)
 
 	updated, _ = m.Update(tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl})
 	m = updated.(teaModel)
 	current, ok = m.list.Current()
 	require.True(t, ok)
-	assert.Equal(t, "api", current.Name)
+	require.Equal(t, "api", current.Name)
 	updated, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 28})
 	m = updated.(teaModel)
 	view := ansi.Strip(m.View().Content)

--- a/internal/picker/theme_test.go
+++ b/internal/picker/theme_test.go
@@ -4,10 +4,11 @@ import (
 	"image/color"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidHexColor(t *testing.T) {
@@ -28,9 +29,7 @@ func TestValidHexColor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := validHexColor(tt.value); got != tt.want {
-				t.Errorf("validHexColor(%q) = %v, want %v", tt.value, got, tt.want)
-			}
+			assert.Equal(t, tt.want, validHexColor(tt.value))
 		})
 	}
 }
@@ -39,18 +38,14 @@ func TestHerdrConfigPath(t *testing.T) {
 	t.Run("HERDR_CONFIG_PATH wins", func(t *testing.T) {
 		t.Setenv("HERDR_CONFIG_PATH", "/custom/herdr.toml")
 		t.Setenv("XDG_CONFIG_HOME", "/xdg")
-		if got := herdrConfigPath(); got != "/custom/herdr.toml" {
-			t.Errorf("herdrConfigPath() = %q, want /custom/herdr.toml", got)
-		}
+		assert.Equal(t, "/custom/herdr.toml", herdrConfigPath())
 	})
 
 	t.Run("XDG_CONFIG_HOME fallback", func(t *testing.T) {
 		t.Setenv("HERDR_CONFIG_PATH", "")
 		t.Setenv("XDG_CONFIG_HOME", "/xdg")
 		want := filepath.Join("/xdg", "herdr", "config.toml")
-		if got := herdrConfigPath(); got != want {
-			t.Errorf("herdrConfigPath() = %q, want %q", got, want)
-		}
+		assert.Equal(t, want, herdrConfigPath())
 	})
 
 	t.Run("home config fallback", func(t *testing.T) {
@@ -62,9 +57,7 @@ func TestHerdrConfigPath(t *testing.T) {
 			t.Skipf("no home directory: %v", err)
 		}
 		want := filepath.Join(home, ".config", "herdr", "config.toml")
-		if got != want {
-			t.Errorf("herdrConfigPath() = %q, want %q", got, want)
-		}
+		assert.Equal(t, want, got)
 	})
 }
 
@@ -83,36 +76,26 @@ key = "prefix+t"
 type = "plugin_action"
 command = "fullerzz.sesh.open-picker"
 `
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
 		name, custom := loadHerdrThemeConfig(path)
-		if name != "catppuccin" {
-			t.Errorf("loadHerdrThemeConfig() name = %q, want %q", name, "catppuccin")
-		}
+		assert.Equal(t, "catppuccin", name)
 		want := map[string]string{"text": "#cdcdcd"}
-		if !reflect.DeepEqual(custom, want) {
-			t.Errorf("loadHerdrThemeConfig() custom = %v, want %v", custom, want)
-		}
+		assert.Equal(t, want, custom)
 	})
 
 	t.Run("missing file yields empty results", func(t *testing.T) {
 		name, custom := loadHerdrThemeConfig(filepath.Join(t.TempDir(), "absent.toml"))
-		if name != "" || custom != nil {
-			t.Errorf("loadHerdrThemeConfig() = (%q, %v), want empty results", name, custom)
-		}
+		assert.Empty(t, name)
+		assert.Nil(t, custom)
 	})
 
 	t.Run("invalid TOML yields empty results", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config.toml")
-		if err := os.WriteFile(path, []byte("[theme"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
+		require.NoError(t, os.WriteFile(path, []byte("[theme"), 0o600))
 		name, custom := loadHerdrThemeConfig(path)
-		if name != "" || custom != nil {
-			t.Errorf("loadHerdrThemeConfig() = (%q, %v), want empty results", name, custom)
-		}
+		assert.Empty(t, name)
+		assert.Nil(t, custom)
 	})
 }
 
@@ -145,36 +128,20 @@ func TestApplyHerdrTheme(t *testing.T) {
 			"bogus":  "#abcdef",
 		})
 
-		if !reflect.DeepEqual(textColor, lipgloss.Color("#112233")) {
-			t.Errorf("textColor = %v, want #112233", textColor)
-		}
-		if !reflect.DeepEqual(skyColor, lipgloss.Color("#445566")) {
-			t.Errorf("skyColor = %v, want #445566", skyColor)
-		}
-		if redColor != saved[4].value {
-			t.Errorf("redColor = %v, want untouched default %v", redColor, saved[4].value)
-		}
-		if violetColor != saved[6].value {
-			t.Errorf("violetColor = %v, want untouched default %v", violetColor, saved[6].value)
-		}
+		assert.Equal(t, lipgloss.Color("#112233"), textColor)
+		assert.Equal(t, lipgloss.Color("#445566"), skyColor)
+		assert.Equal(t, saved[4].value, redColor)
+		assert.Equal(t, saved[6].value, violetColor)
 
-		if got := rowLabelStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#112233")) {
-			t.Errorf("rowLabelStyle foreground = %v, want #112233", got)
-		}
-		if got := selectedLabelStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#112233")) {
-			t.Errorf("selectedLabelStyle foreground = %v, want #112233", got)
-		}
-		if got := selectionRailStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#445566")) {
-			t.Errorf("selectionRailStyle foreground = %v, want #445566", got)
-		}
+		assert.Equal(t, lipgloss.Color("#112233"), rowLabelStyle.GetForeground())
+		assert.Equal(t, lipgloss.Color("#112233"), selectedLabelStyle.GetForeground())
+		assert.Equal(t, lipgloss.Color("#445566"), selectionRailStyle.GetForeground())
 	})
 
 	t.Run("empty table is a no-op", func(t *testing.T) {
 		before := textColor
 		applyHerdrTheme(map[string]string{})
-		if !reflect.DeepEqual(textColor, before) {
-			t.Errorf("textColor = %v, want unchanged %v", textColor, before)
-		}
+		assert.Equal(t, before, textColor)
 	})
 }
 
@@ -254,14 +221,11 @@ func TestResolveHerdrThemeTokens(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveHerdrThemeTokens(tt.rawName, tt.custom)
 			for token, want := range tt.contains {
-				if got[token] != want {
-					t.Errorf("token %q = %q, want %q", token, got[token], want)
-				}
+				assert.Equal(t, want, got[token])
 			}
 			for _, token := range tt.notContains {
-				if value, ok := got[token]; ok {
-					t.Errorf("token %q = %q, want absent", token, value)
-				}
+				value, ok := got[token]
+				assert.Falsef(t, ok, "token %q = %q, want absent", token, value)
 			}
 		})
 	}
@@ -269,16 +233,11 @@ func TestResolveHerdrThemeTokens(t *testing.T) {
 
 func TestHerdrThemePalettesAreComplete(t *testing.T) {
 	for name, palette := range herdrThemePalettes {
-		if len(palette) != len(herdrTokenRoles) {
-			t.Errorf("palette %q has %d tokens, want %d", name, len(palette), len(herdrTokenRoles))
-		}
+		assert.Len(t, palette, len(herdrTokenRoles), name)
 		for token, value := range palette {
-			if !validHexColor(value) {
-				t.Errorf("palette %q token %q = %q, want #RRGGBB hex", name, token, value)
-			}
-			if _, ok := herdrTokenRoles[token]; !ok {
-				t.Errorf("palette %q token %q is not a picker role", name, token)
-			}
+			assert.Truef(t, validHexColor(value), "palette %q token %q = %q", name, token, value)
+			_, ok := herdrTokenRoles[token]
+			assert.Truef(t, ok, "palette %q token %q is not a picker role", name, token)
 		}
 	}
 }
@@ -286,9 +245,7 @@ func TestHerdrThemePalettesAreComplete(t *testing.T) {
 func TestConfigureHerdrThemeResetsColorsBetweenRuns(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	content := "[theme]\nname = \"dracula\"\n"
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	t.Setenv("HERDR_CONFIG_PATH", path)
 
 	saved := []struct {
@@ -312,9 +269,7 @@ func TestConfigureHerdrThemeResetsColorsBetweenRuns(t *testing.T) {
 	})
 
 	configureHerdrTheme(true)
-	if !reflect.DeepEqual(skyColor, lipgloss.Color("#bd93f9")) {
-		t.Fatalf("enabled run did not apply Dracula accent: %v", skyColor)
-	}
+	require.Equal(t, lipgloss.Color("#bd93f9"), skyColor)
 
 	configureHerdrTheme(false)
 
@@ -333,9 +288,7 @@ func TestConfigureHerdrThemeResetsColorsBetweenRuns(t *testing.T) {
 		{name: "ghost", got: ghostColor, want: lipgloss.Color("#737AA2")},
 	}
 	for _, c := range colors {
-		if !reflect.DeepEqual(c.got, c.want) {
-			t.Errorf("%s color after disabled run = %v, want %v", c.name, c.got, c.want)
-		}
+		assert.Equal(t, c.want, c.got)
 	}
 
 	styles := []struct {
@@ -350,9 +303,7 @@ func TestConfigureHerdrThemeResetsColorsBetweenRuns(t *testing.T) {
 		{name: "empty", got: emptyStyle.GetForeground(), want: lipgloss.Color("#E0AF68")},
 	}
 	for _, s := range styles {
-		if !reflect.DeepEqual(s.got, s.want) {
-			t.Errorf("%s style after disabled run = %v, want %v", s.name, s.got, s.want)
-		}
+		assert.Equal(t, s.want, s.got)
 	}
 }
 
@@ -366,10 +317,6 @@ func TestRebuildPickerStylesTracksColorVars(t *testing.T) {
 	violetColor = lipgloss.Color("#010203")
 	rebuildPickerStyles()
 
-	if got := titleStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#010203")) {
-		t.Errorf("titleStyle foreground = %v, want #010203", got)
-	}
-	if got := smearTrailStyle.GetForeground(); !reflect.DeepEqual(got, lipgloss.Color("#010203")) {
-		t.Errorf("smearTrailStyle foreground = %v, want #010203", got)
-	}
+	assert.Equal(t, lipgloss.Color("#010203"), titleStyle.GetForeground())
+	assert.Equal(t, lipgloss.Color("#010203"), smearTrailStyle.GetForeground())
 }

--- a/internal/preview/preview_test.go
+++ b/internal/preview/preview_test.go
@@ -2,7 +2,6 @@ package preview
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,15 +10,16 @@ import (
 	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenderPaneWithoutRunningWorkspace(t *testing.T) {
 	t.Setenv("HERDR_BIN_PATH", "/does-not-exist")
 	for _, s := range []model.Session{{Source: "config", Path: "/tmp"}, {Source: "herdr"}} {
 		text, err := RenderPane(context.Background(), s)
-		if err != nil || !strings.Contains(text, "only available for running Herdr workspaces") {
-			t.Fatalf("text=%q err=%v", text, err)
-		}
+		require.NoError(t, err)
+		require.Contains(t, text, "only available for running Herdr workspaces")
 	}
 }
 
@@ -35,24 +35,17 @@ case "$*" in
 esac
 `
 	//nolint:gosec // the fake Herdr binary must be executable for this test.
-	if err := os.WriteFile(bin, []byte(script), 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0700))
 	t.Setenv("HERDR_BIN_PATH", bin)
 	text, err := RenderPane(context.Background(), model.Session{Source: "herdr", WorkspaceID: "w2", PreviewCommand: "exit 1"})
-	if err != nil || text != "\x1b[32mterminal output\x1b[0m\n" {
-		t.Fatalf("text=%q err=%v", text, err)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "\x1b[32mterminal output\x1b[0m\n", text)
 }
 
 func TestRenderUsesPreviewCommand(t *testing.T) {
 	out, err := Render(context.Background(), model.Session{Path: "/tmp/has space", PreviewCommand: "printf %s {}"}, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(out) != "/tmp/has space" {
-		t.Fatalf("got %q", out)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/has space", strings.TrimSpace(out))
 }
 
 func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
@@ -77,9 +70,7 @@ func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
 		if _, err := os.Stat(ready); err == nil {
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatal("descendant process did not start")
-		}
+		require.False(t, time.Now().After(deadline), "descendant process did not start")
 		time.Sleep(10 * time.Millisecond)
 	}
 
@@ -89,31 +80,27 @@ func TestRunShellCleansUpDescendantAfterShellExit(t *testing.T) {
 	case runErr = <-done:
 		returned = true
 	case <-time.After(time.Second):
-		t.Error("runShell remained blocked after its shell exited")
+		assert.Fail(t, "runShell remained blocked after its shell exited")
 	}
 	cancel()
-	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(release, []byte("release"), 0600))
 	if !returned {
 		select {
 		case runErr = <-done:
 		case <-time.After(time.Second):
-			t.Fatal("runShell did not return after descendant cleanup")
+			require.FailNow(t, "runShell did not return after descendant cleanup")
 		}
-	}
-	if !errors.Is(runErr, exec.ErrWaitDelay) {
-		t.Errorf("runShell error = %v, want %v", runErr, exec.ErrWaitDelay)
 	}
 	deadline = time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(survived); err == nil {
-			t.Fatal("descendant process survived shell exit and cancellation")
-		} else if !os.IsNotExist(err) {
-			t.Fatal(err)
+			require.FailNow(t, "descendant process survived shell exit and cancellation")
+		} else {
+			require.ErrorIs(t, err, os.ErrNotExist)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	require.ErrorIs(t, runErr, exec.ErrWaitDelay)
 }
 
 func TestRunShellCleansUpRedirectedDescendantAfterShellExit(t *testing.T) {
@@ -127,21 +114,16 @@ func TestRunShellCleansUpRedirectedDescendantAfterShellExit(t *testing.T) {
 	t.Cleanup(func() { _ = os.WriteFile(release, []byte("release"), 0600) })
 
 	_, err := runShell(context.Background(), `sh -c 'printf ready > "$READY_FILE"; while [ ! -e "$RELEASE_FILE" ]; do sleep 0.01; done; printf survived > "$SURVIVED_FILE"' >/dev/null 2>&1 & while [ ! -e "$READY_FILE" ]; do sleep 0.01; done`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(ready); err != nil {
-		t.Fatalf("descendant process did not start: %v", err)
-	}
-	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	_, err = os.Stat(ready)
+	require.NoError(t, err, "descendant process did not start")
+	require.NoError(t, os.WriteFile(release, []byte("release"), 0600))
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(survived); err == nil {
-			t.Fatal("redirected descendant survived shell exit")
-		} else if !os.IsNotExist(err) {
-			t.Fatal(err)
+			require.FailNow(t, "redirected descendant survived shell exit")
+		} else {
+			require.ErrorIs(t, err, os.ErrNotExist)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -169,26 +151,22 @@ func TestRunShellCancellationKillsDescendantProcess(t *testing.T) {
 		if _, err := os.Stat(ready); err == nil {
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatal("descendant process did not start")
-		}
+		require.False(t, time.Now().After(deadline), "descendant process did not start")
 		time.Sleep(10 * time.Millisecond)
 	}
 	cancel()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("runShell remained blocked after cancellation")
+		require.FailNow(t, "runShell remained blocked after cancellation")
 	}
-	if err := os.WriteFile(release, []byte("release"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(release, []byte("release"), 0600))
 	deadline = time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(survived); err == nil {
-			t.Fatal("descendant process survived cancellation")
-		} else if !os.IsNotExist(err) {
-			t.Fatal(err)
+			require.FailNow(t, "descendant process survived cancellation")
+		} else {
+			require.ErrorIs(t, err, os.ErrNotExist)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -196,65 +174,37 @@ func TestRunShellCancellationKillsDescendantProcess(t *testing.T) {
 
 func TestRenderMissingPathWithoutWorkspaceReturnsStableText(t *testing.T) {
 	out, err := Render(context.Background(), model.Session{Name: "api"}, "printf %s {}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "No item path available") {
-		t.Fatalf("missing stable no-path text: %q", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "No item path available")
 }
 
 func TestRenderMissingPathWithWorkspaceReturnsWorkspaceSummary(t *testing.T) {
 	out, err := Render(context.Background(), model.Session{Name: "api", WorkspaceID: "ws1"}, "printf %s {}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "workspace: api") {
-		t.Fatalf("missing workspace name: %q", out)
-	}
-	if !strings.Contains(out, "id: ws1") {
-		t.Fatalf("missing workspace id: %q", out)
-	}
+	require.NoError(t, err)
+	require.Contains(t, out, "workspace: api")
+	assert.Contains(t, out, "id: ws1")
 }
 
 func TestRenderDirectoryFallbackSorted(t *testing.T) {
 	d := t.TempDir()
-	if err := os.WriteFile(filepath.Join(d, "b"), []byte(""), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(d, "a"), []byte(""), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(d, "b"), []byte(""), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "a"), []byte(""), 0600))
 	out, err := Render(context.Background(), model.Session{Path: d}, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "a\nb") {
-		t.Fatalf("not sorted: %q", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "a\nb")
 }
 
 func TestRenderBatUsesBatForReadmePreview(t *testing.T) {
 	d := t.TempDir()
-	if err := os.WriteFile(filepath.Join(d, "README.md"), []byte("hello from readme\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(d, "README.md"), []byte("hello from readme\n"), 0600))
 	bin := t.TempDir()
 	bat := filepath.Join(bin, "bat")
-	if err := os.WriteFile(bat, []byte("#!/bin/sh\nfor last do :; done\nif [ -f \"$last\" ]; then /bin/cat \"$last\"; else /bin/cat; fi\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bat, []byte("#!/bin/sh\nfor last do :; done\nif [ -f \"$last\" ]; then /bin/cat \"$last\"; else /bin/cat; fi\n"), 0600))
 	//nolint:gosec // the fake bat binary must be executable for this test.
-	if err := os.Chmod(bat, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Chmod(bat, 0700))
 	t.Setenv("PATH", bin)
 
 	out, err := RenderBat(context.Background(), model.Session{Path: d})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "hello from readme") {
-		t.Fatalf("preview missing readme content: %q", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "hello from readme")
 }

--- a/internal/sources/config_sessions_test.go
+++ b/internal/sources/config_sessions_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigSessionsExpandsHomePaths(t *testing.T) {
@@ -19,19 +21,12 @@ func TestConfigSessionsExpandsHomePaths(t *testing.T) {
 	}
 
 	got, err := ConfigSessions{Config: cfg, Home: "/home/zach"}.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessions := got.Ordered()
-	if len(sessions) != 1 {
-		t.Fatalf("got %d sessions", len(sessions))
-	}
-	if sessions[0].Path != "/home/zach/projects/api" {
-		t.Fatalf("session path = %q", sessions[0].Path)
-	}
-	if len(sessions[0].WindowConfigs) != 1 || sessions[0].WindowConfigs[0].Path != "/home/zach/projects/api/logs" {
-		t.Fatalf("window configs = %#v", sessions[0].WindowConfigs)
-	}
+	require.Len(t, sessions, 1)
+	require.Equal(t, "/home/zach/projects/api", sessions[0].Path)
+	require.Len(t, sessions[0].WindowConfigs, 1)
+	assert.Equal(t, "/home/zach/projects/api/logs", sessions[0].WindowConfigs[0].Path)
 }
 
 func TestApplyConfigAttachesWildcardWindows(t *testing.T) {
@@ -45,9 +40,9 @@ func TestApplyConfigAttachesWildcardWindows(t *testing.T) {
 	ApplyConfig(&sessions, cfg, "/home/zach")
 
 	got := sessions.Ordered()[0]
-	if len(got.WindowConfigs) != 1 || got.WindowConfigs[0].Name != "logs" || got.WindowConfigs[0].Path != "/home/zach/projects/api/logs" {
-		t.Fatalf("window configs = %#v", got.WindowConfigs)
-	}
+	require.Len(t, got.WindowConfigs, 1)
+	require.Equal(t, "logs", got.WindowConfigs[0].Name)
+	assert.Equal(t, "/home/zach/projects/api/logs", got.WindowConfigs[0].Path)
 }
 
 func TestApplyConfigWildcardDisablePrecedesStartupFallback(t *testing.T) {
@@ -66,10 +61,8 @@ func TestApplyConfigWildcardDisablePrecedesStartupFallback(t *testing.T) {
 	ApplyConfig(&sessions, cfg, "")
 
 	got := sessions.Ordered()
-	if !got[0].DisableStartupCommand || got[0].StartupCommand != "configured" {
-		t.Fatalf("explicit session = %#v", got[0])
-	}
-	if !got[1].DisableStartupCommand || got[1].StartupCommand != "" {
-		t.Fatalf("fallback session = %#v", got[1])
-	}
+	require.True(t, got[0].DisableStartupCommand)
+	require.Equal(t, "configured", got[0].StartupCommand)
+	require.True(t, got[1].DisableStartupCommand)
+	assert.Empty(t, got[1].StartupCommand)
 }

--- a/internal/sources/herdr_workspaces_benchmark_test.go
+++ b/internal/sources/herdr_workspaces_benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -60,9 +61,7 @@ func BenchmarkHerdrWorkspacesList(b *testing.B) {
 	for _, missingPath := range []bool{false, true} {
 		b.Run(benchmarkPathCase(missingPath), func(b *testing.B) {
 			workspaceJSON, paneJSON, err := benchmarkHerdrPayloads(missingPath)
-			if err != nil {
-				b.Fatal(err)
-			}
+			require.NoError(b, err)
 			runner := &benchmarkHerdrRunner{workspaces: workspaceJSON, panes: paneJSON}
 			source := HerdrWorkspaces{Client: &herdr.CLIClient{Bin: "herdr", Runner: runner, Timeout: time.Second}}
 			runHerdrWorkspacesBenchmark(b, source, &runner.calls)
@@ -87,11 +86,12 @@ func runHerdrWorkspacesBenchmark(b *testing.B, source HerdrWorkspaces, calls *in
 	b.ReportAllocs()
 	for b.Loop() {
 		sessions, err := source.List(context.Background())
+		// Keep assertion overhead off the measured success path.
 		if err != nil {
-			b.Fatal(err)
+			require.NoError(b, err)
 		}
 		if len(sessions.OrderedIndex) != benchmarkWorkspaceCount {
-			b.Fatalf("sessions=%d, want %d", len(sessions.OrderedIndex), benchmarkWorkspaceCount)
+			require.Len(b, sessions.OrderedIndex, benchmarkWorkspaceCount)
 		}
 	}
 	b.ReportMetric(float64(*calls)/float64(b.N), "commands/op")

--- a/internal/sources/herdr_workspaces_test.go
+++ b/internal/sources/herdr_workspaces_test.go
@@ -28,7 +28,7 @@ func TestHerdrWorkspacesSkipsPaneListWhenWorkspaceHasPath(t *testing.T) {
 
 	got, err := (HerdrWorkspaces{Client: client}).List(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 0, client.paneListCalls)
+	require.Zero(t, client.paneListCalls)
 	paths := got.Ordered()
 	require.Len(t, paths, 2)
 	require.Equal(t, "/tmp/foreground", paths[0].Path)

--- a/internal/sources/herdr_workspaces_test.go
+++ b/internal/sources/herdr_workspaces_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type countingHerdrClient struct {
@@ -25,16 +27,12 @@ func TestHerdrWorkspacesSkipsPaneListWhenWorkspaceHasPath(t *testing.T) {
 	}}}
 
 	got, err := (HerdrWorkspaces{Client: client}).List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if client.paneListCalls != 0 {
-		t.Fatalf("PaneList calls=%d, want 0", client.paneListCalls)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 0, client.paneListCalls)
 	paths := got.Ordered()
-	if len(paths) != 2 || paths[0].Path != "/tmp/foreground" || paths[1].Path != "/tmp/cwd" {
-		t.Fatalf("sessions=%#v", paths)
-	}
+	require.Len(t, paths, 2)
+	require.Equal(t, "/tmp/foreground", paths[0].Path)
+	assert.Equal(t, "/tmp/cwd", paths[1].Path)
 }
 
 func TestHerdrWorkspacesRelatesLinkedWorktreeToUniqueParent(t *testing.T) {
@@ -46,21 +44,17 @@ func TestHerdrWorkspacesRelatesLinkedWorktreeToUniqueParent(t *testing.T) {
 	}}}
 
 	got, err := src.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessions := got.Ordered()
-	if len(sessions) != 3 {
-		t.Fatalf("sessions=%#v", sessions)
-	}
+	require.Len(t, sessions, 3)
 	child := sessions[0]
-	if !child.Worktree.Linked || child.Worktree.ParentWorkspaceID != "w-parent" || child.Worktree.ParentWorkspaceName != "project" {
-		t.Fatalf("child relation=%#v", child.Worktree)
-	}
+	require.True(t, child.Worktree.Linked)
+	require.Equal(t, "w-parent", child.Worktree.ParentWorkspaceID)
+	require.Equal(t, "project", child.Worktree.ParentWorkspaceName)
 	for _, normal := range sessions[1:] {
-		if normal.Worktree.Linked || normal.Worktree.ParentWorkspaceID != "" || normal.Worktree.ParentWorkspaceName != "" {
-			t.Fatalf("normal workspace %q has relation %#v", normal.Name, normal.Worktree)
-		}
+		require.False(t, normal.Worktree.Linked)
+		require.Empty(t, normal.Worktree.ParentWorkspaceID)
+		require.Empty(t, normal.Worktree.ParentWorkspaceName)
 	}
 }
 
@@ -96,13 +90,11 @@ func TestHerdrWorkspacesFallsBackForUnresolvedLinkedWorktree(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			src := HerdrWorkspaces{Client: &herdr.FakeClient{Workspaces: tt.workspaces}}
 			got, err := src.List(context.Background())
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			child := got.Ordered()[0]
-			if !child.Worktree.Linked || child.Worktree.ParentWorkspaceID != "" || child.Worktree.ParentWorkspaceName != "" {
-				t.Fatalf("child relation=%#v", child.Worktree)
-			}
+			require.True(t, child.Worktree.Linked)
+			require.Empty(t, child.Worktree.ParentWorkspaceID)
+			assert.Empty(t, child.Worktree.ParentWorkspaceName)
 		})
 	}
 }
@@ -114,13 +106,9 @@ func TestHerdrWorkspacesUsesParentIDWhenLabelIsEmpty(t *testing.T) {
 		{ID: "w-child", Label: "feature", Worktree: &herdr.Worktree{IsLinkedWorktree: true, RepoKey: repo}},
 	}}}
 	got, err := src.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	child := got.Ordered()[1]
-	if child.Worktree.ParentWorkspaceName != "w-parent" {
-		t.Fatalf("child relation=%#v", child.Worktree)
-	}
+	assert.Equal(t, "w-parent", child.Worktree.ParentWorkspaceName)
 }
 
 func TestHerdrWorkspacesUsesLinkedWorktreeCheckoutPathAsFallback(t *testing.T) {
@@ -134,13 +122,10 @@ func TestHerdrWorkspacesUsesLinkedWorktreeCheckoutPathAsFallback(t *testing.T) {
 	}}}}
 
 	got, err := src.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessions := got.Ordered()
-	if len(sessions) != 1 || sessions[0].Path != "/worktrees/feature" {
-		t.Fatalf("sessions=%#v", sessions)
-	}
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "/worktrees/feature", sessions[0].Path)
 }
 
 func TestHerdrWorkspacesUsesPaneCWDWhenWorkspaceListOmitsPath(t *testing.T) {
@@ -152,11 +137,9 @@ func TestHerdrWorkspacesUsesPaneCWDWhenWorkspaceListOmitsPath(t *testing.T) {
 		},
 	}}
 	got, err := src.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessions := got.Ordered()
-	if len(sessions) != 1 || sessions[0].Path != "/tmp/api" || sessions[0].AgentStatus != "working" {
-		t.Fatalf("sessions=%#v", sessions)
-	}
+	require.Len(t, sessions, 1)
+	require.Equal(t, "/tmp/api", sessions[0].Path)
+	assert.Equal(t, "working", sessions[0].AgentStatus)
 }

--- a/internal/sources/merge_test.go
+++ b/internal/sources/merge_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type staticSource struct {
@@ -23,17 +25,16 @@ func (s staticSource) List(context.Context) (model.Sessions, error) {
 func TestMergeOrderBlacklistDedupe(t *testing.T) {
 	srcs := []Source{staticSource{"zoxide", []model.Session{{Source: "zoxide", Name: "api", Path: "/z"}}}, staticSource{"config", []model.Session{{Source: "config", Name: "api", Path: "/c"}, {Source: "config", Name: "scratch", Path: "/s"}}}}
 	got, err := Merge(context.Background(), srcs, []string{"config", "zoxide"}, []string{"scratch"}, false, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	os := got.Ordered()
-	if len(os) != 1 || os[0].Source != "config" || os[0].Name != "api" {
-		t.Fatalf("bad merge %#v", os)
-	}
+	require.Len(t, os, 1)
+	require.Equal(t, "config", os[0].Source)
+	assert.Equal(t, "api", os[0].Name)
 }
 func TestParseZoxideLine(t *testing.T) {
 	s, ok := ParseZoxideLine("42.5 /tmp/my app")
-	if !ok || s.Score != 42.5 || s.Path != "/tmp/my app" || s.Name != "my app" {
-		t.Fatalf("bad parse %#v %v", s, ok)
-	}
+	require.True(t, ok)
+	require.InDelta(t, 42.5, s.Score, 0)
+	require.Equal(t, "/tmp/my app", s.Path)
+	assert.Equal(t, "my app", s.Name)
 }

--- a/internal/startup/startup_test.go
+++ b/internal/startup/startup_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/herdr"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyCreatesTabsAndRunsCommands(t *testing.T) {
@@ -14,36 +16,24 @@ func TestApplyCreatesTabsAndRunsCommands(t *testing.T) {
 		Path: "/tmp/app", StartupCommand: "echo {}",
 		WindowConfigs: []model.WindowConfig{{Name: "git", StartupScript: "git -C {} status"}},
 	}
-	if err := Apply(context.Background(), f, Plan{WorkspaceID: "ws1", Session: s}); err != nil {
-		t.Fatal(err)
-	}
-	if len(f.CreatedTabs) != 1 || f.CreatedTabs[0].Label != "git" {
-		t.Fatalf("tabs: %#v", f.CreatedTabs)
-	}
-	if len(f.PaneRuns) != 2 {
-		t.Fatalf("pane runs: %#v", f.PaneRuns)
-	}
+	require.NoError(t, Apply(context.Background(), f, Plan{WorkspaceID: "ws1", Session: s}))
+	require.Len(t, f.CreatedTabs, 1)
+	require.Equal(t, "git", f.CreatedTabs[0].Label)
+	require.Len(t, f.PaneRuns, 2)
 }
 
 func TestApplySkipsDisabledStartup(t *testing.T) {
 	f := &herdr.FakeClient{}
 	s := model.Session{Path: "/tmp/app", StartupCommand: "echo hi", DisableStartupCommand: true}
-	if err := Apply(context.Background(), f, Plan{WorkspaceID: "ws1", Session: s}); err != nil {
-		t.Fatal(err)
-	}
-	if len(f.PaneRuns) != 0 {
-		t.Fatalf("unexpected pane runs: %#v", f.PaneRuns)
-	}
+	require.NoError(t, Apply(context.Background(), f, Plan{WorkspaceID: "ws1", Session: s}))
+	assert.Empty(t, f.PaneRuns)
 }
 
 func TestApplyFailsClearlyWhenOnlyOffTargetPaneExists(t *testing.T) {
 	f := &herdr.FakeClient{Panes: []herdr.Pane{{ID: "existing-pane", WorkspaceID: "existing-workspace"}}}
 	s := model.Session{Path: "/tmp/app", StartupCommand: "echo hi"}
 	err := Apply(context.Background(), f, Plan{WorkspaceID: "new-workspace", Session: s})
-	if err == nil || err.Error() != `no pane available in workspace "new-workspace"` {
-		t.Fatalf("error = %v", err)
-	}
-	if len(f.PaneRuns) != 0 {
-		t.Fatalf("unexpected pane runs: %#v", f.PaneRuns)
-	}
+	require.Error(t, err)
+	require.Equal(t, `no pane available in workspace "new-workspace"`, err.Error())
+	assert.Empty(t, f.PaneRuns)
 }

--- a/internal/state/cache_test.go
+++ b/internal/state/cache_test.go
@@ -5,56 +5,41 @@ import (
 	"time"
 
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSessionCacheUsesFreshEntries(t *testing.T) {
 	d := t.TempDir()
 	want := []model.Session{{Source: "config", Name: "api", Path: "/tmp/api"}}
-	if err := SaveSessionCache(d, "/tmp/sesh.toml", want, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveSessionCache(d, "/tmp/sesh.toml", want, time.Now()))
 	got, ok, err := LoadSessionCache(d, "/tmp/sesh.toml", 5*time.Second, time.Now())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || len(got) != 1 || got[0].Name != "api" {
-		t.Fatalf("got=%#v ok=%v", got, ok)
-	}
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, got, 1)
+	assert.Equal(t, "api", got[0].Name)
 }
 
 func TestSessionCacheIgnoresStaleEntries(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveSessionCache(d, "", []model.Session{{Name: "old"}}, time.Unix(0, 0)); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveSessionCache(d, "", []model.Session{{Name: "old"}}, time.Unix(0, 0)))
 	got, ok, err := LoadSessionCache(d, "", time.Second, time.Unix(10, 0))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || got != nil {
-		t.Fatalf("expected stale cache miss, got=%#v ok=%v", got, ok)
-	}
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
 }
 
 func TestSessionCacheMissWhenMissing(t *testing.T) {
 	got, ok, err := LoadSessionCache(t.TempDir(), "", time.Second, time.Now())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || got != nil {
-		t.Fatalf("expected cache miss, got=%#v ok=%v", got, ok)
-	}
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
 }
 
 func TestSessionCacheNoopsWithoutStateDir(t *testing.T) {
-	if err := SaveSessionCache("", "", []model.Session{{Name: "api"}}, time.Now()); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveSessionCache("", "", []model.Session{{Name: "api"}}, time.Now()))
 	got, ok, err := LoadSessionCache("", "", time.Second, time.Now())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || got != nil {
-		t.Fatalf("expected cache miss, got=%#v ok=%v", got, ok)
-	}
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
 }

--- a/internal/state/history_test.go
+++ b/internal/state/history_test.go
@@ -2,116 +2,71 @@ package state
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSessionHistoryDirIsolatesSockets(t *testing.T) {
 	stateDir := t.TempDir()
 	firstDir, err := SessionHistoryDir(stateDir, "/tmp/herdr-a.sock")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	secondDir, err := SessionHistoryDir(stateDir, "/tmp/herdr-b.sock")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if firstDir == secondDir {
-		t.Fatalf("session history dirs are shared: %q", firstDir)
-	}
+	require.NoError(t, err)
+	require.NotEqual(t, secondDir, firstDir)
 
-	if err := SaveHistory(firstDir, History{Workspaces: []string{"w1", "first-only"}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := SaveHistory(secondDir, History{Workspaces: []string{"w1", "second-only"}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := RecordSwitch(firstDir, "w1", "first-only"); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveWorkspace(secondDir, "w1"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(firstDir, History{Workspaces: []string{"w1", "first-only"}}))
+	require.NoError(t, SaveHistory(secondDir, History{Workspaces: []string{"w1", "second-only"}}))
+	require.NoError(t, RecordSwitch(firstDir, "w1", "first-only"))
+	require.NoError(t, RemoveWorkspace(secondDir, "w1"))
 
 	first, err := LoadHistory(firstDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	second, err := LoadHistory(secondDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := []string{"first-only", "w1"}; !reflect.DeepEqual(first.Workspaces, want) {
-		t.Fatalf("first workspaces=%#v want %#v", first.Workspaces, want)
-	}
-	if want := []string{"second-only"}; !reflect.DeepEqual(second.Workspaces, want) {
-		t.Fatalf("second workspaces=%#v want %#v", second.Workspaces, want)
-	}
+	require.NoError(t, err)
+	require.Equal(t, []string{"first-only", "w1"}, first.Workspaces)
+	assert.Equal(t, []string{"second-only"}, second.Workspaces)
 }
 
 func TestSessionHistoryDirMigratesOnlyDefaultSessionHistory(t *testing.T) {
 	stateDir := t.TempDir()
 	legacy := History{Workspaces: []string{"current", "previous"}}
-	if err := SaveHistory(stateDir, legacy); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(stateDir, legacy))
 
 	namedDir, err := SessionHistoryDir(stateDir, filepath.Join("/config", "herdr", "sessions", "work", "herdr.sock"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	named, err := LoadHistory(namedDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(named.Workspaces) != 0 {
-		t.Fatalf("named session imported legacy history: %#v", named.Workspaces)
-	}
+	require.NoError(t, err)
+	require.Empty(t, named.Workspaces)
 
 	defaultDir, err := SessionHistoryDir(stateDir, filepath.Join("/config", "herdr", "herdr.sock"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	migrated, err := LoadHistory(defaultDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(migrated, legacy) {
-		t.Fatalf("migrated history=%#v want %#v", migrated, legacy)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, legacy, migrated)
 }
 
 func TestSessionHistoryDirMigrationWaitsForDestinationLock(t *testing.T) {
 	stateDir := t.TempDir()
 	socketPath := filepath.Join(t.TempDir(), "herdr", "herdr.sock")
 	sessionDir, err := SessionHistoryDir(stateDir, socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	legacy := History{Workspaces: []string{"legacy"}}
-	if err := SaveHistory(stateDir, legacy); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(sessionDir, 0700); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(stateDir, legacy))
+	require.NoError(t, os.MkdirAll(sessionDir, 0700))
 
 	//nolint:gosec // Test lock path is derived from t.TempDir().
 	lock, err := os.OpenFile(filepath.Join(sessionDir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = lock.Close() }()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_EX))
 	locked := true
 	defer func() {
 		if locked {
@@ -126,72 +81,43 @@ func TestSessionHistoryDirMigrationWaitsForDestinationLock(t *testing.T) {
 	}()
 	select {
 	case err := <-done:
-		t.Fatalf("migration bypassed destination lock: %v", err)
+		require.FailNow(t, fmt.Sprintf("migration bypassed destination lock: %v", err))
 	case <-time.After(100 * time.Millisecond):
 	}
 
 	concurrent := History{Workspaces: []string{"concurrent"}}
-	if err := writeJSONFile(Path(sessionDir), concurrent); err != nil {
-		t.Fatal(err)
-	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, writeJSONFile(Path(sessionDir), concurrent))
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))
 	locked = false
-	if err := <-done; err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, <-done)
 
 	got, err := LoadHistory(sessionDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(got, concurrent) {
-		t.Fatalf("migrated history=%#v want concurrent history %#v", got, concurrent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, concurrent, got)
 }
 
 func TestHistoryRecordsMostRecentWithoutDuplicates(t *testing.T) {
 	d := t.TempDir()
-	if err := Record(d, "a"); err != nil {
-		t.Fatal(err)
-	}
-	if err := Record(d, "b"); err != nil {
-		t.Fatal(err)
-	}
-	if err := Record(d, "b"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, Record(d, "a"))
+	require.NoError(t, Record(d, "b"))
+	require.NoError(t, Record(d, "b"))
 	last, ok, err := Last(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || last != "a" {
-		t.Fatalf("last=%q ok=%v", last, ok)
-	}
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "a", last)
 }
 
 func TestRecordKeepsCurrentHistoryFile(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveHistory(d, History{Workspaces: []string{"current", "older"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(d, History{Workspaces: []string{"current", "older"}}))
 	before, err := os.Stat(Path(d))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if err := Record(d, "current"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, Record(d, "current"))
 
 	after, err := os.Stat(Path(d))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !os.SameFile(before, after) {
-		t.Fatal("Record rewrote history.json for the current workspace")
-	}
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(before, after), "Record rewrote history.json for the current workspace")
 }
 
 func TestHistoryMutationsWaitForProcessLock(t *testing.T) {
@@ -228,9 +154,7 @@ func TestHistoryMutationsWaitForProcessLock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := t.TempDir()
 			if tc.setup != nil {
-				if err := tc.setup(d); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, tc.setup(d))
 			}
 			assertHistoryMutationWaitsForLock(t, d, tc.action)
 		})
@@ -241,13 +165,9 @@ func TestHistoryMutationTimesOutWaitingForProcessLock(t *testing.T) {
 	d := t.TempDir()
 	//nolint:gosec // Test lock path is derived from t.TempDir().
 	lock, err := os.OpenFile(filepath.Join(d, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = lock.Close() }()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_EX))
 	locked := true
 	defer func() {
 		if locked {
@@ -259,16 +179,12 @@ func TestHistoryMutationTimesOutWaitingForProcessLock(t *testing.T) {
 	go func() { done <- Record(d, "blocked") }()
 	select {
 	case err := <-done:
-		if !errors.Is(err, ErrHistoryLockTimeout) {
-			t.Fatalf("err=%v, want history lock timeout", err)
-		}
+		require.ErrorIs(t, err, ErrHistoryLockTimeout)
 	case <-time.After(2 * time.Second):
-		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))
 		locked = false
 		<-done
-		t.Fatal("history mutation remained blocked for two seconds")
+		require.FailNow(t, "history mutation remained blocked for two seconds")
 	}
 }
 
@@ -276,17 +192,11 @@ func assertHistoryMutationWaitsForLock(t *testing.T, dir, action string) {
 	t.Helper()
 	//nolint:gosec // Test lock path is derived from t.TempDir().
 	lock, err := os.OpenFile(filepath.Join(dir, "history.lock"), os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		if err := lock.Close(); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, lock.Close())
 	})
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_EX))
 	locked := true
 	defer func() {
 		if locked {
@@ -298,12 +208,8 @@ func assertHistoryMutationWaitsForLock(t *testing.T, dir, action string) {
 	cmd := exec.Command(os.Args[0], "-test.run=^TestHistoryMutationsWaitForProcessLock$")
 	cmd.Env = append(os.Environ(), "HERDR_SESH_HISTORY_LOCK_HELPER=1", "HERDR_SESH_HISTORY_LOCK_DIR="+dir, "HERDR_SESH_HISTORY_LOCK_ACTION="+action)
 	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
 	waitDone := make(chan struct{})
 	var waitErr error
 	go func() {
@@ -320,7 +226,7 @@ func assertHistoryMutationWaitsForLock(t *testing.T, dir, action string) {
 		select {
 		case <-waitDone:
 		case <-time.After(time.Second):
-			t.Error("history mutation helper did not exit after being killed")
+			assert.Fail(t, "history mutation helper did not exit after being killed")
 		}
 	})
 
@@ -333,34 +239,28 @@ func assertHistoryMutationWaitsForLock(t *testing.T, dir, action string) {
 	}()
 	select {
 	case line := <-lines:
-		if line != "ready" {
-			t.Fatalf("helper readiness = %q", line)
-		}
+		require.Equal(t, "ready", line)
 	case <-time.After(time.Second):
-		t.Fatal("history mutation helper did not start")
+		require.FailNow(t, "history mutation helper did not start")
 	}
 
 	select {
 	case line := <-lines:
-		t.Fatalf("history mutation bypassed held process lock: %q", line)
+		require.FailNow(t, fmt.Sprintf("history mutation bypassed held process lock: %q", line))
 	case <-time.After(100 * time.Millisecond):
 	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, syscall.Flock(int(lock.Fd()), syscall.LOCK_UN))
 	locked = false
 	select {
 	case <-waitDone:
-		if waitErr != nil {
-			t.Fatal(waitErr)
-		}
+		require.NoError(t, waitErr)
 	case <-time.After(2 * time.Second):
 		_ = cmd.Process.Kill()
 		select {
 		case <-waitDone:
-			t.Fatalf("history mutation helper did not exit after lock release: %v", waitErr)
+			require.FailNow(t, fmt.Sprintf("history mutation helper did not exit after lock release: %v", waitErr))
 		case <-time.After(time.Second):
-			t.Fatal("history mutation helper did not exit after being killed")
+			require.FailNow(t, "history mutation helper did not exit after being killed")
 		}
 	}
 }
@@ -381,102 +281,62 @@ func runHistoryLockHelper(t *testing.T) {
 	case "save-history":
 		mutateErr = SaveHistory(dir, History{Workspaces: []string{"saved"}})
 	default:
-		t.Fatalf("unknown helper action %q", action)
+		require.FailNow(t, fmt.Sprintf("unknown helper action %q", action))
 	}
-	if mutateErr != nil {
-		t.Fatal(mutateErr)
-	}
+	require.NoError(t, mutateErr)
 	fmt.Println("done")
 }
 
 func TestHistoryNoopsWithoutStateDir(t *testing.T) {
-	if err := Record("", "ws1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := RecordSwitch("", "ws1", "ws2"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, Record("", "ws1"))
+	require.NoError(t, RecordSwitch("", "ws1", "ws2"))
 	last, ok, err := Last("")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || last != "" {
-		t.Fatalf("last=%q ok=%v", last, ok)
-	}
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, last)
 	previous, ok, err := Previous("", "ws1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || previous != "" {
-		t.Fatalf("previous=%q ok=%v", previous, ok)
-	}
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Empty(t, previous)
 }
 
 func TestRecordRecoversCorruptHistory(t *testing.T) {
 	d := t.TempDir()
-	if err := os.WriteFile(filepath.Join(d, "history.json"), []byte("{"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := Record(d, "ws1"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(d, "history.json"), []byte("{"), 0600))
+	require.NoError(t, Record(d, "ws1"))
 	h, err := LoadHistory(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(h.Workspaces) != 1 || h.Workspaces[0] != "ws1" {
-		t.Fatalf("history=%#v", h)
-	}
+	require.NoError(t, err)
+	require.Len(t, h.Workspaces, 1)
+	assert.Equal(t, "ws1", h.Workspaces[0])
 }
 
 func TestPreviousSkipsCurrentWorkspace(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}))
 	previous, ok, err := Previous(d, "current")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || previous != "previous" {
-		t.Fatalf("previous=%q ok=%v", previous, ok)
-	}
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "previous", previous)
 }
 
 func TestRecordSwitchRotatesPreviousWorkspace(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := RecordSwitch(d, "current", "previous"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(d, History{Workspaces: []string{"current", "previous", "older"}}))
+	require.NoError(t, RecordSwitch(d, "current", "previous"))
 	h, err := LoadHistory(d)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := []string{"previous", "current", "older"}
-	if !reflect.DeepEqual(h.Workspaces, want) {
-		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
-	}
+	assert.Equal(t, want, h.Workspaces)
 }
 
 func TestRemoveWorkspacePrunesHistory(t *testing.T) {
 	d := t.TempDir()
-	if err := SaveHistory(d, History{Workspaces: []string{"current", "closed", "older"}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveWorkspace(d, "closed"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(d, History{Workspaces: []string{"current", "closed", "older"}}))
+	require.NoError(t, RemoveWorkspace(d, "closed"))
 	h, err := LoadHistory(d)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := []string{"current", "older"}
-	if !reflect.DeepEqual(h.Workspaces, want) {
-		t.Fatalf("workspaces=%#v want %#v", h.Workspaces, want)
-	}
+	assert.Equal(t, want, h.Workspaces)
 }
 
 func TestRecordSwitchDeduplicatesAndCapsHistory(t *testing.T) {
@@ -485,27 +345,16 @@ func TestRecordSwitchDeduplicatesAndCapsHistory(t *testing.T) {
 	for i := 0; i < maxWorkspaces+20; i++ {
 		workspaces = append(workspaces, fmt.Sprintf("ws-%02d", i))
 	}
-	if err := SaveHistory(d, History{Workspaces: workspaces}); err != nil {
-		t.Fatal(err)
-	}
-	if err := RecordSwitch(d, "from", "target"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, SaveHistory(d, History{Workspaces: workspaces}))
+	require.NoError(t, RecordSwitch(d, "from", "target"))
 	h, err := LoadHistory(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(h.Workspaces) != maxWorkspaces {
-		t.Fatalf("len=%d want %d", len(h.Workspaces), maxWorkspaces)
-	}
-	if h.Workspaces[0] != "target" || h.Workspaces[1] != "from" {
-		t.Fatalf("workspaces start=%#v", h.Workspaces[:2])
-	}
+	require.NoError(t, err)
+	require.Len(t, h.Workspaces, maxWorkspaces)
+	require.Equal(t, "target", h.Workspaces[0])
+	require.Equal(t, "from", h.Workspaces[1])
 	seen := map[string]bool{}
 	for _, id := range h.Workspaces {
-		if seen[id] {
-			t.Fatalf("duplicate workspace %q in %#v", id, h.Workspaces)
-		}
+		require.False(t, seen[id])
 		seen[id] = true
 	}
 }


### PR DESCRIPTION
## Summary

Replace manual assertions across all 26 Go test files with Testify `require` and `assert` for clearer failures and less repetition. Preserve prerequisite guards, worker error propagation, process cleanup, and benchmark success-path overhead.

Enable all `testifylint` checkers, document assertion conventions in `AGENTS.md`, and replace the mutating configuration comparison helper with structural equality assertions. Production behavior is unchanged.

## Related issue

N/A

## Validation

- [x] `just check` — 464 tests passed
- [x] `just build`
- [x] `just build-docs`
- `go test -race -count=1 ./...` — passed during review
- `go test -run '^$' -bench=. -benchtime=1x ./internal/sources ./internal/picker`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `mise exec -- golangci-lint config verify`

## User-facing changes

N/A. Contributor testing guidance is updated in `AGENTS.md`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fullerzz/herdr-plugin-sesh/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

