### PR TITLE
feat: allow hiding the native picker path column

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,7 @@ path_components = 1
 
 [picker]
 show_icons = true
+show_path = true
 show_preview = true
 preview_mode = "command"
 prioritize_home = false
@@ -221,6 +222,7 @@ configure shortcuts in Herdr itself.
 | Field | Runtime effect |
 | --- | --- |
 | `show_icons` | Shows Nerd Font source icons in the native picker. The default is `false`; source names remain visible when icons are hidden. |
+| `show_path` | Shows the path column in the native picker when space permits (default `true`). Set it to `false` to hide the column and give the side-by-side preview 50% of the available width initially. The divider remains draggable; narrow terminals keep stacked previews. This does not affect path matching, the last-workspace footer, or fzf. |
 | `show_preview` | Shows the preview panel in the native picker. The default is `true`; set it to `false` to give the workspace list the full available width and height without running preview commands. This does not change fzf preview behavior. |
 | `preview_mode` | Sets the native picker's initial preview to `command` (the configured preview command or built-in fallback, the default) or `pane` (the active pane of the selected Herdr workspace, refreshed once per second). Press ++ctrl+o++ (or `keys.cycle_preview_mode`) to switch modes while the picker is open. `show_preview = false` still disables previews. This does not affect fzf or `herdr-sesh preview`. |
 | `prioritize_home` | Controls exact case-insensitive `home` searches in the native picker. The default is `true`, which promotes the actual home-directory session ahead of real-name and ordinary path matches. Set it to `false` to keep real-name matches first, then path matches in their existing order; the actual home-directory session remains searchable through the exact `home` alias. |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -211,6 +211,7 @@ func pickerOptionsFromConfig(ctx context.Context, output io.Writer, cfg config.C
 		HideLastWorkspacePath:          !cfg.TUI.ShowLastWorkspacePath,
 		SeparatorAware:                 cfg.SeparatorAware,
 		DisableHomePrioritization:      !cfg.TUI.PrioritizeHome,
+		HidePath:                       !cfg.TUI.ShowPath,
 		HidePreview:                    !cfg.TUI.ShowPreview,
 		PreviewMode:                    cfg.TUI.PreviewMode,
 		CyclePreviewModeKey:            &cfg.Keys.CyclePreviewMode,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1324,3 +1324,10 @@ func TestPickerOptionsPropagateCyclePreviewModeKey(t *testing.T) {
 		assert.Equal(t, binding, *opts.CyclePreviewModeKey)
 	}
 }
+
+func TestPickerOptionsPropagatePathVisibility(t *testing.T) {
+	cfg := config.Default()
+	require.False(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).HidePath)
+	cfg.TUI.ShowPath = false
+	assert.True(t, pickerOptionsFromConfig(context.Background(), io.Discard, cfg).HidePath)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,8 @@ type SessionConfig struct {
 
 type TUIConfig struct {
 	ShowIcons bool `toml:"show_icons"`
-	// ShowPreview is native-only; the legacy Sesh schema has no equivalent setting.
+	// ShowPath and ShowPreview are native-only; the legacy Sesh schema has no equivalents.
+	ShowPath              bool   `toml:"-"`
 	ShowPreview           bool   `toml:"-"`
 	PreviewMode           string `toml:"-"`
 	PrioritizeHome        bool   `toml:"-"`
@@ -75,6 +76,7 @@ func Default() Config {
 		DefaultSessionConfig: DefaultSessionConfig{PreviewCommand: DefaultPreviewCommand},
 		TUI: TUIConfig{
 			DefaultSort:           DefaultWorkspaceSort,
+			ShowPath:              true,
 			ShowPreview:           true,
 			PreviewMode:           DefaultPreviewMode,
 			PrioritizeHome:        true,

--- a/internal/config/native.go
+++ b/internal/config/native.go
@@ -51,6 +51,7 @@ type nativePicker struct {
 	// No omitempty: migration must keep an explicitly configured false, and
 	// an always-present value keeps icon behavior self-documenting.
 	ShowIcons             bool   `toml:"show_icons"`
+	ShowPath              *bool  `toml:"show_path,omitempty"`
 	ShowPreview           *bool  `toml:"show_preview,omitempty"`
 	PreviewMode           string `toml:"preview_mode,omitempty"`
 	PrioritizeHome        *bool  `toml:"prioritize_home,omitempty"`
@@ -218,6 +219,9 @@ func (n nativeConfig) apply(cfg *Config) {
 	}
 	cfg.SeparatorAware = n.Picker.SeparatorAware
 	cfg.TUI.ShowIcons = n.Picker.ShowIcons
+	if n.Picker.ShowPath != nil {
+		cfg.TUI.ShowPath = *n.Picker.ShowPath
+	}
 	if n.Picker.ShowPreview != nil {
 		cfg.TUI.ShowPreview = *n.Picker.ShowPreview
 	}

--- a/internal/config/native_test.go
+++ b/internal/config/native_test.go
@@ -39,6 +39,7 @@ path_components = 2
 
 [picker]
 show_icons = true
+show_path = false
 show_preview = false
 preview_mode = "pane"
 prioritize_home = false
@@ -515,4 +516,12 @@ func TestCyclePreviewKeyNamesMatchBubbleTea(t *testing.T) {
 		configuredNames = append(configuredNames, strconv.Itoa(n))
 	}
 	assert.ElementsMatch(t, configuredNames, slices.Collect(maps.Keys(names)))
+}
+
+func TestNativePickerShowPath(t *testing.T) {
+	for _, setting := range []string{"", "show_path = true", "show_path = false"} {
+		cfg, err := loadNative(t, "version = 1\n[picker]\n"+setting+"\n")
+		require.NoError(t, err)
+		assert.Equal(t, setting != "show_path = false", cfg.TUI.ShowPath)
+	}
 }

--- a/internal/picker/tea.go
+++ b/internal/picker/tea.go
@@ -144,6 +144,7 @@ type Options struct {
 	HideLastWorkspacePath          bool
 	SeparatorAware                 bool
 	DisableHomePrioritization      bool
+	HidePath                       bool
 	HidePreview                    bool
 	PreviewMode                    string
 	DefaultPreviewCommand          string
@@ -220,6 +221,7 @@ type teaModel struct {
 	cyclePreviewModeKey  string
 
 	defaultPreviewCommand   string
+	hidePath                bool
 	hidePreview             bool
 	showIcons               bool
 	replaceWorktreeIcon     bool
@@ -320,6 +322,7 @@ func newTeaModel(items []sessionmodel.Session, opts Options) teaModel {
 		input:                 input,
 		agentSpinner:          spinner.New(spinner.WithSpinner(agentStatusSpinner)),
 		defaultPreviewCommand: opts.DefaultPreviewCommand,
+		hidePath:              opts.HidePath,
 		hidePreview:           opts.HidePreview,
 		panePreview:           opts.PreviewMode == "pane",
 		cyclePreviewModeKey:   cyclePreviewModeKey,
@@ -945,7 +948,7 @@ func (m teaModel) listView(width, visibleRows int) string {
 			selected := m.listFocused && !m.focusSmearActive && i == m.list.Selected
 			selectedRail := m.smear.headStyle().Render(m.smear.headGlyph + " ")
 			treePrefix := worktreeTreePrefix(m.list.Filtered, i)
-			line := strings.TrimSuffix(rowWithRail(m.list.Filtered[i], selected, width, m.showIcons, m.replaceWorktreeIcon, m.list.Query, selectedRail, m.agentSpinner.View(), treePrefix), "\n")
+			line := strings.TrimSuffix(rowWithRail(m.list.Filtered[i], selected, width, m.showIcons, m.replaceWorktreeIcon, m.hidePath, m.list.Query, selectedRail, m.agentSpinner.View(), treePrefix), "\n")
 			if rail, age := m.smearRail(i); rail != "" {
 				line = m.smear.trailStyle(age).Render(rail+" ") + strings.TrimPrefix(line, "  ")
 			}
@@ -1385,7 +1388,10 @@ func (m teaModel) previewLayout() (int, int) {
 	}
 	previewWidth := m.previewWidth
 	if previewWidth == 0 {
-		previewWidth = min(width/2, maxPreviewWidth)
+		previewWidth = width / 2
+		if !m.hidePath {
+			previewWidth = min(previewWidth, maxPreviewWidth)
+		}
 	}
 	previewWidth = min(max(previewWidth, minPreviewWidth), width-minListWidth-3)
 	return width - previewWidth - 3, previewWidth
@@ -1437,10 +1443,10 @@ func fixedVisualLines(text string, width, count int) string {
 }
 
 func row(s sessionmodel.Session, selected bool, width int, showIcons bool, query string) string {
-	return rowWithRail(s, selected, width, showIcons, true, query, selectionRailStyle.Render("┃ "), agentStatusSpinner.Frames[0], "")
+	return rowWithRail(s, selected, width, showIcons, true, false, query, selectionRailStyle.Render("┃ "), agentStatusSpinner.Frames[0], "")
 }
 
-func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons, replaceWorktreeIcon bool, query, selectedRail, workingGlyph, treePrefix string) string {
+func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons, replaceWorktreeIcon, hidePath bool, query, selectedRail, workingGlyph, treePrefix string) string {
 	rail := "  "
 	if selected {
 		rail = selectedRail
@@ -1473,7 +1479,7 @@ func rowWithRail(s sessionmodel.Session, selected bool, width int, showIcons, re
 	if path == label {
 		path = ""
 	}
-	showSecondary := width >= rowPathMinWidth && path != ""
+	showSecondary := !hidePath && width >= rowPathMinWidth && path != ""
 	nameWidth := remaining
 	secondaryWidth := 0
 	if showSecondary {

--- a/internal/picker/tea_test.go
+++ b/internal/picker/tea_test.go
@@ -2093,3 +2093,34 @@ func sessionNames(items []model.Session) []string {
 	}
 	return names
 }
+
+func TestTeaModelHidePath(t *testing.T) {
+	items := []model.Session{{Name: "workspace", Path: "/unique/path", Source: "config"}}
+	for _, hide := range []bool{false, true} {
+		m := newTeaModel(items, Options{HidePath: hide})
+		m.width = 204
+		listWidth, previewWidth := m.previewLayout()
+		if hide {
+			assert.Equal(t, 100, previewWidth)
+			assert.NotContains(t, ansi.Strip(m.listView(listWidth, 1)), "/unique/path")
+		} else {
+			assert.Equal(t, maxPreviewWidth, previewWidth)
+			assert.Contains(t, ansi.Strip(m.listView(listWidth, 1)), "/unique/path")
+		}
+		assert.Contains(t, ansi.Strip(m.listView(listWidth, 1)), "workspace")
+		assert.Equal(t, m.contentWidth(), listWidth+3+previewWidth)
+		m.previewWidth = 70
+		_, previewWidth = m.previewLayout()
+		assert.Equal(t, 70, previewWidth, "manual resizing takes precedence")
+		m.width = 80
+		_, previewWidth = m.previewLayout()
+		assert.Zero(t, previewWidth, "narrow terminals keep stacked previews")
+		m.width = 204
+		m.hidePreview = true
+		_, previewWidth = m.previewLayout()
+		assert.Zero(t, previewWidth)
+		if hide {
+			assert.NotContains(t, ansi.Strip(m.listView(m.contentWidth(), 1)), "/unique/path")
+		}
+	}
+}


### PR DESCRIPTION
Adds `[picker] show_path = false` to hide the native picker's path column and give the side-by-side preview 50% of the available width initially. Paths remain visible by default; divider dragging and narrow-terminal stacked previews keep their existing behavior.

Documents the option and tests config decoding/defaults, propagation into picker options, column visibility, preview sizing, and manual resize precedence.

Validation:
- `GOLANGCI_LINT_CACHE=/private/tmp/herdr-sesh-show-path-lint just check` — 519 tests passed, lint and formatting passed
- `go test ./internal/config ./internal/app ./internal/picker`
- `go vet ./...`
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/sesh.toml`
- `just build-docs`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `[picker] show_path` option that hides the path column in the native picker and gives the side-by-side preview 50% of the available width initially. Paths remain visible by default; divider dragging and narrow-terminal stacked previews behave as before.

**Configuration**
- `show_path` defaults to `true`; set it to `false` to hide the column.
- Hidden paths do not affect path matching, the last-workspace footer, or fzf.

<sup>Written for commit a7aab891ae883cecbbd1f557b6f975e5a66b7cc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

