### PR TITLE
docs: improve wiki onboarding and contributor guidance

### DIFF
--- a/.github/scripts/test-docs-versions.py
+++ b/.github/scripts/test-docs-versions.py
@@ -31,6 +31,7 @@ with tempfile.TemporaryDirectory() as directory:
         'repo_url = "https://github.com/example/test"\nedit_uri = "edit/main/docs/"\n'
         'nav = [{"Overview" = "index.md"}, {"Guide" = "guide.md"}, '
         '{"Benchmarks" = "development/benchmarks.md"}]\n'
+        '[project.theme]\nfeatures = ["content.action.edit"]\n'
     )
     (source / "docs/index.md").write_text("# Released documentation\n\n[Guide](guide.md)\n")
     (source / "docs/guide.md").write_text("# Released guide\n")
@@ -65,6 +66,7 @@ with tempfile.TemporaryDirectory() as directory:
     )
     assert runtime_config["version"] == {"default": "latest", "provider": "mike"}
     assert "edit/main/docs/" not in release
+    assert "edit/main/docs/index.md" in latest
     assert 'href="latest/"' in (output / "index.html").read_text()
     not_found = (output / "404.html").read_text()
     assert not_found == (output / "latest/404.html").read_text()

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ plugin actions are the normal entry points for day-to-day use.
 
 ## Local development
 
+See the [contributor guide](docs/development/index.md) for setup, the code map,
+verification, and the documentation workflow.
+
 Tool versions are pinned in [`mise.toml`](mise.toml), and common tasks live in
 the [`justfile`](justfile).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,83 @@
+---
+icon: lucide/terminal
+---
+
+# Commands
+
+For daily use, open the picker or return to the previous workspace through
+Herdr's installed actions:
+
+```bash
+herdr plugin action invoke fullerzz.sesh.open-picker
+herdr plugin action invoke fullerzz.sesh.last
+```
+
+## Run the binary directly
+
+The installed binary is inside Herdr's managed plugin checkout; installation
+does not put `herdr-sesh` on your shell's `PATH`. Set up the following variables
+in the shell where you will run the examples. The installed-plugin example
+requires `jq`.
+
+=== "Installed plugin"
+
+    ```bash
+    sesh_root="$(herdr plugin list --plugin fullerzz.sesh --json | jq -r '.result.plugins[0].plugin_root')"
+    sesh_bin="$sesh_root/bin/herdr-sesh"
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
+    ```
+
+=== "Local checkout"
+
+    ```bash
+    just build
+    sesh_bin="$PWD/bin/herdr-sesh"
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
+    ```
+
+Run workspace operations from the intended Herdr session so they inherit its
+socket context. `HERDR_SESH_CONFIG`, when set, still overrides the plugin config
+directory.
+
+!!! note "Use the Herdr action for previous-workspace history"
+
+    These shell examples set the config directory, but do not supply
+    `HERDR_PLUGIN_STATE_DIR`. Running `last` directly with that variable unset
+    returns `no previous workspace recorded`, even when the installed plugin
+    has history. Use `herdr plugin action invoke fullerzz.sesh.last` to inherit
+    the plugin's state and session context. Use the `open-picker` action above
+    when you need the picker's history footer and recent sorting as well.
+
+## Command reference
+
+Use `"$sesh_bin"` followed by a command from this table:
+
+| Command | Purpose |
+| --- | --- |
+| `--version` | Print the build version. |
+| `picker` | Open the native picker. |
+| `picker --fzf` | Open the experimental picker; requires fzf. |
+| `list --json` | List merged session sources as JSON. |
+| `list --blacklisted` | Show only blacklisted results. |
+| `list --hide-duplicates=false` | Keep duplicate results. |
+| `connect TARGET` | Focus or create a workspace by name, path, or workspace ID. |
+| `preview TARGET` | Run the configured command preview for a target. |
+| `clone REPOSITORY` | Clone a repository and connect to its workspace. |
+| `root --connect` | Connect to the current Git repository root. |
+| `window [PATH]` | List tabs, or create a tab for a path. |
+| `config path` | Print the resolved config path, or the destination when none exists. |
+| `config init` | Create a native starter config only when no config exists. |
+| `config validate [PATH]` | Validate the active or specified configuration. |
+| `config migrate` | Convert a legacy Sesh config without deleting its source. |
+
+For example:
+
+```bash
+"$sesh_bin" list --json
+"$sesh_bin" connect my-project
+"$sesh_bin" config validate
+```
+
+Consult [Configuration](config.md) before migrating. Use its lookup order to
+check which file is active; do not assume the current working directory selects
+the configuration.

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,26 +27,85 @@ at that exact path. `config validate [PATH]` strictly validates the active or
 specified config and prints its resolved path on success. It returns an error
 when no config exists; legacy files remain valid but emit the migration warning.
 
-For a linked Herdr plugin, create or inspect the plugin-owned config with:
+## Create your configuration
 
-```bash
-just install-plugin
-HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)" ./bin/herdr-sesh config init
-HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)" ./bin/herdr-sesh config path
-```
+=== "Installed plugin"
+
+    Run these commands in a shell with Herdr available. `jq` is used to read
+    the installed plugin path from Herdr's JSON output.
+
+    ```bash
+    sesh_root="$(herdr plugin list --plugin fullerzz.sesh --json | jq -r '.result.plugins[0].plugin_root')"
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
+    "$sesh_root/bin/herdr-sesh" config init
+    "$sesh_root/bin/herdr-sesh" config path
+    ```
+
+=== "Local checkout"
+
+    From the repository root:
+
+    ```bash
+    just install-plugin
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
+    ./bin/herdr-sesh config init
+    ./bin/herdr-sesh config path
+    ```
 
 Herdr creates `HERDR_PLUGIN_CONFIG_DIR` and `HERDR_PLUGIN_STATE_DIR` for the
 plugin. Keep user configuration in the config directory and runtime state in
 the state directory.
 
-## Example
+### Add a workspace with a tab
+
+Open the file printed by `config path`. Keep its `version = 1` line, then add
+the following entries, replacing the path with an existing Git checkout:
+
+If the existing file uses the legacy schema, [migrate it](#legacy-migration)
+before adding native entries. Use unique workspace and tab names if the file
+already defines them.
 
 ```toml
-version = 1
+[[tab]]
+name = "git"
+startup = "git status"
+
+[[workspace]]
+name = "my-project"
+path = "~/projects/my-project"
+tabs = ["git"]
+```
+
+Validate the file using the same shell setup as above:
+
+=== "Installed plugin"
+
+    ```bash
+    "$sesh_root/bin/herdr-sesh" config validate
+    ```
+
+=== "Local checkout"
+
+    ```bash
+    ./bin/herdr-sesh config validate
+    ```
+
+Open the picker, search for `my-project`, and press ++enter++. A newly created
+workspace receives the named `git` tab and runs `git status` there. Selecting
+an existing workspace focuses it; it does not recreate its tabs or rerun startup
+commands.
+
+## Example
+
+This is a customization example, not a dump of the defaults. Omitted settings
+use the defaults described in [Settings](#settings).
+
+```toml
+version = 1 # (1)!
 
 [list]
 cache = true
-source_order = ["herdr", "config", "zoxide", "dir"]
+source_order = ["herdr", "config", "zoxide", "dir"] # (2)!
 blacklist = ["^scratch$"]
 
 [naming]
@@ -79,7 +138,7 @@ startup = "git status"
 name = "brain"
 path = "~/brain"
 disable_startup = true
-tabs = ["git"]
+tabs = ["git"] # (3)!
 
 [[rule]]
 path_glob = "~/projects/**"
@@ -87,6 +146,10 @@ startup = "git status"
 preview = "eza --icons=always --color=always -la {}"
 tabs = ["git"]
 ```
+
+1. Native configuration requires this schema version; unknown keys are rejected.
+2. Source order controls how results are combined; picker sorting affects Herdr rows.
+3. Tab names refer to `[[tab]]` definitions. They are created when the workspace is new.
 
 ## Legacy migration
 
@@ -96,13 +159,16 @@ Run `config migrate` to convert the active legacy file automatically:
 === "Local checkout"
 
     ```bash
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
     ./bin/herdr-sesh config migrate
     ```
 
 === "Installed plugin"
 
     ```bash
-    "$(herdr plugin list --plugin fullerzz.sesh --json | jq -r '.result.plugins[0].plugin_root')/bin/herdr-sesh" config migrate
+    sesh_root="$(herdr plugin list --plugin fullerzz.sesh --json | jq -r '.result.plugins[0].plugin_root')"
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
+    "$sesh_root/bin/herdr-sesh" config migrate
     ```
 
 Conversion intentionally modernizes two defaults: when

--- a/docs/config.md
+++ b/docs/config.md
@@ -76,17 +76,20 @@ path = "~/projects/my-project"
 tabs = ["git"]
 ```
 
-Validate the file using the same shell setup as above:
+Validate the file:
 
 === "Installed plugin"
 
     ```bash
+    sesh_root="$(herdr plugin list --plugin fullerzz.sesh --json | jq -r '.result.plugins[0].plugin_root')"
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
     "$sesh_root/bin/herdr-sesh" config validate
     ```
 
 === "Local checkout"
 
     ```bash
+    export HERDR_PLUGIN_CONFIG_DIR="$(herdr plugin config-dir fullerzz.sesh)"
     ./bin/herdr-sesh config validate
     ```
 

--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -79,11 +79,9 @@ behavioral metrics that protect the shape of an optimization:
 | `canceled/op` | Exactly `7` | The seven superseded preview renders are canceled. |
 | `completed/op` | Exactly `1` | The final, active preview render completes. |
 
-!!! warning "Preview cancellation is a target metric"
+!!! info "Preview cancellation is implemented"
 
-    `PreviewNavigationBurst` currently reports `0 canceled/op` and
-    `8 completed/op` because preview rendering uses a background context. Once
-    stale preview cancellation is implemented, the correct result is exactly
+    Each new selection cancels the superseded preview. The expected result is
     `7 canceled/op` and `1 completed/op`: seven stale renders stop while the
     active selection still updates. Any other pair is a behavioral regression,
     even if one value moved farther in an apparently favorable direction.
@@ -95,16 +93,18 @@ through [CodSpeed](https://app.codspeed.io/fullerzz/herdr-plugin-sesh), which
 reports the walltime of each benchmark and comments the comparison against the
 base branch.
 
-Run the CodSpeed suite locally with the
-[CodSpeed CLI](https://codspeed.io/docs/cli):
+For local comparisons on Linux or macOS, use `just bench` and
+`just bench-compare` above; no CodSpeed installation is needed. The repository's
+Ubuntu workflow installs the CodSpeed instrument through its pinned action and
+runs:
 
 ```bash
-curl -fsSL https://codspeed.io/install.sh | sh
-codspeed run --mode walltime -- just bench-codspeed
+just bench-codspeed
 ```
 
-`just bench-codspeed` runs `go test -bench=.` over `internal/sources` and
-`internal/picker`. CodSpeed only supports the `-bench` flag, so the extra
+`just bench-codspeed` alone runs ordinary Go benchmarks; the CI action supplies
+the instrument. It runs `go test -bench=.` over `internal/sources` and
+`internal/picker`. The extra
 `-benchmem`, `-count`, and `-run` flags used by `just bench` are omitted; the
 custom `commands/op`, `canceled/op`, and `completed/op` metrics are still
 reported.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -92,8 +92,12 @@ Then use the checks appropriate to the change:
 ```bash
 ./bin/herdr-sesh --version
 ./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml
+./bin/herdr-sesh list --json --config testdata/sesh.toml
 git diff --check
 ```
+
+Run both fixtures to cover native configuration and legacy Sesh compatibility.
+The legacy fixture's deprecation warning on stderr is expected.
 
 !!! note "What just check includes"
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,181 @@
+---
+icon: lucide/code
+---
+
+# Contributing
+
+Start here to build and verify a change. The [workspace history](workspace-history.md)
+and [benchmark](benchmarks.md) pages explain those subsystems in more depth.
+
+## Set up a checkout
+
+Install Git, Git LFS, and [mise](https://mise.jdx.dev/) before cloning. Herdr is
+needed for interactive plugin checks; the unit tests use test doubles.
+
+```bash
+git clone https://github.com/fullerzz/herdr-plugin-sesh.git
+cd herdr-plugin-sesh
+git lfs install
+git lfs pull
+mise install
+just build
+```
+
+`mise.toml` pins development tools. `go.mod` declares the minimum Go version;
+the development pin can be newer. Use `just` to list repository recipes.
+
+### Link and exercise the plugin
+
+From a Herdr session:
+
+```bash
+just install-plugin
+herdr plugin action list --plugin fullerzz.sesh
+herdr plugin action invoke fullerzz.sesh.open-picker
+herdr plugin log list --plugin fullerzz.sesh
+```
+
+`install-plugin` rebuilds and links this checkout. Re-run it after changes, then
+open a fresh picker. Use the [configuration setup](../config.md#create-your-configuration)
+to inspect the config used by the linked plugin.
+
+Local builds embed `git describe` output: the nearest reachable version tag,
+commit distance, and hash, with `-dirty` for tracked changes. An exact clean tag
+uses the tag alone; without a version tag the hash is used, and without Git
+metadata the fallback is `dev`. Release builds use the release version.
+
+## Find the code
+
+```mermaid
+flowchart LR
+    CLI[CLI routing] --> Config[Config discovery and validation]
+    Config --> Sources[Herdr / configured workspaces / zoxide / direct path]
+    Sources --> Merge[Merge and apply configuration]
+    Merge --> Picker[Picker selection]
+    Picker --> Connect[Focus or create workspace]
+    Connect --> Startup[Startup commands and tabs]
+```
+
+| Area | Entry points |
+| --- | --- |
+| Executable and orchestration | `cmd/herdr-sesh/`, `internal/app/` |
+| Native schema, defaults, legacy migration | `internal/config/` |
+| Session types and collection | `internal/model/`, `internal/sources/` |
+| Native and fzf picker behavior | `internal/picker/` |
+| Target resolution and startup | `internal/connect/`, `internal/startup/` |
+| Herdr CLI/socket integration | `internal/herdr/` |
+| Preview commands and pane reads | `internal/preview/` |
+| Cache, history, atomic writes | `internal/state/` |
+| Shipped actions, hooks, minimum Herdr version | `herdr-plugin.toml` |
+
+Before changing shared behavior, inspect its callers and focused tests. Keep
+command routing in `internal/app` and reusable behavior in its existing package.
+
+## Verify a change
+
+Start with the affected package, for example:
+
+```bash
+go test -race -count=1 ./internal/config
+```
+
+Then use the checks appropriate to the change:
+
+| Change | Checks |
+| --- | --- |
+| Go behavior | `just check`, `go vet ./...`, `just build`, then the CLI smoke commands below |
+| Documentation | `just build-docs` and inspect the rendered pages with `just serve-docs` |
+| Versioning, navigation, or docs build configuration | `just test-docs-versions`, `just build-docs`, `just build-docs-versions` |
+| Docs Python scripts | `uv run --frozen ruff check .`, `uv run --frozen ruff format --check .`, plus versioning checks |
+| Performance-sensitive behavior | Baseline/candidate comparison from [Benchmarks](benchmarks.md) |
+
+```bash
+./bin/herdr-sesh --version
+./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml
+git diff --check
+```
+
+!!! note "What just check includes"
+
+    `just check` runs lint, formatting checks, race-enabled tests, and the release
+    ref regression. It does not build the binary or documentation. Run the build
+    and smoke checks separately before opening a code PR, and the docs checks
+    when documentation changes.
+
+### Test conventions
+
+Place `Test<Behavior>` tests beside the implementation. Use the smallest
+regression that fails for the behavior being changed, reusing existing fake
+Herdr clients/runners rather than requiring a live session in unit tests.
+Keep fixtures in `testdata/`.
+
+Use Testify `require` for prerequisites such as errors, nil values, and lengths
+before indexing; use `assert` for independent expectations. Keep `require` on
+the test goroutine and return worker errors to it. The linter checks assertion
+usage. For interactive changes, also exercise the picker in Herdr, including a
+narrow terminal when layout is affected.
+
+## Work on documentation
+
+Edit `docs/` and add navigation entries in `zensical.toml`. `site/` is generated
+output. Use the pinned Python environment through `uv`; use `xh` for HTTP
+checks and `mise` or `brew` to install tools. Shared tool pins belong in
+`mise.toml`.
+
+```bash
+just serve-docs
+```
+
+Open the address printed by Zensical. Check links, code copying, configuration
+tabs, diagrams, and narrow-screen navigation. Admonitions suit important
+behavior, tabs separate installed-plugin and checkout commands, and code
+annotations explain non-obvious settings. Keep basic instructions visible.
+
+### Versions and deployment
+
+The versioned builder takes `latest` from the current checkout and each eligible
+release's docs and config from its exact tag. Published `latest` follows `main`;
+snapshots begin at `v0.10.0`. Historical snapshots use the current builder's
+Python environment. Their source is not rewritten by edits to `docs/` today.
+
+Before building all versions, fetch tags and historical media:
+
+```bash
+git fetch --tags
+git lfs fetch --all
+just test-docs-versions
+just build-docs-versions
+```
+
+The builder exports into `site/` without pushing a deployment branch. It keeps
+unversioned links working through redirects to `latest`, preserves queries and
+fragments, and supplies a root `404.html`. Keep `site_url` unversioned.
+
+The Docs workflow builds and tests PRs; only trusted push/manual runs deploy to
+GitHub Pages. A local build confirms generation, not deployment. Check the Docs
+workflow and the published URL before reporting a release's docs as live.
+
+“Edit this page” targets `main`; release snapshots disable the edit link.
+Use the version selector to return to `latest` before proposing a correction.
+
+## Pull requests and releases
+
+Use Conventional Commit subjects such as `fix: correct picker selection`.
+Explain the user-visible change, link its issue when applicable, and list the
+validation commands actually run. Include screenshots for visual changes when
+they help review.
+
+For maintainers, update `version` and the embedded build version in
+`herdr-plugin.toml`, then commit the release preparation to `main`. Set
+`GITHUB_TOKEN` for GitHub changelog metadata. From a clean checkout:
+
+```bash
+just preview-changelog vX.Y.Z
+just release vX.Y.Z
+```
+
+The release recipe asks for confirmation, requires a new `v` tag matching the
+manifest, runs code checks and CLI smokes, generates the changelog, tags the
+release source commit, commits the changelog as a follow-up, and atomically
+pushes `main` and the tag. Run the docs gates beforehand; the recipe does not
+include them. Verify the release and Docs workflow results after publication.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,18 +37,19 @@ Use the version selector in the header to choose a release's documentation.
 `latest` follows the `main` branch and may describe changes not yet released.
 Release snapshots are available starting with `v0.10.0`, when the wiki was added.
 
-### Changes since v0.10.1
+For changes in each release, see the
+[release notes](https://github.com/fullerzz/herdr-plugin-sesh/releases).
 
-- Native search puts name matches before path-only matches, with configurable
-  home-directory priority through `picker.prioritize_home`.
-- Previous-workspace history tracks switches outside the plugin and is isolated
-  per Herdr session. This raises the minimum Herdr version to 0.8.2.
-- Native previews can show the selected workspace's active pane. Use ++ctrl+o++
-  to toggle modes or `picker.preview_mode = "pane"` to choose the initial mode.
-- Drag the vertical preview divider to resize side-by-side panels for the
-  current picker invocation.
-- Local builds embed a Git-derived version, including a `-dirty` suffix for
-  tracked working-tree changes.
+### First steps
+
+1. Open the picker, type part of a workspace name or path, then press ++enter++.
+2. [Bind the picker to a key](keybindings.md#herdr-actions) in Herdr.
+3. Optionally [create a configuration and add a named workspace with tabs](config.md#create-your-configuration).
+
+Use ++ctrl+o++ to switch command and active-pane previews, and ++ctrl+r++ to
+cycle workspace sorting. [Picker controls](keybindings.md#native-picker-controls)
+lists the other shortcuts. If something looks wrong, start with
+[Troubleshooting](troubleshooting.md).
 
 ### Reference
 
@@ -56,6 +57,9 @@ Release snapshots are available starting with `v0.10.0`, when the wiki was added
   workspaces, tabs, and legacy Sesh migration.
 - [Keybindings](keybindings.md) shows how to invoke the picker and related
   actions from Herdr.
+- [Commands](commands.md) covers direct CLI use and installed-binary setup.
+- [Contributing](development/index.md) covers local development, tests, docs,
+  and releases.
 - [GitHub releases](https://github.com/fullerzz/herdr-plugin-sesh/releases)
   contains versioned source and release notes.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,5 +1,31 @@
 # Keybindings
 
+## Native picker controls
+
+| Key | Action |
+| --- | --- |
+| ++enter++ | Focus the selected workspace, or create it for a configured session or directory. |
+| ++esc++ / ++ctrl+c++ | Close the picker without selecting a workspace. |
+| ++down++ / ++ctrl+n++ / ++ctrl+j++ | Move from the filter into the list, then move down. |
+| ++up++ / ++ctrl+p++ / ++ctrl+k++ | Move up while the list is focused; moving above its first row returns to the filter. In the filter, ++ctrl+k++ keeps its text-editing behavior. |
+| ++right++ | Return from the list to the filter; within the filter, move the text cursor. |
+| ++ctrl+u++ | Clear the filter and focus it. |
+| ++ctrl+v++ | Paste into the filter. |
+| ++ctrl+r++ | Cycle workspace → recent → agent sorting for Herdr workspaces. |
+| ++ctrl+o++ | Switch command/pane previews, unless overridden by `keys.cycle_preview_mode`. |
+| ++ctrl+x++ | Close the selected running Herdr workspace and refresh the list. |
+
+Typing updates the filter even when the list is focused. These controls describe
+the native picker; the experimental fzf picker uses its own controls.
+
+!!! warning "Closing a workspace"
+
+    ++ctrl+x++ requests a workspace close immediately, without a picker
+    confirmation. It affects the running workspace, not just its row. It does
+    nothing for configured sessions or directory results. During the request,
+    selection is disabled; ++esc++ requests cancellation and exits once the
+    request returns. Cancellation cannot undo a close that already completed.
+
 ## Native picker previews
 
 In the native picker, press ++ctrl+o++ by default to switch between the configured preview
@@ -45,6 +71,9 @@ session and closed workspaces are pruned automatically. See
     page.
 
 Example Herdr keybinding once the plugin is linked:
+
+Add this to **Herdr's** `~/.config/herdr/config.toml` (or the file selected by
+`HERDR_CONFIG_PATH` / `XDG_CONFIG_HOME`), not the plugin's `config.toml`.
 
 ```toml
 [keys]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,89 @@
+---
+icon: lucide/wrench
+---
+
+# Troubleshooting
+
+## Check installation and logs
+
+```bash
+herdr plugin action list --plugin fullerzz.sesh
+herdr plugin log list --plugin fullerzz.sesh
+herdr plugin config-dir fullerzz.sesh
+```
+
+Check that the picker action is listed and inspect recent errors before changing
+configuration. Use the documentation version selector for your installed
+release. For direct binary commands below, first follow the
+[shell setup](commands.md#run-the-binary-directly).
+
+## A workspace is missing
+
+- Clear the filter with ++ctrl+u++. Name and path matching can place results
+  in different groups.
+- Confirm you are in the intended Herdr session. Its socket determines which
+  running workspaces are visible.
+- Run `"$sesh_bin" list --json` and check the active config with
+  `"$sesh_bin" config path`.
+- Check `list.blacklist` and deduplication with `list --blacklisted` and
+  `list --hide-duplicates=false`. These options bypass the normal list cache.
+- Directory-history results require `zoxide` to be available and populated.
+  Configured workspaces require a valid `[[workspace]]` entry.
+
+The list cache lasts five seconds and does not cache the picker. Repeatedly
+clearing state files is not necessary to refresh picker results.
+
+## Configuration changes have no effect
+
+Run `"$sesh_bin" config path` and `"$sesh_bin" config validate` in the same
+shell context used to invoke the plugin. An explicit `HERDR_SESH_CONFIG` takes
+precedence over the plugin config directory. See the full
+[lookup order](config.md).
+
+Herdr action bindings belong in Herdr's config; picker appearance and
+`keys.cycle_preview_mode` belong in the plugin config. Native plugin files need
+`version = 1` and reject unknown keys. Reopen the picker after changing its
+configuration. Startup commands and tabs apply when creating a workspace, not
+when focusing an existing one.
+
+## Preview is unavailable or reports an error
+
+Pane mode requires a running Herdr workspace. A configured session or directory
+without a running pane cannot provide a pane preview. Switch back to command
+mode with ++ctrl+o++ or your configured shortcut.
+
+Command previews use `eza` by default. If it is unavailable, install it or set
+`workspace_defaults.preview` to an available command, for example `ls -la {}`.
+Test the command with `"$sesh_bin" preview TARGET`. Commands time out after
+five seconds; superseded previews are canceled when the selection changes.
+The loading message appears only after a preview has been pending for 500 ms.
+
+If no preview panel appears, check `picker.show_preview`. Narrow terminals put
+the preview below the list, and hiding paths does not force a side-by-side
+layout.
+
+## Icons or cursor animation look wrong
+
+Source icons need a Nerd Font in your terminal. Set `picker.show_icons = false`
+to use source labels. The default `eza` preview has its own icon flag; customize
+the preview command separately if its glyphs are missing.
+
+Set `HERDR_SESH_REDUCE_MOTION=1` in the environment inherited by Herdr to disable
+the cursor trail. See [cursor settings](config.md#cursor-and-status-indicators).
+
+## Previous workspace is unexpected
+
+History is scoped to the Herdr session and automatically removes closed
+workspaces. Use the installed `fullerzz.sesh.last` action to retain Herdr's
+plugin environment. Check logs if lifecycle tracking stops; a subsequent
+lifecycle hook can restart the watcher. Hiding the footer does not disable
+history. See [history behavior](config.md#workspace-history) and the
+[reconnect limitations](development/workspace-history.md#failure-model).
+
+## Report a reproducible problem
+
+Include the Herdr and plugin versions, OS, native/fzf picker choice, the exact
+action or command, expected and actual behavior, and relevant log errors.
+Share a minimal config that reproduces the issue, removing private paths and
+commands as needed. A screenshot is useful for layout problems; include terminal
+dimensions and whether a Nerd Font is configured.

--- a/internal/picker/tea_benchmark_test.go
+++ b/internal/picker/tea_benchmark_test.go
@@ -62,10 +62,8 @@ func BenchmarkRenderPicker(b *testing.B) {
 }
 
 // BenchmarkPreviewNavigationBurst measures a rapid navigation burst across
-// sessions, each triggering a preview render. canceled/op currently reads 0
-// because previewCommand renders with context.Background() — stale previews
-// run to completion. The metric exists to show the win once preview
-// cancellation is wired up.
+// sessions, each triggering a preview render. Superseded previews are canceled;
+// the expected metrics are 7 canceled/op and 1 completed/op.
 func BenchmarkPreviewNavigationBurst(b *testing.B) {
 	const previewCount = 8
 	var active atomic.Pointer[previewBenchmarkWorkload]

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,8 +11,11 @@ copyright = "Copyright &copy; 2026 Zach Fuller"
 nav = [
   { "Overview" = "index.md" },
   { "Configuration" = "config.md" },
+  { "Commands" = "commands.md" },
   { "Keybindings" = "keybindings.md" },
+  { "Troubleshooting" = "troubleshooting.md" },
   { "Development" = [
+    { "Contributing" = "development/index.md" },
     { "Workspace history" = "development/workspace-history.md" },
     { "Benchmarks" = "development/benchmarks.md" },
   ] },
@@ -31,6 +34,9 @@ variant = "modern"
 favicon = "assets/favicon.svg"
 language = "en"
 features = [
+  "content.action.edit",
+  "content.tabs.link",
+  "content.code.annotate",
   "content.code.copy",
   "content.footnote.tooltips",
   "navigation.footer",


### PR DESCRIPTION
The wiki had detailed configuration references but lacked an installed-user walkthrough, a complete picker controls reference, and a contributor starting point. This update adds commands, troubleshooting, and contributor guides; expands setup and keybindings; and replaces the selective overview changelog with release-note links.

It also fixes the installed-plugin migration environment and stale preview cancellation guidance, and directs previous-workspace operations through the Herdr action so they receive the required state context. Zensical now provides linked example tabs, annotated configuration, and edit-page links. A regression check verifies that edit links appear for latest documentation and remain absent from release snapshots.

Validation:
- `just build-docs`
- `just test-docs-versions`
- `just build-docs-versions`
- `just fmt-check`
- `just bench` (preview burst: 7 canceled/op, 1 completed/op)
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- Native CLI validation of the quickstart and annotated TOML examples
- Browser inspection of navigation, linked tabs, annotations, and contributor page
- Local HTTP route check and `git diff --check`

No runtime behavior changes; the Go change only corrects a benchmark comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the wiki with contributor, commands, and troubleshooting pages, adds linked tabs and annotated code examples, and replaces the selective changelog with release-note links. It also corrects stale docs for preview cancellation, the installed-plugin migration environment, and previous-workspace history.

**Behavior changes**
- Previous-workspace operations must use `herdr plugin action invoke fullerzz.sesh.last` to inherit state context; direct binary runs return "no previous workspace recorded."
- Config and migration examples now export `HERDR_PLUGIN_CONFIG_DIR` before invoking the binary, for both installed-plugin and local-checkout shells.
- The benchmarks page now documents the implemented 7 canceled/op figure instead of describing cancellation as unimplemented.
- The docs version test now verifies edit links appear for `latest` and not for release snapshots.

<sup>Written for commit cee14833801325ea070177adbf3764f4436d55e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

