### PR TITLE
feat: make preview mode keybinding configurable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -201,7 +201,10 @@ cycle_preview_mode = "ctrl+o"
 `cycle_preview_mode` changes the native picker's preview-mode shortcut. Omit it
 for `"ctrl+o"`, choose a key such as `"alt+p"` or `"f2"`, or set it to `""` to
 disable cycling and hide the shortcut hint. Key names use Bubble Tea's exact,
-case-sensitive spelling, with modifiers joined by `+`. The configured shortcut
+case-sensitive spelling: a single printable character or a named key, with
+modifiers joined by `+` in `ctrl`, `alt`, `shift`, `meta`, `hyper`, `super` order.
+Unsupported names, duplicate modifiers, and incorrect modifier order are rejected
+as configuration errors. The configured shortcut
 takes precedence over other native picker bindings, so choose an unused key.
 Disabling cycling leaves the initial `[picker].preview_mode` in effect and
 returns keys to their normal picker/input handling. This does not affect fzf or

--- a/docs/config.md
+++ b/docs/config.md
@@ -207,7 +207,9 @@ Unsupported names, duplicate modifiers, and incorrect modifier order are rejecte
 as configuration errors. For shifted printable keys, configure the resulting
 character (`"P"` rather than `"shift+p"`, or `"?"` rather than `"shift+/"`).
 Shift-only printable spellings are rejected because key events report the text;
-combinations such as `"ctrl+shift+p"` and `"shift+f2"` remain valid.
+combinations such as `"ctrl+shift+p"` and `"shift+f2"` remain valid. When Shift is
+combined with other modifiers, use the unshifted base key: `"ctrl+shift+p"`, not
+`"ctrl+shift+P"`, and `"alt+shift+/"`, not `"alt+shift+?"`.
 The configured shortcut
 takes precedence over other native picker bindings, so choose an unused key.
 Disabling cycling leaves the initial `[picker].preview_mode` in effect and

--- a/docs/config.md
+++ b/docs/config.md
@@ -204,7 +204,11 @@ disable cycling and hide the shortcut hint. Key names use Bubble Tea's exact,
 case-sensitive spelling: a single printable character or a named key, with
 modifiers joined by `+` in `ctrl`, `alt`, `shift`, `meta`, `hyper`, `super` order.
 Unsupported names, duplicate modifiers, and incorrect modifier order are rejected
-as configuration errors. The configured shortcut
+as configuration errors. For shifted printable keys, configure the resulting
+character (`"P"` rather than `"shift+p"`, or `"?"` rather than `"shift+/"`).
+Shift-only printable spellings are rejected because key events report the text;
+combinations such as `"ctrl+shift+p"` and `"shift+f2"` remain valid.
+The configured shortcut
 takes precedence over other native picker bindings, so choose an unused key.
 Disabling cycling leaves the initial `[picker].preview_mode` in effect and
 returns keys to their normal picker/input handling. This does not affect fzf or

--- a/docs/config.md
+++ b/docs/config.md
@@ -191,13 +191,29 @@ equivalent; native decoding rejects them like any other unknown key.
 | --- | --- |
 | `path_components` | Sets the number of path components used by the directory-name fallback for a newly created direct-path workspace. Git repositories keep their repository-derived name. Must be at least `1` (the default). |
 
+### `[keys]`
+
+```toml
+[keys]
+cycle_preview_mode = "ctrl+o"
+```
+
+`cycle_preview_mode` changes the native picker's preview-mode shortcut. Omit it
+for `"ctrl+o"`, choose a key such as `"alt+p"` or `"f2"`, or set it to `""` to
+disable cycling and hide the shortcut hint. Key names use Bubble Tea's exact,
+case-sensitive spelling, with modifiers joined by `+`. The configured shortcut
+takes precedence over other native picker bindings, so choose an unused key.
+Disabling cycling leaves the initial `[picker].preview_mode` in effect and
+returns keys to their normal picker/input handling. This does not affect fzf or
+configure shortcuts in Herdr itself.
+
 ### `[picker]`
 
 | Field | Runtime effect |
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
 | `show_preview` | Shows the preview panel in the native picker. The default is `true`; set it to `false` to give the workspace list the full available width and height without running preview commands. This does not change fzf preview behavior. |
-| `preview_mode` | Sets the native picker's initial preview to `command` (the configured preview command or built-in fallback, the default) or `pane` (the active pane of the selected Herdr workspace, refreshed once per second). Press ++ctrl+o++ to switch modes while the picker is open. `show_preview = false` still disables previews. This does not affect fzf or `herdr-sesh preview`. |
+| `preview_mode` | Sets the native picker's initial preview to `command` (the configured preview command or built-in fallback, the default) or `pane` (the active pane of the selected Herdr workspace, refreshed once per second). Press ++ctrl+o++ (or `keys.cycle_preview_mode`) to switch modes while the picker is open. `show_preview = false` still disables previews. This does not affect fzf or `herdr-sesh preview`. |
 | `prioritize_home` | Controls exact case-insensitive `home` searches in the native picker. The default is `true`, which promotes the actual home-directory session ahead of real-name and ordinary path matches. Set it to `false` to keep real-name matches first, then path matches in their existing order; the actual home-directory session remains searchable through the exact `home` alias. |
 | `herdr_theme_inherit` | Inherits colors from Herdr's active theme. The default is `true`; set it to `false` to keep the native picker's built-in colors. |
 | `replace_worktree_icon` | Replaces the Herdr sheep icon with `↳` for linked worktree rows. The default is `true`. Set it to `false` to keep the sheep icon (or plain `[herdr]` when icons are hidden); the purple type color and tree branches remain. |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -2,11 +2,21 @@
 
 ## Native picker previews
 
-In the native picker, press ++ctrl+o++ to switch between the configured preview
+In the native picker, press ++ctrl+o++ by default to switch between the configured preview
 and **Pane** mode. Pane mode shows the visible terminal contents of the selected
 Herdr workspace's active pane, in its active tab, and refreshes once per second.
 It works for background workspaces without changing focus. Press ++ctrl+o++ again
 to return to the configured preview. ++ctrl+v++ pastes into the filter.
+
+Override the shortcut in the herdr-sesh `config.toml`:
+
+```toml
+[keys]
+cycle_preview_mode = "alt+p" # default: "ctrl+o"; "" disables cycling
+```
+
+The preview heading shows the configured shortcut, or no shortcut when disabled.
+See [picker keys](config.md#keys) for key syntax and binding precedence.
 
 Set `[picker].preview_mode = "pane"` in `config.toml` to start in Pane mode;
 the default is `"command"`. Switching modes in the picker does not change the file.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -213,6 +213,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		DisableHomePrioritization:      !cfg.TUI.PrioritizeHome,
 		HidePreview:                    !cfg.TUI.ShowPreview,
 		PreviewMode:                    cfg.TUI.PreviewMode,
+		CyclePreviewModeKey:            &cfg.Keys.CyclePreviewMode,
 		DefaultPreviewCommand:          cfg.DefaultSessionConfig.PreviewCommand,
 		WorkspaceSort:                  cfg.TUI.DefaultSort,
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1314,3 +1314,13 @@ func configureFakeSources(t *testing.T, zoxideOutput string) {
 	t.Setenv("FAKE_ZOXIDE_OUTPUT", zoxideOutput)
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
+
+func TestPickerOptionsPropagateCyclePreviewModeKey(t *testing.T) {
+	for _, binding := range []string{"ctrl+o", "alt+p", ""} {
+		cfg := config.Default()
+		cfg.Keys.CyclePreviewMode = binding
+		opts := pickerOptionsFromConfig(context.Background(), io.Discard, cfg)
+		require.NotNil(t, opts.CyclePreviewModeKey)
+		assert.Equal(t, binding, *opts.CyclePreviewModeKey)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,12 @@ const (
 	DefaultWorkspaceSort  = "workspace"
 )
 
+type KeyConfig struct {
+	CyclePreviewMode string
+}
+
 type Config struct {
+	Keys                 KeyConfig            `toml:"-"`
 	Cache                bool                 `toml:"cache"`
 	StrictMode           bool                 `toml:"strict_mode"`
 	ImportPaths          []string             `toml:"import"`
@@ -64,6 +69,7 @@ type WildcardConfig struct {
 
 func Default() Config {
 	return Config{
+		Keys:                 KeyConfig{CyclePreviewMode: "ctrl+o"},
 		DirLength:            1,
 		SortOrder:            []string{"herdr", "config", "zoxide", "dir"},
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -140,7 +140,7 @@ func (n nativeConfig) validate(path string) error {
 		return fail("picker.preview_mode", "must be \"command\" or \"pane\", got %q", mode)
 	}
 	if binding := n.Keys.CyclePreviewMode; !validCyclePreviewKey(binding) {
-		return fail("keys.cycle_preview_mode", "unsupported key %q; use Bubble Tea key names such as ctrl+o, alt+p, or f2, or an empty string to disable; for shifted printable keys use the resulting character (e.g. P instead of shift+p)", *binding)
+		return fail("keys.cycle_preview_mode", "unsupported key %q; use Bubble Tea key names such as ctrl+o, alt+p, or f2, or an empty string to disable; for shifted printable keys use the resulting character (e.g. P instead of shift+p), and with other modifiers use the unshifted base key (e.g. ctrl+shift+p or alt+shift+/)", *binding)
 	}
 	seenSources := map[string]bool{}
 	for _, s := range n.List.SourceOrder {
@@ -286,9 +286,11 @@ func validCyclePreviewKey(configured *string) bool {
 		return true
 	}
 	name := *configured
+	shifted := false
 	for _, modifier := range []string{"ctrl", "alt", "shift", "meta", "hyper", "super"} {
 		if rest, ok := strings.CutPrefix(name, modifier+"+"); ok {
 			name = rest
+			shifted = shifted || modifier == "shift"
 			// Bubble Tea omits the modifier when it is itself the pressed key.
 			if strings.HasSuffix(name, "+left"+modifier) || strings.HasSuffix(name, "+right"+modifier) || name == "left"+modifier || name == "right"+modifier {
 				return false
@@ -296,6 +298,10 @@ func validCyclePreviewKey(configured *string) bool {
 		}
 	}
 	if code, size := utf8.DecodeRuneInString(name); size == len(name) && unicode.IsPrint(code) {
+		// Explicit Shift combinations use the unshifted PC-101 base key.
+		if shifted && (unicode.IsUpper(code) || strings.ContainsRune("~!@#$%^&*()_+{}|:\"<>?", code)) {
+			return false
+		}
 		// Shift-only printable events carry their resulting text, not shift+key.
 		return size > 0 && code != ' ' && *configured != "shift+"+name
 	}

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	tea "charm.land/bubbletea/v2"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -272,42 +271,41 @@ func (n nativeConfig) apply(cfg *Config) {
 	}
 }
 
-// validCyclePreviewKey checks the exact spelling emitted by Bubble Tea without
-// maintaining a separate list of its named keys.
+// Keep UI dependencies out of config: their initialization runs in every
+// non-UI consumer too. TestCyclePreviewKeyNamesMatchBubbleTea checks this list.
+const cyclePreviewKeyNames = `enter tab backspace esc space up down left right
+begin find insert delete select pgup pgdown home end equal mul plus comma minus
+period div sep capslock scrolllock numlock printscreen pause menu mediaplay
+mediapause mediaplaypause mediareverse mediastop mediafastforward mediarewind
+medianext mediaprev mediarecord lowervol raisevol mute leftshift leftalt leftctrl
+leftsuper lefthyper leftmeta rightshift rightalt rightctrl rightsuper righthyper
+rightmeta isolevel3shift isolevel5shift`
+
 func validCyclePreviewKey(configured *string) bool {
 	if configured == nil || *configured == "" {
 		return true
 	}
-	binding := *configured
-	name := binding
-	var mod tea.KeyMod
-	for _, modifier := range []struct {
-		name string
-		mod  tea.KeyMod
-	}{
-		{"ctrl", tea.ModCtrl}, {"alt", tea.ModAlt}, {"shift", tea.ModShift},
-		{"meta", tea.ModMeta}, {"hyper", tea.ModHyper}, {"super", tea.ModSuper},
-	} {
-		if rest, ok := strings.CutPrefix(name, modifier.name+"+"); ok {
+	name := *configured
+	for _, modifier := range []string{"ctrl", "alt", "shift", "meta", "hyper", "super"} {
+		if rest, ok := strings.CutPrefix(name, modifier+"+"); ok {
 			name = rest
-			mod |= modifier.mod
+			// Bubble Tea omits the modifier when it is itself the pressed key.
+			if strings.HasSuffix(name, "+left"+modifier) || strings.HasSuffix(name, "+right"+modifier) || name == "left"+modifier || name == "right"+modifier {
+				return false
+			}
 		}
-	}
-	matches := func(code rune) bool {
-		return (tea.Key{Code: code, Mod: mod}).String() == binding
 	}
 	if code, size := utf8.DecodeRuneInString(name); size == len(name) && unicode.IsPrint(code) {
-		return matches(code)
+		return size > 0 && code != ' '
 	}
-	for _, code := range []rune{tea.KeyEnter, tea.KeyTab, tea.KeyBackspace, tea.KeyEscape, tea.KeySpace} {
-		if matches(code) {
-			return true
+	if number, ok := strings.CutPrefix(name, "f"); ok {
+		n, err := strconv.Atoi(number)
+		if err == nil {
+			return n >= 1 && n <= 63 && strconv.Itoa(n) == number
 		}
 	}
-	// Bubble Tea's extended key constants are contiguous, from arrows through
-	// function, keypad, media, and modifier keys.
-	for code := tea.KeyUp; code <= tea.KeyIsoLevel5Shift; code++ {
-		if matches(code) {
+	for _, key := range strings.Fields(cyclePreviewKeyNames) {
+		if name == key {
 			return true
 		}
 	}

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -140,7 +140,7 @@ func (n nativeConfig) validate(path string) error {
 		return fail("picker.preview_mode", "must be \"command\" or \"pane\", got %q", mode)
 	}
 	if binding := n.Keys.CyclePreviewMode; !validCyclePreviewKey(binding) {
-		return fail("keys.cycle_preview_mode", "unsupported key %q; use Bubble Tea key names such as ctrl+o, alt+p, or f2, or an empty string to disable", *binding)
+		return fail("keys.cycle_preview_mode", "unsupported key %q; use Bubble Tea key names such as ctrl+o, alt+p, or f2, or an empty string to disable; for shifted printable keys use the resulting character (e.g. P instead of shift+p)", *binding)
 	}
 	seenSources := map[string]bool{}
 	for _, s := range n.List.SourceOrder {
@@ -296,7 +296,8 @@ func validCyclePreviewKey(configured *string) bool {
 		}
 	}
 	if code, size := utf8.DecodeRuneInString(name); size == len(name) && unicode.IsPrint(code) {
-		return size > 0 && code != ' '
+		// Shift-only printable events carry their resulting text, not shift+key.
+		return size > 0 && code != ' ' && *configured != "shift+"+name
 	}
 	if number, ok := strings.CutPrefix(name, "f"); ok {
 		n, err := strconv.Atoi(number)

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -15,7 +15,13 @@ import (
 
 const NativeVersion = 1
 
+type nativeKeys struct {
+	// nil keeps the default; an explicit empty string disables cycling.
+	CyclePreviewMode *string `toml:"cycle_preview_mode,omitempty"`
+}
+
 type nativeConfig struct {
+	Keys              nativeKeys        `toml:"keys,omitempty"`
 	Version           int               `toml:"version"`
 	List              nativeList        `toml:"list,omitempty"`
 	Naming            nativeNaming      `toml:"naming"`
@@ -193,6 +199,9 @@ func (n nativeConfig) validate(path string) error {
 // apply converts the validated native document onto a Default()-initialized
 // runtime Config so downstream consumers see the same shape as legacy loads.
 func (n nativeConfig) apply(cfg *Config) {
+	if n.Keys.CyclePreviewMode != nil {
+		cfg.Keys.CyclePreviewMode = *n.Keys.CyclePreviewMode
+	}
 	cfg.Cache = n.List.Cache
 	cfg.Blacklist = n.List.Blacklist
 	if len(n.List.SourceOrder) > 0 {

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -136,6 +140,9 @@ func (n nativeConfig) validate(path string) error {
 	if mode := n.Picker.PreviewMode; mode != "" && mode != "command" && mode != "pane" {
 		return fail("picker.preview_mode", "must be \"command\" or \"pane\", got %q", mode)
 	}
+	if binding := n.Keys.CyclePreviewMode; !validCyclePreviewKey(binding) {
+		return fail("keys.cycle_preview_mode", "unsupported key %q; use Bubble Tea key names such as ctrl+o, alt+p, or f2, or an empty string to disable", *binding)
+	}
 	seenSources := map[string]bool{}
 	for _, s := range n.List.SourceOrder {
 		if !knownSources[s] {
@@ -263,4 +270,46 @@ func (n nativeConfig) apply(cfg *Config) {
 			Windows:             r.Tabs,
 		})
 	}
+}
+
+// validCyclePreviewKey checks the exact spelling emitted by Bubble Tea without
+// maintaining a separate list of its named keys.
+func validCyclePreviewKey(configured *string) bool {
+	if configured == nil || *configured == "" {
+		return true
+	}
+	binding := *configured
+	name := binding
+	var mod tea.KeyMod
+	for _, modifier := range []struct {
+		name string
+		mod  tea.KeyMod
+	}{
+		{"ctrl", tea.ModCtrl}, {"alt", tea.ModAlt}, {"shift", tea.ModShift},
+		{"meta", tea.ModMeta}, {"hyper", tea.ModHyper}, {"super", tea.ModSuper},
+	} {
+		if rest, ok := strings.CutPrefix(name, modifier.name+"+"); ok {
+			name = rest
+			mod |= modifier.mod
+		}
+	}
+	matches := func(code rune) bool {
+		return (tea.Key{Code: code, Mod: mod}).String() == binding
+	}
+	if code, size := utf8.DecodeRuneInString(name); size == len(name) && unicode.IsPrint(code) {
+		return matches(code)
+	}
+	for _, code := range []rune{tea.KeyEnter, tea.KeyTab, tea.KeyBackspace, tea.KeyEscape, tea.KeySpace} {
+		if matches(code) {
+			return true
+		}
+	}
+	// Bubble Tea's extended key constants are contiguous, from arrows through
+	// function, keypad, media, and modifier keys.
+	for code := tea.KeyUp; code <= tea.KeyIsoLevel5Shift; code++ {
+		if matches(code) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -474,14 +474,14 @@ func TestNativeCyclePreviewModeKey(t *testing.T) {
 }
 
 func TestNativeCyclePreviewModeKeyValidation(t *testing.T) {
-	for _, binding := range []string{"f01", "ctrl+leftctrl", "ctrl+alt+rightctrl", " ", "ctrl+ ", "ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
+	for _, binding := range []string{"shift+p", "shift+/", "shift+1", "f01", "ctrl+leftctrl", "ctrl+alt+rightctrl", " ", "ctrl+ ", "ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
 		t.Run(binding, func(t *testing.T) {
 			_, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "keys.cycle_preview_mode")
 		})
 	}
-	for _, binding := range []string{"", "ctrl+o", "alt+p", "f2", "ctrl+alt+shift+f12", "enter", "space", "esc", "+", "ctrl++", "é", "A", "?"} {
+	for _, binding := range []string{"", "ctrl+o", "alt+p", "ctrl+shift+p", "f2", "ctrl+alt+shift+f12", "enter", "space", "esc", "+", "ctrl++", "é", "A", "P", "?"} {
 		t.Run("valid "+binding, func(t *testing.T) {
 			cfg, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
 			require.NoError(t, err)
@@ -500,7 +500,10 @@ func TestCyclePreviewKeyNamesMatchBubbleTea(t *testing.T) {
 		names[(tea.Key{Code: code}).String()] = true
 		for mod := tea.KeyMod(0); mod < tea.ModSuper*2; mod++ {
 			binding := (tea.Key{Code: code, Mod: mod}).String()
-			require.True(t, validCyclePreviewKey(&binding), "rejected Bubble Tea key %q", binding)
+			// Shift-only printable spellings also arise from keypad events,
+			// but are rejected because ordinary typing reports the resulting text.
+			shiftedPrintable := mod == tea.ModShift && len([]rune(strings.TrimPrefix(binding, "shift+"))) == 1
+			require.Equal(t, !shiftedPrintable, validCyclePreviewKey(&binding), "Bubble Tea key %q", binding)
 		}
 	}
 	configuredNames := strings.Fields(cyclePreviewKeyNames)

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"testing"
 
@@ -463,6 +464,23 @@ func TestNativeCyclePreviewModeKey(t *testing.T) {
 			cfg, err := loadNative(t, "version = 1\n[keys]\n"+tc.setting+"\n")
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, cfg.Keys.CyclePreviewMode)
+		})
+	}
+}
+
+func TestNativeCyclePreviewModeKeyValidation(t *testing.T) {
+	for _, binding := range []string{"ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
+		t.Run(binding, func(t *testing.T) {
+			_, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "keys.cycle_preview_mode")
+		})
+	}
+	for _, binding := range []string{"", "ctrl+o", "alt+p", "f2", "ctrl+alt+shift+f12", "enter", "space", "esc", "+", "ctrl++", "é", "A", "?"} {
+		t.Run("valid "+binding, func(t *testing.T) {
+			cfg, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
+			require.NoError(t, err)
+			assert.Equal(t, binding, cfg.Keys.CyclePreviewMode)
 		})
 	}
 }

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -71,6 +71,7 @@ tabs = ["git"]
 	require.NoError(t, err)
 	disable := true
 	want := Config{
+		Keys:           KeyConfig{CyclePreviewMode: "ctrl+o"},
 		Cache:          true,
 		DirLength:      2,
 		SeparatorAware: true,
@@ -450,4 +451,18 @@ func TestInitConfigAtRejectsDirectory(t *testing.T) {
 	require.NoError(t, os.Mkdir(p, 0700))
 	_, err := InitConfigAt(p)
 	require.ErrorContains(t, err, "not a regular file")
+}
+
+func TestNativeCyclePreviewModeKey(t *testing.T) {
+	for _, tc := range []struct{ name, setting, want string }{
+		{"omitted", "", "ctrl+o"},
+		{"custom", `cycle_preview_mode = "alt+p"`, "alt+p"},
+		{"disabled", `cycle_preview_mode = ""`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadNative(t, "version = 1\n[keys]\n"+tc.setting+"\n")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.Keys.CyclePreviewMode)
+		})
+	}
 }

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -2,12 +2,17 @@ package config
 
 import (
 	"bytes"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
+
 	"syscall"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -469,7 +474,7 @@ func TestNativeCyclePreviewModeKey(t *testing.T) {
 }
 
 func TestNativeCyclePreviewModeKeyValidation(t *testing.T) {
-	for _, binding := range []string{"ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
+	for _, binding := range []string{"f01", "ctrl+leftctrl", "ctrl+alt+rightctrl", " ", "ctrl+ ", "ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
 		t.Run(binding, func(t *testing.T) {
 			_, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
 			require.Error(t, err)
@@ -483,4 +488,28 @@ func TestNativeCyclePreviewModeKeyValidation(t *testing.T) {
 			assert.Equal(t, binding, cfg.Keys.CyclePreviewMode)
 		})
 	}
+}
+
+func TestCyclePreviewKeyNamesMatchBubbleTea(t *testing.T) {
+	codes := []rune{tea.KeyEnter, tea.KeyTab, tea.KeyBackspace, tea.KeyEscape, tea.KeySpace}
+	for code := tea.KeyUp; code <= tea.KeyIsoLevel5Shift; code++ {
+		codes = append(codes, code)
+	}
+	names := make(map[string]bool)
+	for _, code := range codes {
+		names[(tea.Key{Code: code}).String()] = true
+		for mod := tea.KeyMod(0); mod < tea.ModSuper*2; mod++ {
+			binding := (tea.Key{Code: code, Mod: mod}).String()
+			require.True(t, validCyclePreviewKey(&binding), "rejected Bubble Tea key %q", binding)
+		}
+	}
+	configuredNames := strings.Fields(cyclePreviewKeyNames)
+	for n := 1; n <= 63; n++ {
+		configuredNames = append(configuredNames, "f"+strconv.Itoa(n))
+	}
+	// Keypad digits are covered by the printable-character path.
+	for n := 0; n <= 9; n++ {
+		configuredNames = append(configuredNames, strconv.Itoa(n))
+	}
+	assert.ElementsMatch(t, configuredNames, slices.Collect(maps.Keys(names)))
 }

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -474,14 +474,14 @@ func TestNativeCyclePreviewModeKey(t *testing.T) {
 }
 
 func TestNativeCyclePreviewModeKeyValidation(t *testing.T) {
-	for _, binding := range []string{"shift+p", "shift+/", "shift+1", "f01", "ctrl+leftctrl", "ctrl+alt+rightctrl", " ", "ctrl+ ", "ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
+	for _, binding := range []string{"ctrl+shift+P", "alt+shift+?", "ctrl+alt+shift+!", "shift+super+P", "shift+p", "shift+/", "shift+1", "f01", "ctrl+leftctrl", "ctrl+alt+rightctrl", " ", "ctrl+ ", "ctrl-o", "Ctrl+o", "ctrl+", "ctrl+ctrl+o", "alt+ctrl+o", "ctrl+unknown", "f64", "escape", "ctrl+o ", "\n"} {
 		t.Run(binding, func(t *testing.T) {
 			_, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "keys.cycle_preview_mode")
 		})
 	}
-	for _, binding := range []string{"", "ctrl+o", "alt+p", "ctrl+shift+p", "f2", "ctrl+alt+shift+f12", "enter", "space", "esc", "+", "ctrl++", "é", "A", "P", "?"} {
+	for _, binding := range []string{"", "ctrl+o", "alt+p", "ctrl+shift+p", "alt+shift+/", "ctrl+alt+shift+1", "shift+super+p", "f2", "ctrl+alt+shift+f12", "enter", "space", "esc", "+", "ctrl++", "é", "A", "P", "?"} {
 		t.Run("valid "+binding, func(t *testing.T) {
 			cfg, err := loadNative(t, "version = 1\n[keys]\ncycle_preview_mode = "+strconv.Quote(binding)+"\n")
 			require.NoError(t, err)

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -159,3 +159,16 @@ func TestCyclePreviewModeKey(t *testing.T) {
 		})
 	}
 }
+
+func TestCyclePreviewModeShiftedPrintableText(t *testing.T) {
+	for _, key := range []tea.KeyPressMsg{
+		{Code: 'p', Mod: tea.ModShift, Text: "P"},
+		{Code: 'P', Text: "P"},
+		{Code: '/', Mod: tea.ModShift, Text: "?"},
+	} {
+		binding := key.Text
+		m := newTeaModel(nil, Options{CyclePreviewModeKey: &binding})
+		updated, _ := m.Update(key)
+		assert.True(t, updated.(teaModel).panePreview, "binding %q", binding)
+	}
+}

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -137,3 +137,25 @@ func TestInitialPreviewMode(t *testing.T) {
 		})
 	}
 }
+
+func TestCyclePreviewModeKey(t *testing.T) {
+	for _, binding := range []string{"alt+p", ""} {
+		t.Run(binding, func(t *testing.T) {
+			m := newTeaModel(nil, Options{CyclePreviewModeKey: &binding})
+			updated, _ := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+			m = updated.(teaModel)
+			assert.False(t, m.panePreview)
+			assert.NotContains(t, ansi.Strip(m.previewTitle()), "[ctrl+o]")
+			updated, _ = m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModAlt})
+			m = updated.(teaModel)
+			assert.Equal(t, binding != "", m.panePreview)
+			if binding != "" {
+				assert.Contains(t, ansi.Strip(m.previewTitle()), "["+binding+"]")
+				updated, _ = m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModAlt})
+				assert.False(t, updated.(teaModel).panePreview)
+			} else {
+				assert.NotContains(t, ansi.Strip(m.previewTitle()), "[]")
+			}
+		})
+	}
+}

--- a/internal/picker/pane_preview_test.go
+++ b/internal/picker/pane_preview_test.go
@@ -172,3 +172,17 @@ func TestCyclePreviewModeShiftedPrintableText(t *testing.T) {
 		assert.True(t, updated.(teaModel).panePreview, "binding %q", binding)
 	}
 }
+
+func TestCyclePreviewModeModifiedShiftUsesBaseKey(t *testing.T) {
+	for _, tc := range []struct {
+		binding string
+		key     tea.KeyPressMsg
+	}{
+		{"ctrl+shift+p", tea.KeyPressMsg{Code: 'p', ShiftedCode: 'P', Mod: tea.ModCtrl | tea.ModShift}},
+		{"alt+shift+/", tea.KeyPressMsg{Code: '/', ShiftedCode: '?', Mod: tea.ModAlt | tea.ModShift}},
+	} {
+		m := newTeaModel(nil, Options{CyclePreviewModeKey: &tc.binding})
+		updated, _ := m.Update(tc.key)
+		assert.True(t, updated.(teaModel).panePreview, "binding %q", tc.binding)
+	}
+}

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -18,6 +18,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/fullerzz/herdr-plugin-sesh/internal/config"
 	sessionmodel "github.com/fullerzz/herdr-plugin-sesh/internal/model"
 	previewpkg "github.com/fullerzz/herdr-plugin-sesh/internal/preview"
 )
@@ -130,6 +131,8 @@ var renderPreview = previewpkg.Render
 var renderPanePreview = previewpkg.RenderPane
 
 type Options struct {
+	// nil uses the default binding; an empty string disables cycling.
+	CyclePreviewModeKey            *string
 	Context                        context.Context
 	Output                         io.Writer
 	Prompt                         string
@@ -214,6 +217,7 @@ type teaModel struct {
 	cancelPreview        context.CancelFunc
 	previewRequestID     uint64
 	panePreview          bool
+	cyclePreviewModeKey  string
 
 	defaultPreviewCommand   string
 	hidePreview             bool
@@ -306,6 +310,10 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 	styles.Cursor.Color = skyColor
 	input.SetStyles(styles)
 	input.Focus()
+	cyclePreviewModeKey := config.Default().Keys.CyclePreviewMode
+	if opts.CyclePreviewModeKey != nil {
+		cyclePreviewModeKey = *opts.CyclePreviewModeKey
+	}
 	reduceMotion := os.Getenv("HERDR_SESH_REDUCE_MOTION")
 	m := teaModel{
 		list:                  list,
@@ -314,6 +322,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
 		hidePreview:           opts.HidePreview,
 		panePreview:           opts.PreviewMode == "pane",
+		cyclePreviewModeKey:   cyclePreviewModeKey,
 		showIcons:             opts.ShowIcons,
 		replaceWorktreeIcon:   !opts.DisableWorktreeIconReplacement,
 		hideLastWorkspace:     opts.HideLastWorkspace,
@@ -565,6 +574,14 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmd, previewCmd)
 	}
 	m.closeError = ""
+	if m.cyclePreviewModeKey != "" && key.String() == m.cyclePreviewModeKey {
+		if m.hidePreview || m.closingWorkspaceID != "" {
+			return m, nil
+		}
+		m.panePreview = !m.panePreview
+		m.previewKey = ""
+		return m.refreshPreview()
+	}
 	switch key.String() {
 	case "ctrl+c", "esc":
 		if m.closingWorkspaceID != "" {
@@ -614,13 +631,6 @@ func (m teaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(focusCmd, previewCmd)
 	case "ctrl+r":
 		return m.toggleWorkspaceSort()
-	case "ctrl+o":
-		if m.hidePreview || m.closingWorkspaceID != "" {
-			return m, nil
-		}
-		m.panePreview = !m.panePreview
-		m.previewKey = ""
-		return m.refreshPreview()
 	case "ctrl+x":
 		return m.closeSelectedWorkspace()
 	case "right":
@@ -1080,7 +1090,9 @@ func (m teaModel) previewTitle() string {
 	if m.panePreview {
 		title = sectionStyle.Render("PANE")
 	}
-	title += countStyle.Render(" [ctrl+o]")
+	if m.cyclePreviewModeKey != "" {
+		title += countStyle.Render(" [" + m.cyclePreviewModeKey + "]")
+	}
 	current, ok := m.list.Current()
 	if !ok {
 		return title


### PR DESCRIPTION
Makes the native picker's preview-mode shortcut configurable through `[keys].cycle_preview_mode`. It defaults to `ctrl+o`; a custom binding replaces it, and an explicit empty string disables cycling. The preview heading displays the configured shortcut and hides the hint when disabled.

Adds configuration, option propagation, and picker regression coverage, plus documentation for key syntax and binding precedence.

Closes #115.

Validation:
- `go test ./internal/config ./internal/picker ./internal/app`
- `env GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-115-lint just check` (472 tests passed)
- `just build-docs`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `git diff --check`
- Commit hooks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the native picker's preview-mode shortcut configurable via `[keys].cycle_preview_mode`. It defaults to `ctrl+o`; a custom binding replaces it, and an explicit empty string disables cycling and hides the shortcut hint.

**New Features**
- Adds `cycle_preview_mode` to the `[keys]` TOML section; invalid names, duplicate modifiers, wrong modifier order, and shift-only printable spellings are rejected as configuration errors.
- Shift-only printable keys must use the resulting character (`"P"` not `"shift+p"`); when Shift is combined with other modifiers, use the unshifted base key (`"ctrl+shift+p"` not `"ctrl+shift+P"`).
- A configured shortcut takes precedence over other picker bindings; disabling cycling leaves the initial `[picker].preview_mode` in effect.
- Key validation uses a hardcoded name list instead of importing Bubble Tea, keeping UI initialization out of config; a test cross-checks the list against Bubble Tea.
- Closes #115.

<sup>Written for commit 2d147b30ced8af9e022f1f244a53981f38cd6215. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

