### PR TITLE
fix: refresh overlay geometry when opening picker

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1252,7 +1252,12 @@ func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {
 	logPath := filepath.Join(d, "herdr.log")
 	fakeHerdr := filepath.Join(d, "herdr")
 	//nolint:gosec // test creates a local executable fixture.
-	require.NoError(t, os.WriteFile(fakeHerdr, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$HERDR_FAKE_LOG\"\n"), 0700))
+	require.NoError(t, os.WriteFile(fakeHerdr, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$HERDR_FAKE_LOG"
+if [ "$1" = plugin ]; then
+  printf '%s\n' '{"result":{"plugin_pane":{"pane":{"pane_id":"w5:pE0"}}}}'
+fi
+`), 0700))
 	t.Setenv("HERDR_BIN_PATH", fakeHerdr)
 	t.Setenv("HERDR_FAKE_LOG", logPath)
 
@@ -1261,7 +1266,7 @@ func TestPluginOpenPickerStillOpensPickerPane(t *testing.T) {
 	//nolint:gosec // logPath is a test-owned temp file.
 	log, err := os.ReadFile(logPath)
 	require.NoError(t, err)
-	assert.Equal(t, "plugin pane open --plugin fullerzz.sesh --entrypoint picker --placement overlay", strings.TrimSpace(string(log)))
+	assert.Equal(t, "plugin pane open --plugin fullerzz.sesh --entrypoint picker --placement overlay\npane zoom w5:pE0 --on", strings.TrimSpace(string(log)))
 }
 
 func runPickerJSON(t *testing.T, cfgPath, zoxideOutput string) []model.Session {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -409,6 +409,29 @@ func (c *CLIClient) PaneRun(ctx context.Context, id, cmd string) error {
 	return err
 }
 func (c *CLIClient) PluginPaneOpen(ctx context.Context, plugin, entry, placement string) error {
-	_, err := c.run(ctx, "plugin", "pane", "open", "--plugin", plugin, "--entrypoint", entry, "--placement", placement)
+	out, err := c.run(ctx, "plugin", "pane", "open", "--plugin", plugin, "--entrypoint", entry, "--placement", placement)
+	if err != nil || placement != "overlay" {
+		return err
+	}
+	raw, _, err := responseJSON(out, "plugin pane open")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		PluginPane struct {
+			Pane Pane `json:"pane"`
+		} `json:"plugin_pane"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("decode herdr plugin pane open JSON: %w", err)
+	}
+	if resp.PluginPane.Pane.ID == "" {
+		return fmt.Errorf("herdr plugin pane open: missing pane ID for overlay geometry refresh")
+	}
+	// Work around Herdr 0.9.0 starting overlays at the outer pane size rather
+	// than the bordered interior (#123). Overlays are already zoomed; --on
+	// preserves their layout while making Herdr synchronize the PTY size.
+	// Target the returned ID, not the caller or whichever pane is focused.
+	_, err = c.run(ctx, "pane", "zoom", resp.PluginPane.Pane.ID, "--on")
 	return err
 }

--- a/internal/herdr/plugin_pane_test.go
+++ b/internal/herdr/plugin_pane_test.go
@@ -1,0 +1,70 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type pluginPaneRunner struct {
+	calls   [][]string
+	open    fixedRunner
+	refresh fixedRunner
+}
+
+func (r *pluginPaneRunner) Run(ctx context.Context, bin string, args ...string) ([]byte, []byte, error) {
+	r.calls = append(r.calls, append([]string{bin}, args...))
+	if len(r.calls) == 1 {
+		return r.open.Run(ctx, bin, args...)
+	}
+	return r.refresh.Run(ctx, bin, args...)
+}
+
+func TestCLIClientRefreshesOverlayGeometryAfterOpen(t *testing.T) {
+	// Herdr 0.9.0 initially gives overlays the outer pane dimensions.
+	// Keeping the new overlay zoomed triggers a resize to its bordered interior.
+	r := &pluginPaneRunner{open: fixedRunner{stdout: []byte(`{"result":{"type":"plugin_pane_opened","plugin_pane":{"plugin_id":"fullerzz.sesh","entrypoint":"picker","pane":{"pane_id":"w5:pE0"}}}}`)}}
+	c := &CLIClient{Bin: "/bin/herdr", Runner: r}
+	require.NoError(t, c.PluginPaneOpen(context.Background(), "fullerzz.sesh", "picker", "overlay"))
+	assert.Equal(t, [][]string{
+		{"/bin/herdr", "plugin", "pane", "open", "--plugin", "fullerzz.sesh", "--entrypoint", "picker", "--placement", "overlay"},
+		{"/bin/herdr", "pane", "zoom", "w5:pE0", "--on"},
+	}, r.calls)
+}
+
+func TestCLIClientOverlayRefreshErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		open      fixedRunner
+		refresh   fixedRunner
+		wantError string
+		wantCalls int
+	}{
+		{name: "open failed", open: fixedRunner{err: errors.New("open failed")}, wantError: "open failed", wantCalls: 1},
+		{name: "invalid response", open: fixedRunner{stdout: []byte(`not JSON`)}, wantError: "decode herdr plugin pane open JSON", wantCalls: 1},
+		{name: "missing pane ID", open: fixedRunner{stdout: []byte(`{"result":{"plugin_pane":{"pane":{}}}}`)}, wantError: "missing pane ID", wantCalls: 1},
+		{name: "refresh failed", open: fixedRunner{stdout: []byte(`{"result":{"plugin_pane":{"pane":{"pane_id":"w5:pE0"}}}}`)}, refresh: fixedRunner{err: errors.New("refresh failed")}, wantError: "refresh failed", wantCalls: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &pluginPaneRunner{open: tc.open, refresh: tc.refresh}
+			c := &CLIClient{Bin: "/bin/herdr", Runner: r}
+			err := c.PluginPaneOpen(context.Background(), "fullerzz.sesh", "picker", "overlay")
+			require.ErrorContains(t, err, tc.wantError)
+			assert.Len(t, r.calls, tc.wantCalls)
+		})
+	}
+}
+
+func TestCLIClientDoesNotZoomNonOverlayPluginPanes(t *testing.T) {
+	for _, placement := range []string{"split", "tab", "zoomed", "popup"} {
+		t.Run(placement, func(t *testing.T) {
+			r := &pluginPaneRunner{}
+			c := &CLIClient{Bin: "/bin/herdr", Runner: r}
+			require.NoError(t, c.PluginPaneOpen(context.Background(), "fullerzz.sesh", "picker", placement))
+			assert.Len(t, r.calls, 1)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #123.

Work around Herdr 0.9.0 initializing plugin overlays with their outer pane dimensions rather than the bordered content area. The picker correctly rendered its footer, but Herdr clipped it until a layout refresh corrected the PTY size.

- Refresh geometry from picker startup so both the plugin action and the documented direct `plugin pane open` flow are covered.
- Inspect `herdr pane layout --pane <id>` and repeat `pane zoom <id> --on` only when the launched pane is already zoomed, preserving explicitly requested split and tab layouts.
- Treat the compatibility refresh as best-effort: layout or zoom failures emit a warning and continue opening the picker.
- Keep `PluginPaneOpen` as a plain launcher and leave picker layout calculations unchanged.
- Cover zoomed and unzoomed launches, non-picker entrypoints, missing pane IDs, layout and zoom failures, and the action-mediated open path.

## Validation

- `go test ./internal/app -run '^TestPickerRefreshesPluginPaneGeometry$' -count=1`
- `just check` — 0 lint issues; 527 tests with race detection; release-ref check passed
- `just build`
- `./bin/herdr-sesh --version`
- `./bin/herdr-sesh list --json --config testdata/herdr-sesh.toml`
- `git diff --check`

Earlier live verification on Herdr 0.9.0 established that repeating `pane zoom --on` corrects the broken overlay from a 45-row PTY to the 43-row bordered content area, making the keybind help and `LAST WORKSPACE` footer visible without a click. The implementation applies that refresh from the shared picker startup path and guards it with the pane's current zoom state.

## Scope

This is a Sesh-side workaround for a Herdr overlay-sizing defect. A permanent host-side fix belongs in Herdr.
